### PR TITLE
docs: migrate site from unitysvc-services + add Python SDK chapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ htmlcov/
 # Lock files
 uv.lock
 .tool-venv/
+site/

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,25 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+  jobs:
+    post_create_environment:
+      - pip install uv
+    post_install:
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH uv pip install .[docs]
+
+mkdocs:
+  configuration: mkdocs.yml
+  fail_on_warning: false
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,0 +1,1477 @@
+# CLI Reference
+
+Complete command-line interface reference for `unitysvc_sellers` (alias: `usvc_seller`).
+
+## Global Options
+
+```bash
+unitysvc_sellers [OPTIONS] COMMAND [ARGS]...
+# Or using the shorter alias:
+usvc_seller [OPTIONS] COMMAND [ARGS]...
+```
+
+### Options
+
+- `--install-completion` - Install shell completion
+- `--show-completion` - Show completion script
+- `--help` - Show help message
+
+**Note:** All examples below use the shorter `usvc_seller` alias. You can always replace `usvc_seller` with `unitysvc_sellers` if preferred.
+
+## Commands Overview
+
+The CLI is organized into two main command groups with a clear separation of concerns:
+
+### Local Data Operations (`usvc_seller data`)
+
+Work with local data files - can be used offline without API credentials (except `upload`).
+
+| Command      | Description                                         |
+| ------------ | --------------------------------------------------- |
+| `validate`   | Validate data files against schemas                 |
+| `format`     | Format/prettify data files                          |
+| `populate`   | Generate data files from provider scripts           |
+| `upload`     | Upload local data to backend (draft status)         |
+| `list`       | List local data files (services, providers, etc.)   |
+| `show`       | Show details of a local data object                 |
+| `list-tests` | List code examples in local data                    |
+| `run-tests`  | Run code examples locally with upstream credentials |
+| `show-test`  | Show details of a local test                        |
+
+### Remote Service Operations (`usvc_seller services`)
+
+Manage services on the backend - can be run from anywhere with the right API key.
+
+| Command       | Description                                   |
+| ------------- | --------------------------------------------- |
+| `list`        | List deployed services on backend             |
+| `show`        | Show details of a deployed service            |
+| `submit`      | Submit draft service(s) for ops review        |
+| `withdraw`    | Withdraw pending/rejected service(s) to draft |
+| `deprecate`   | Deprecate active service(s)                   |
+| `delete`      | Delete service(s) from backend                |
+| `dedup`       | Remove duplicate draft services               |
+| `list-tests`  | List tests for deployed services              |
+| `show-test`   | Show details of a test for a deployed service |
+| `run-tests`   | Run tests via gateway (backend execution)     |
+| `skip-test`   | Mark a code example test as skipped           |
+| `unskip-test` | Remove skip status from a test                |
+
+### Promotion Management (`usvc_seller promotions`)
+
+Manage seller promotions (pricing rules).
+
+All commands operate on promotions already uploaded to the backend. Use `usvc_seller data validate` and `usvc_seller data upload` for local file operations (promotions are discovered alongside services).
+
+| Command       | Description                                    |
+| ------------- | ---------------------------------------------- |
+| `list`        | List promotions on the backend                 |
+| `show`        | Show details of a promotion (including generated codes) |
+| `activate`    | Activate a promotion                           |
+| `pause`       | Pause a promotion                              |
+| `delete`      | Delete a promotion                             |
+
+**Note:** To create initial service data, use the [UnitySVC web interface](https://unitysvc.com) which provides a visual editor with validation. You can export your data for use with this SDK.
+
+## usvc_seller data - Local Data Operations
+
+Commands for working with local data files. These commands work offline and don't require API credentials.
+
+### usvc_seller data list - List Local Files
+
+List data files in local directory.
+
+#### usvc_seller data list providers
+
+```bash
+usvc_seller data list providers [DATA_DIR]
+```
+
+**Arguments:**
+
+- `[DATA_DIR]` - Data directory (default: current directory)
+
+**Examples:**
+
+```bash
+# List providers in current directory
+usvc_seller data list providers
+
+# List providers in specific directory
+usvc_seller data list providers ./data
+```
+
+#### usvc_seller data list sellers
+
+```bash
+usvc_seller data list sellers [DATA_DIR]
+```
+
+#### usvc_seller data list offerings
+
+```bash
+usvc_seller data list offerings [DATA_DIR]
+```
+
+#### usvc_seller data list listings
+
+```bash
+usvc_seller data list listings [DATA_DIR]
+```
+
+#### usvc_seller data list services
+
+```bash
+usvc_seller data list services [DATA_DIR]
+```
+
+List all services with their provider, offering, and listing files.
+
+**Output:**
+
+- Table format with file paths and key fields
+- Color-coded status indicators
+
+### usvc_seller data upload - Upload Services to Backend
+
+Upload services to UnitySVC backend. The upload command uses a **listing-centric** approach where each listing file triggers a unified upload of provider + offering + listing together.
+
+#### How Uploading Works
+
+A **Service** in UnitySVC consists of three data components that are uploaded together:
+
+```mermaid
+flowchart TB
+    subgraph Service["Uploaded Together"]
+        P["<b>Provider Data</b><br/>WHO provides<br/><i>provider_v1</i>"]
+        O["<b>Offering Data</b><br/>WHAT is provided<br/><i>offering_v1</i>"]
+        L["<b>Listing Data</b><br/>HOW it's sold<br/><i>listing_v1</i>"]
+    end
+
+    P --> O --> L
+
+    style P fill:#e3f2fd
+    style O fill:#fff3e0
+    style L fill:#e8f5e9
+```
+
+When you run `usvc_seller data upload`:
+
+1. **Finds** all listing files (`listing_v1` schema) in the directory tree
+2. For each listing, **locates** the offering file (`offering_v1`) in the same directory
+3. **Locates** the provider file (`provider_v1`) in the parent directory
+4. **Uploads** all three together to the `/seller/services` endpoint
+
+This ensures atomic uploading - all three components are validated and uploaded as a single unit.
+
+**Usage:**
+
+```bash
+usvc_seller data upload [OPTIONS]
+```
+
+**Options:**
+
+- `--data-path, -d PATH` - Data directory or single listing file (default: current directory)
+- `--dryrun` - Preview what would be created/updated without making actual changes
+
+**Required Environment Variables:**
+
+- `UNITYSVC_API_URL` - Backend API URL
+- `UNITYSVC_SELLER_API_KEY` - API key for authentication (seller API key)
+
+**Examples:**
+
+```bash
+# Upload all services from current directory
+usvc_seller data upload
+
+# Upload all services from custom directory
+usvc_seller data upload --data-path ./data
+
+# Upload a single service (specific listing file)
+usvc_seller data upload --data-path ./data/my-provider/services/my-service/listing.json
+
+# Preview changes before uploading (dryrun mode)
+usvc_seller data upload --dryrun
+```
+
+**Dryrun Mode:**
+
+The `--dryrun` option allows you to preview what would happen during upload without making actual changes to the backend. This is useful for:
+
+- Verifying which services would be created vs updated
+- Checking that all required files exist (provider, offering, listing)
+- Confirming changes before committing them
+
+In dryrun mode:
+
+- No actual data is sent to the backend
+- Backend returns what action would be taken (create/update/unchanged)
+- Missing files are reported as errors
+- Summary shows what would happen if uploaded
+
+**Output Format:**
+
+Uploading displays progress for each service and a summary table:
+
+```bash
+$ usvc_seller data upload
+Uploading services from: /path/to/data
+Backend URL: https://api.unitysvc.com/v1
+
+  + Created service: listing-premium (offering: gpt-4, provider: openai)
+  ~ Updated service: listing-basic (offering: gpt-4, provider: openai)
+  = Unchanged service: listing-default (offering: claude-3, provider: anthropic)
+
+Upload Summary
+╭──────────┬───────┬─────────┬─────────┬────────┬─────────┬─────────┬───────────╮
+│ Type     │ Found │ Success │ Skipped │ Failed │ Created │ Updated │ Unchanged │
+├──────────┼───────┼─────────┼─────────┼────────┼─────────┼─────────┼───────────┤
+│ Services │ 3     │ 3       │         │        │ 1       │ 1       │ 1         │
+╰──────────┴───────┴─────────┴─────────┴────────┴─────────┴─────────┴───────────╯
+
+✓ All services uploaded successfully!
+```
+
+**Status Indicators:**
+
+| Symbol | Status    | Meaning                                 |
+| ------ | --------- | --------------------------------------- |
+| `+`    | Created   | New service uploaded for the first time |
+| `~`    | Updated   | Existing service updated with changes   |
+| `=`    | Unchanged | Service already exists and is identical |
+| `⊘`    | Skipped   | Service has draft status or deprecated without service_id |
+| `✗`    | Failed    | Error during uploading                  |
+
+**Upload Rules Based on Status:**
+
+The upload behavior depends on the `status` field of provider, offering, and listing:
+
+| Condition | Behavior |
+|-----------|----------|
+| Any status is `draft` | **Skip** - service not uploaded (still being configured) |
+| Any status is `deprecated` (none draft) | **Upload if `service_id` exists** - deprecates service on server |
+| Any status is `deprecated` (no `service_id`) | **Skip** - cannot deprecate a service that doesn't exist on server |
+| All statuses are `ready` | **Upload** - normal upload, service created/updated |
+
+**Draft Services:**
+
+Services with any component in `draft` status are skipped. This allows you to work on services locally without uploading incomplete data. Set status to `ready` when you're ready to upload.
+
+**Deprecated Services:**
+
+When any component (provider, offering, or listing) has `status: deprecated`:
+
+- If `service_id` exists (from override file or `--revision-to`): The service is uploaded and the backend sets `Service.status` to `deprecated`
+- If no `service_id`: The service is skipped with message "cannot deprecate on server"
+
+This ensures deprecated services properly sync their status to the backend, while preventing creation of new deprecated services that never existed.
+
+**Error Handling:**
+
+If uploading fails for a service, the error is displayed and uploading continues with remaining services. Common errors:
+
+- Missing offering file in the same directory as the listing
+- Missing provider file in the parent directory
+- Invalid data that fails schema validation
+- Network/authentication errors
+
+**Idempotent Uploading:**
+
+Uploading is idempotent - running `usvc_seller data upload` multiple times with the same data will result in "unchanged" status for services that haven't changed. The backend tracks content hashes to detect changes efficiently.
+
+**Override Files and Service ID Persistence:**
+
+After a successful first upload, the SDK automatically saves the `service_id` to an override file:
+
+```
+listing.json       →  listing.override.json
+listing.toml       →  listing.override.toml
+```
+
+Example override file content:
+
+```json
+{
+    "service_id": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+**Important:** The `service_id` is the stable identifier that subscriptions reference. When you first upload from a new repository or data directory, a **new Service is always created**, even if the content is identical to an existing service. The `service_id` in the override file ensures subsequent uploads update this specific service.
+
+On subsequent uploads, the `service_id` is automatically loaded from the override file and included in the upload request, ensuring the existing service is **updated** rather than creating a new one.
+
+**Uploading as New (Remove Existing Service ID):**
+
+If you need to upload as a completely new service (ignoring any existing `service_id`), delete the override file before uploading:
+
+```bash
+# Remove override file to upload as new service
+rm listing.override.json
+
+# Upload - will create a new service with a new service_id
+usvc_seller data upload --data-path ./my-provider/services/my-service/listing.json
+```
+
+Use cases for uploading as new:
+
+- Accidentally deleted the service from the backend and need to recreate it
+- Deploying to a different environment (staging vs production)
+- Backend data was reset
+
+**Cloning a Service:**
+
+To create a variant or copy of an existing service (e.g., different pricing tier, different region):
+
+```bash
+# 1. Copy the listing file with a new name
+cp listing.json listing-enterprise.json
+
+# 2. Edit the new file to change name/configuration
+#    - Change "name" field to a unique value (e.g., "enterprise")
+#    - Modify pricing, parameters, etc. as needed
+
+# 3. Upload the new listing (no override file exists, so creates new service)
+usvc_seller data upload --data-path ./my-provider/services/my-service/listing-enterprise.json
+```
+
+**Important:** Each listing file should have a unique `name` field. The new listing will get its own `service_id` saved to `listing-enterprise.override.json`.
+
+For multiple environment deployments, you can use different override files:
+
+```bash
+# Production override
+listing.override.json          # service_id for production
+
+# Staging override (manually managed or gitignored)
+listing.staging.override.json  # service_id for staging
+```
+
+---
+
+## usvc_seller services - Remote Service Operations
+
+Commands for managing services on the backend. These commands require API credentials and can be run from anywhere.
+
+### usvc_seller services list - Query Backend
+
+Query services for the current seller from UnitySVC backend API. Services are the identity layer that connects sellers to content versions (Provider, ServiceOffering, ServiceListing).
+
+```bash
+usvc_seller services list [OPTIONS]
+```
+
+**Options:**
+
+- `--format, -f {table|json|tsv|csv}` - Output format (default: table)
+- `--fields FIELDS` - Comma-separated list of fields to display (default: id,name,status,seller_id,provider_id,offering_id,listing_id)
+- `--skip SKIP` - Number of records to skip for pagination (default: 0)
+- `--limit LIMIT` - Maximum number of records to return (default: 100)
+- `--status STATUS` - Filter by status (draft, pending, testing, active, rejected, suspended)
+
+**Available Fields:**
+
+id, name, display_name, status, seller_id, provider_id, offering_id, listing_id, revision_of, created_by_id, updated_by_id, created_at, updated_at
+
+**Required Environment Variables:**
+
+- `UNITYSVC_API_URL` - Backend API URL
+- `UNITYSVC_SELLER_API_KEY` - API key for authentication
+
+**Examples:**
+
+```bash
+# Table output with default fields
+usvc_seller services list
+
+# JSON output
+usvc_seller services list --format json
+
+# Custom fields - show only specific columns
+usvc_seller services list --fields id,name,status
+
+# Filter by status
+usvc_seller services list --status active
+
+# Retrieve more than 100 records
+usvc_seller services list --limit 500
+
+# Pagination: get second page of 100 records
+usvc_seller services list --skip 100 --limit 100
+```
+
+### usvc_seller services withdraw - Withdraw to Draft
+
+Withdraw one or more services back to draft status (pending/rejected → draft).
+
+```bash
+usvc_seller services withdraw [SERVICE_ID...] [OPTIONS]
+```
+
+**Arguments:**
+
+- `[SERVICE_ID...]` - UUID(s) or partial UUID(s) of the service(s) to withdraw (optional if using --all)
+
+**Options:**
+
+- `--all` - Withdraw all pending and rejected services
+- `--yes, -y` - Skip confirmation prompt
+
+**Examples:**
+
+```bash
+# Withdraw a single service
+usvc_seller services withdraw abc123-uuid
+
+# Withdraw multiple services
+usvc_seller services withdraw abc123 def456
+
+# Withdraw all pending/rejected services
+usvc_seller services withdraw --all
+
+# Withdraw all without confirmation
+usvc_seller services withdraw --all -y
+```
+
+### usvc_seller services deprecate - Deprecate a Service
+
+Deprecate one or more active services. Deprecated services remain accessible but are marked as deprecated.
+
+```bash
+usvc_seller services deprecate [SERVICE_ID...] [OPTIONS]
+```
+
+**Arguments:**
+
+- `[SERVICE_ID...]` - UUID(s) or partial UUID(s) of the service(s) to deprecate (optional if using --all)
+
+**Options:**
+
+- `--all` - Deprecate all active services
+- `--yes, -y` - Skip confirmation prompt
+
+**Examples:**
+
+```bash
+# Deprecate a single service (with confirmation)
+usvc_seller services deprecate abc123-uuid
+
+# Deprecate multiple services
+usvc_seller services deprecate abc123 def456 ghi789
+
+# Deprecate all active services
+usvc_seller services deprecate --all
+
+# Deprecate without confirmation
+usvc_seller services deprecate abc123-uuid -y
+```
+
+### usvc_seller services delete - Delete a Service
+
+Permanently delete one or more services from the backend.
+
+```bash
+usvc_seller services delete [SERVICE_ID...] [OPTIONS]
+```
+
+**Arguments:**
+
+- `[SERVICE_ID...]` - UUID(s) or partial UUID(s) of the service(s) to delete (optional if using --all)
+
+**Options:**
+
+- `--all` - Delete all deletable services (draft, pending, testing, rejected, suspended, deprecated)
+- `--status STATUS` - Filter by status when using --all (e.g., `--all --status draft`)
+- `--dryrun` - Show what would be deleted without actually deleting
+- `--force` - Force deletion even with active subscriptions
+- `--yes, -y` - Skip confirmation prompt
+
+**Examples:**
+
+```bash
+# Delete a single service (with confirmation)
+usvc_seller services delete abc123-uuid
+
+# Delete multiple services
+usvc_seller services delete abc123 def456 ghi789
+
+# Delete all draft services
+usvc_seller services delete --all --status draft
+
+# Delete all deletable services (use with caution!)
+usvc_seller services delete --all
+
+# Dry-run to see what would be deleted
+usvc_seller services delete --all --status draft --dryrun
+
+# Delete without confirmation
+usvc_seller services delete abc123-uuid -y
+```
+
+### usvc_seller services submit - Submit for Review
+
+Submit one or more draft services for ops review (draft → pending).
+
+```bash
+usvc_seller services submit [SERVICE_ID...] [OPTIONS]
+```
+
+**Arguments:**
+
+- `[SERVICE_ID...]` - UUID(s) or partial UUID(s) of the service(s) to submit (optional if using --all)
+
+**Options:**
+
+- `--all` - Submit all draft services
+- `--yes, -y` - Skip confirmation prompt
+
+**Examples:**
+
+```bash
+# Submit a single service for review
+usvc_seller services submit abc123-uuid
+
+# Submit multiple services
+usvc_seller services submit abc123 def456 ghi789
+
+# Submit all draft services
+usvc_seller services submit --all
+
+# Submit all draft services without confirmation
+usvc_seller services submit --all -y
+```
+
+**Required Environment Variables:**
+
+- `UNITYSVC_API_URL` - Backend API URL
+- `UNITYSVC_SELLER_API_KEY` - API key for authentication
+
+### usvc_seller services dedup - Remove Duplicate Drafts
+
+Remove duplicate draft services that have identical content. This is useful for cleaning up services that were cloned or repeatedly uploaded with the same data.
+
+```bash
+usvc_seller services dedup [OPTIONS]
+```
+
+**Options:**
+
+- `--yes, -y` - Skip confirmation prompt
+
+**How It Works:**
+
+A draft service is considered a duplicate if another service (draft or non-draft) exists with identical content, meaning they share the same:
+
+- `provider_id` - Same provider content
+- `offering_id` - Same offering content
+- `listing_id` - Same listing content
+
+The dedup command processes draft services in creation order (oldest first) and:
+
+1. Keeps the first draft with unique content
+2. Removes subsequent drafts that have identical content to an earlier draft
+3. Removes drafts that duplicate a non-draft service (e.g., pending, active)
+
+**Why Use Dedup:**
+
+- **Cloning creates duplicates**: When you clone a service for editing, uploading without changes creates a duplicate
+- **Repeated uploads**: Uploading the same data multiple times creates duplicates
+- **Submit will fail**: Attempting to submit a duplicate service for review will fail with "A service with identical content already exists"
+
+**Examples:**
+
+```bash
+# Check for and remove duplicate drafts (with confirmation)
+usvc_seller services dedup
+
+# Remove duplicates without confirmation
+usvc_seller services dedup -y
+```
+
+**Output:**
+
+```bash
+$ usvc_seller services dedup
+Checking for duplicate draft services...
+
+Remove duplicate draft services? [y/N]: y
+✓ Removed 2 duplicate draft(s):
+  • abc123-def456-...
+  • 789xyz-012abc-...
+
+Total drafts examined: 5
+```
+
+**Important Notes:**
+
+- Only draft services can be removed by dedup
+- Services with archived history (were previously active) cannot be removed
+- The oldest draft with unique content is always kept
+- Run `usvc_seller services list --status draft` to see your draft services before deduping
+
+**Required Environment Variables:**
+
+- `UNITYSVC_API_URL` - Backend API URL
+- `UNITYSVC_SELLER_API_KEY` - API key for authentication
+
+---
+
+## usvc_seller promotions - Promotion Management
+
+Commands for managing seller promotions (pricing rules). Promotions are identified by name (unique per seller).
+
+All commands operate on promotions already uploaded to the backend. Local file operations (validate, upload) are handled by `usvc_seller data validate` and `usvc_seller data upload`, which automatically discover `promotion_v1` files alongside service data.
+
+### Promotion File Format
+
+Promotion files use the `promotion_v1` schema and live in a `promotions/` directory alongside service data:
+
+```
+seller-data/
+├── provider.json
+├── services/
+│   └── my-llm/
+│       ├── offering.json
+│       └── listing.json
+└── promotions/
+    ├── summer-discount.json
+    └── volume-tier.json
+```
+
+### Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `schema` | str | `"promotion_v1"` | File schema identifier (stripped before upload) |
+| `name` | str | **required** | Unique per seller. Used for idempotent upsert |
+| `description` | str \| null | null | Human-readable description |
+| `scope` | dict \| null | null | Who + where the promotion applies (see below) |
+| `pricing` | dict | **required** | Pricing adjustment (Pricing union type) |
+| `apply_at` | str | `"request"` | `"request"` (per API call) or `"statement"` (billing) |
+| `priority` | int | 0 | Higher-priority rules applied first |
+| `status` | str | `"draft"` | `"draft"`, `"active"`, `"paused"`, etc. |
+| `expires_at` | datetime \| null | null | When the promotion expires (code-based only) |
+| `max_uses` | int \| null | null | Maximum total redemptions (code-based only) |
+
+### Scope
+
+The `scope` field controls which **customers** and **services** a promotion applies to. When omitted, the promotion is a blanket discount for all customers on all of the seller's services.
+
+**Customer targeting** (`scope.customers`):
+
+| Value | Effect |
+|-------|--------|
+| `"*"` or omitted | All customers (blanket) |
+| `{"code": "SUMMER25"}` | Customers who redeem this code |
+| `{"code": "{{ promotion_code(6) }}"}` | Backend auto-generates a 6-char code |
+| `{"subscription": "premium"}` | Customers on a specific plan tier |
+| `["id1", "id2"]` | Specific customers (backend auto-assigns the code to their accounts) |
+
+**Service targeting** (`scope.services`):
+
+| Value | Effect |
+|-------|--------|
+| `"*"` or omitted | All of this seller's services |
+| `["gpt-4", "gpt-4-enterprise"]` | Specific services by name |
+
+### Examples
+
+**Blanket discount** — 20% off everything, no code needed:
+
+```json
+{
+  "schema": "promotion_v1",
+  "name": "summer-sale",
+  "description": "Summer 2026 sale — 20% off all services",
+  "pricing": {"type": "multiply", "factor": "0.80"},
+  "status": "active"
+}
+```
+
+**Code-based with auto-generated code:**
+
+```json
+{
+  "schema": "promotion_v1",
+  "name": "vip-discount",
+  "description": "30% off for VIP customers",
+  "scope": {"customers": {"code": "{{ promotion_code(6) }}"}},
+  "pricing": {"type": "multiply", "factor": "0.70"},
+  "expires_at": "2026-12-31T00:00:00Z",
+  "max_uses": 100
+}
+```
+
+After upload, `usvc_seller promotions show vip-discount` will show the generated code (e.g., `XKWPQM`).
+
+**Explicit code for specific services:**
+
+```json
+{
+  "schema": "promotion_v1",
+  "name": "launch-promo",
+  "scope": {
+    "customers": {"code": "LAUNCH2026"},
+    "services": ["my-new-service"]
+  },
+  "pricing": {"type": "multiply", "factor": "0.50"},
+  "max_uses": 500
+}
+```
+
+**Tier-restricted discount:**
+
+```json
+{
+  "schema": "promotion_v1",
+  "name": "premium-llm-discount",
+  "scope": {
+    "customers": {"subscription": "premium"},
+    "services": ["gpt-4", "claude-3-opus"]
+  },
+  "pricing": {"type": "multiply", "factor": "0.85"}
+}
+```
+
+**Targeted discount for specific customers:**
+
+```json
+{
+  "schema": "promotion_v1",
+  "name": "beta-tester-reward",
+  "scope": {"customers": ["550e8400-...", "6ba7b810-..."]},
+  "pricing": {"type": "constant", "price": "-5.00"}
+}
+```
+
+### usvc_seller promotions list
+
+List seller's promotions on the backend.
+
+```bash
+usvc_seller promotions list
+```
+
+**Environment:**
+
+- `UNITYSVC_API_URL` - Backend API URL
+- `UNITYSVC_SELLER_API_KEY` - API key for authentication
+
+### usvc_seller promotions show
+
+Show details of a promotion on the backend (including generated codes).
+
+```bash
+usvc_seller promotions show <NAME_OR_ID>
+```
+
+### usvc_seller promotions activate
+
+Activate a promotion by name or ID.
+
+```bash
+usvc_seller promotions activate <NAME_OR_ID>
+```
+
+### usvc_seller promotions pause
+
+Pause a promotion by name or ID.
+
+```bash
+usvc_seller promotions pause <NAME_OR_ID>
+```
+
+### usvc_seller promotions delete
+
+Delete a promotion by name or ID.
+
+```bash
+usvc_seller promotions delete <NAME_OR_ID> [--force]
+```
+
+**Options:**
+
+- `--force`, `-f` - Skip confirmation prompt
+
+---
+
+## usvc_seller services test commands
+
+Commands for managing and running tests on deployed services via the gateway.
+
+### usvc_seller services list-tests
+
+List tests for deployed services. If no service ID is specified, lists tests for all services.
+
+```bash
+usvc_seller services list-tests [SERVICE_ID] [OPTIONS]
+```
+
+**Arguments:**
+
+- `[SERVICE_ID]` - UUID or partial UUID of the service (optional, lists all if omitted)
+
+**Options:**
+
+- `--format, -f TEXT` - Output format: table, json, tsv, csv (default: table)
+
+**Examples:**
+
+```bash
+# List tests for all services
+usvc_seller services list-tests
+
+# List tests for specific service
+usvc_seller services list-tests abc123
+
+# JSON output
+usvc_seller services list-tests --format json
+```
+
+### usvc_seller services show-test
+
+Show details of a test for a deployed service.
+
+```bash
+usvc_seller services show-test <SERVICE_ID> -t <TEST_TITLE> [OPTIONS]
+```
+
+**Arguments:**
+
+- `<SERVICE_ID>` - UUID or partial UUID of the service (required)
+
+**Options:**
+
+- `--test-title, -t TEXT` - Test title (required)
+- `--format, -f TEXT` - Output format: json, table, tsv, csv (default: json)
+
+**Examples:**
+
+```bash
+usvc_seller services show-test abc123 -t "Python Example"
+```
+
+### usvc_seller services run-tests
+
+Run tests **locally** on your machine. Fetches test scripts from the backend, executes them with your local environment variables, and reports results back to the platform.
+
+**Environment Setup Required:**
+
+Before running tests, you need a **customer API key** for gateway access (separate from your seller API key). Follow these steps once:
+
+1. **Join the unitysvc-ops team** — Contact [support@unitysvc.com](mailto:support@unitysvc.com) to request an invitation code
+2. **Apply the invitation code** — In the web interface, go to **Add a Role** → **Join a Team** and enter the code
+3. **Create a customer API key** — Navigate to **API Keys** (under your team/customer role) and create a new key
+4. **Export environment variables** — Save the key and set up your shell:
+
+```bash
+# Customer API key (used by test scripts to access services through the gateway)
+export UNITYSVC_API_KEY="svcpass_your_customer_api_key"
+
+# Backend API URL
+export UNITYSVC_API_URL="https://backend.unitysvc.com/v1"
+```
+
+**Note:** `SERVICE_BASE_URL` is automatically set per access interface — you do not need to set it yourself.
+
+Your existing `UNITYSVC_SELLER_API_KEY` (seller key) and `UNITYSVC_API_URL` are still used for backend API access.
+
+```bash
+usvc_seller services run-tests <SERVICE_ID> [OPTIONS]
+```
+
+**Arguments:**
+
+- `<SERVICE_ID>` - UUID or partial UUID of the service (required)
+
+**Options:**
+
+- `--test-title, -t TEXT` - Run specific test by title (runs all if not specified)
+- `--doc-id, -d TEXT` - Run specific test by document ID (supports partial IDs)
+- `--verbose, -v` - Show detailed output including stdout/stderr
+- `--force` - Force rerun (ignore previous success status)
+- `--fail-fast, -x` - Stop on first failure
+- `--timeout INT` - Execution timeout in seconds (default: 30)
+
+**Examples:**
+
+```bash
+# Run all tests for a service
+usvc_seller services run-tests abc123
+
+# Run specific test by title
+usvc_seller services run-tests abc123 -t "Demo"
+
+# Run specific test by document ID
+usvc_seller services run-tests abc123 -d def456
+
+# Verbose output
+usvc_seller services run-tests abc123 -v
+
+# Force rerun even if previously successful
+usvc_seller services run-tests abc123 --force
+
+# Stop on first failure
+usvc_seller services run-tests abc123 --fail-fast
+```
+
+**Note:** Two API keys are involved. `UNITYSVC_SELLER_API_KEY` (seller key) authenticates with the backend to fetch scripts and submit results. `UNITYSVC_API_KEY` (customer key) is used by the test scripts themselves to access services through the gateway. See the environment setup steps above for how to obtain a customer API key.
+
+### usvc_seller services skip-test
+
+Mark a code example test as skipped. Skipped tests are excluded from test runs. Note: Connectivity tests cannot be skipped.
+
+```bash
+usvc_seller services skip-test <SERVICE_ID> -t <TEST_TITLE>
+```
+
+**Arguments:**
+
+- `<SERVICE_ID>` - UUID or partial UUID of the service (required)
+
+**Options:**
+
+- `--test-title, -t TEXT` - Test title (required)
+
+**Examples:**
+
+```bash
+usvc_seller services skip-test abc123 -t "Demo that requires GPU"
+```
+
+### usvc_seller services unskip-test
+
+Remove skip status from a test, making it eligible for execution again.
+
+```bash
+usvc_seller services unskip-test <SERVICE_ID> -t <TEST_TITLE>
+```
+
+**Arguments:**
+
+- `<SERVICE_ID>` - UUID or partial UUID of the service (required)
+
+**Options:**
+
+- `--test-title, -t TEXT` - Test title (required)
+
+**Examples:**
+
+```bash
+usvc_seller services unskip-test abc123 -t "Demo that requires GPU"
+```
+
+---
+
+## Editing Local Files
+
+To update fields in local data files, edit the JSON or TOML files directly. This file-based approach gives you full control and integrates naturally with version control.
+
+**Listing Status Values:**
+
+Seller-accessible statuses:
+
+- `draft` - Listing is being worked on, skipped during upload (won't be sent to backend)
+- `ready` - Listing is complete and ready for admin review/testing
+- `deprecated` - Seller marks service as retired/replaced
+
+Note: Admin-managed workflow statuses are set by the backend admin after testing and validation.
+
+### usvc_seller data validate - Validate Data
+
+Validate data consistency and schema compliance.
+
+```bash
+usvc_seller data validate [DATA_DIR]
+```
+
+**Arguments:**
+
+- `[DATA_DIR]` - Data directory (default: current directory)
+
+**Checks:**
+
+- Schema compliance
+- Service name uniqueness
+- Listing references
+- Provider/service name matching
+- File path validity
+- Seller uniqueness
+
+**Examples:**
+
+```bash
+# Validate current directory
+usvc_seller data validate
+
+# Validate specific directory
+usvc_seller data validate ./data
+```
+
+**Exit Codes:**
+
+- `0` - All validations passed
+- `1` - Validation errors found
+
+### usvc_seller data format - Format Files
+
+Format data files to match pre-commit requirements.
+
+```bash
+usvc_seller data format [DATA_DIR] [OPTIONS]
+```
+
+**Arguments:**
+
+- `[DATA_DIR]` - Data directory (default: current directory)
+
+**Options:**
+
+- `--check` - Check formatting without modifying files
+
+**Actions:**
+
+- Format JSON with 2-space indentation
+- Remove trailing whitespace
+- Ensure single newline at end of file
+- Sort JSON keys
+
+**Examples:**
+
+```bash
+# Format all files in current directory
+usvc_seller data format
+
+# Check formatting without changes
+usvc_seller data format --check
+
+# Format specific directory
+usvc_seller data format ./data
+```
+
+**Exit Codes:**
+
+- `0` - All files formatted or already formatted
+- `1` - Formatting errors or files need formatting (with --check)
+
+### usvc_seller data populate - Generate Services
+
+Execute provider populate scripts to auto-generate service data from upstream sources (APIs, web scraping, etc.).
+
+```bash
+usvc_seller data populate [DATA_DIR] [OPTIONS]
+```
+
+**Arguments:**
+
+- `[DATA_DIR]` - Data directory (default: current directory)
+
+**Options:**
+
+- `--provider, -p NAME` - Only populate specific provider
+- `--dry-run` - Show what would execute without running
+
+**Requirements:**
+
+- Provider file must have `services_populator` configuration
+- Script specified in `services_populator.command`
+- Environment variables from `services_populator.envs`
+
+**Examples:**
+
+```bash
+# Run all populate scripts
+usvc_seller data populate
+
+# Run for specific provider
+usvc_seller data populate --provider openai
+
+# Dry run
+usvc_seller data populate --dry-run
+```
+
+**Automatic Deprecation of Removed Services:**
+
+When a populate script runs, services that exist locally but are no longer returned by the upstream source are automatically marked as deprecated:
+
+1. Before running, the system records all existing service directories (those with `offering.json`)
+2. During population, services returned by the upstream API are created/updated
+3. After population, services that weren't touched are marked as deprecated
+
+**What gets updated:**
+
+- `offering.json` → `status` field set to `"deprecated"`
+- `listing.json` files are **not** modified (deprecation is conceptually an offering-level change)
+
+**Output includes deprecation count:**
+
+```
+Done! Total: 150, Written: 145, Skipped: 3, Filtered: 0, Errors: 0, Deprecated: 2
+  Deprecated: old-model-v1
+  Deprecated: legacy-service
+```
+
+**Important:** Deprecated services need a `service_id` (from override file) to sync the deprecation to the backend. Services without a `service_id` will be skipped during upload with message "cannot deprecate on server".
+
+**Disabling automatic deprecation:**
+
+Your populator script decides whether missing services get
+deprecated — just skip the deprecation pass if you don't want that
+behaviour. See the [automated workflow example](workflows.md#automated-workflow-template-based)
+for the full pattern.
+
+## usvc_seller data test commands
+
+Test code examples locally with upstream API credentials. These commands discover code examples from listing files and execute them with provider credentials.
+
+**How it works:**
+
+1. Scans for all listing files (schema: listing_v1)
+2. Extracts code example documents (category = `code_examples`)
+3. Loads provider credentials from provider files
+4. Renders Jinja2 templates with listing, offering, provider, and seller data
+5. Sets environment variables (UNITYSVC_API_KEY, SERVICE_BASE_URL) automatically from provider credentials
+6. Executes code examples using appropriate interpreter (python3, node, bash)
+7. Validates results based on exit code and optional `expect` field
+
+### usvc_seller data list-tests
+
+List available code examples without running them.
+
+```bash
+usvc_seller data list-tests [DATA_DIR] [OPTIONS]
+```
+
+**Arguments:**
+
+- `[DATA_DIR]` - Data directory (default: current directory)
+
+**Options:**
+
+- `--provider, -p NAME` - Only list code examples for a specific provider
+- `--services, -s PATTERNS` - Comma-separated list of service patterns (supports wildcards)
+
+**Output:**
+
+- Table showing: Service name, Provider, Title, File type, Relative file path
+
+**Examples:**
+
+```bash
+# List all code examples
+usvc_seller data list-tests
+
+# List for specific provider
+usvc_seller data list-tests --provider fireworks
+
+# List for specific services (with wildcards)
+usvc_seller data list-tests --services "llama*,gpt-4*"
+
+# List from custom directory
+usvc_seller data list-tests ./data
+```
+
+### usvc_seller data run-tests
+
+Execute code examples and report results.
+
+```bash
+usvc_seller data run-tests [DATA_DIR] [OPTIONS]
+```
+
+**Upstream Credentials (Secrets):**
+
+Offering files reference upstream API keys using `${ secrets.VAR_NAME }` instead
+of storing credentials in plain text. Before running tests, export the
+corresponding environment variables:
+
+```bash
+# Check which secrets your offerings reference
+grep -r 'secrets\.' data/ --include='*.json'
+# → "api_key": "${ secrets.AIONLABS_API_KEY }"
+
+# Export the required secrets
+export AIONLABS_API_KEY="your-upstream-api-key"
+
+# Now run tests
+usvc_seller data run-tests
+```
+
+If a required secret is missing, the command will exit with an error showing
+which environment variable needs to be set.
+
+**Arguments:**
+
+- `[DATA_DIR]` - Data directory (default: current directory)
+
+**Options:**
+
+- `--provider, -p NAME` - Only test code examples for a specific provider
+- `--services, -s PATTERNS` - Comma-separated list of service patterns (supports wildcards)
+- `--test-file, -t FILENAME` - Only run a specific test file by filename (e.g., 'code-example.py.j2')
+- `--verbose, -v` - Show detailed output including stdout/stderr from scripts
+- `--force, -f` - Force rerun all tests, ignoring existing .out and .err files
+- `--fail-fast, -x` - Stop testing on first failure
+
+**Test Pass Criteria:**
+
+- Exit code is 0 AND
+- If `expect` field is defined in document: expected string found in stdout
+- If `expect` field is NOT defined: only exit code matters
+
+**Test Result Caching:**
+
+By default, successful test results are cached to avoid re-running tests unnecessarily:
+
+- When a test passes, `.out` and `.err` files are saved in the same directory as the listing file
+- On subsequent runs, tests with existing result files are skipped
+- Use `--force` to ignore cached results and re-run all tests
+- Failed tests are always re-run (their output goes to current directory with `failed_` prefix)
+
+**Failed Test Output:**
+
+When a test fails, the rendered content is saved to the current directory:
+
+- Filename format: `failed_{service}_{listing}_{filename}.{out|err|extension}`
+- `.out` file: stdout from the test
+- `.err` file: stderr from the test
+- Script file: Full rendered template content with environment variables
+- Can be run directly to reproduce the issue
+
+**Successful Test Output:**
+
+When a test passes, output files are saved in the listing directory:
+
+- Filename format: `{service}_{listing}_{filename}.{out|err}`
+- Saved alongside the listing definition file
+- Used to skip re-running tests unless `--force` is specified
+
+**Examples:**
+
+```bash
+# Test all code examples
+usvc_seller data run-tests
+
+# Test specific provider
+usvc_seller data run-tests --provider fireworks
+
+# Test specific services (with wildcards)
+usvc_seller data run-tests --services "llama*,gpt-4*"
+
+# Test single service
+usvc_seller data run-tests --services "llama-3-1-405b-instruct"
+
+# Test specific file
+usvc_seller data run-tests --test-file "code-example.py.j2"
+
+# Combine filters
+usvc_seller data run-tests --provider fireworks --services "llama*"
+
+# Show detailed output
+usvc_seller data run-tests --verbose
+
+# Force rerun all tests (ignore cached results)
+usvc_seller data run-tests --force
+
+# Stop on first failure (useful for quick feedback)
+usvc_seller data run-tests --fail-fast
+
+# Combine options
+usvc_seller data run-tests --force --fail-fast --verbose
+usvc_seller data run-tests -f -x -v  # Short form
+```
+
+**Interpreter Detection:**
+
+- `.py` files: Uses `python3` (falls back to `python`)
+- `.js` files: Uses `node` (Node.js required)
+- `.sh` files: Uses `bash`
+- Other files: Checks shebang line for interpreter
+
+**Exit Codes:**
+
+- `0` - All tests passed
+- `1` - One or more tests failed
+
+### usvc_seller data show-test
+
+Show details of a local code example test, including rendered content and test results.
+
+```bash
+usvc_seller data show-test [DATA_DIR] [OPTIONS]
+```
+
+**Arguments:**
+
+- `[DATA_DIR]` - Data directory (default: current directory)
+
+**Options:**
+
+- `--provider, -p NAME` - Filter by provider
+- `--services, -s NAME` - Filter by service name
+- `--test-file, -t FILENAME` - Show specific test file
+
+**Examples:**
+
+```bash
+usvc_seller data show-test --services "my-service" --test-file "example.py.j2"
+```
+
+See [Creating Code Examples](https://unitysvc-sellers.readthedocs.io/en/latest/code-examples/) for detailed guide on creating and debugging code examples.
+
+## Environment Variables
+
+| Variable            | Description            | Used By                  |
+| ------------------- | ---------------------- | ------------------------ |
+| `UNITYSVC_API_URL`      | Backend API URL        | `usvc_seller services` commands |
+| `UNITYSVC_SELLER_API_KEY` | API authentication key | `usvc_seller services` commands |
+
+**Example:**
+
+```bash
+export UNITYSVC_API_URL=https://api.unitysvc.com/v1
+export UNITYSVC_SELLER_API_KEY=your-api-key
+
+# Local operations (no API key needed)
+usvc_seller data validate
+usvc_seller data format
+
+# Remote operations (requires API key)
+usvc_seller data upload
+usvc_seller services list
+```
+
+## Exit Codes
+
+| Code | Meaning                           |
+| ---- | --------------------------------- |
+| 0    | Success                           |
+| 1    | Error (validation, publish, etc.) |
+
+## Shell Completion
+
+### Install Completion
+
+```bash
+# Bash
+usvc_seller --install-completion bash
+
+# Zsh
+usvc_seller --install-completion zsh
+
+# Fish
+usvc_seller --install-completion fish
+```
+
+### Show Completion Script
+
+```bash
+usvc_seller --show-completion
+```
+
+## Common Workflows
+
+### Creating Data
+
+Create data using the web interface at [unitysvc.com](https://unitysvc.com), then export for SDK use:
+
+1. Sign in to unitysvc.com
+2. Create your Provider, Offerings, and Listings using the visual editor
+3. Export your data as JSON/TOML files
+4. Place files in the expected directory structure
+
+Alternatively, create files manually following the [File Schemas](file-schemas.md) documentation.
+
+### Full Upload Flow
+
+```bash
+# Set seller environment (only needed for remote operations)
+export UNITYSVC_API_URL=https://api.unitysvc.com/v1
+export UNITYSVC_SELLER_API_KEY=your-seller-api-key
+
+# Local operations: validate and format
+usvc_seller data validate
+usvc_seller data format
+
+# Local operations: test code examples with upstream credentials
+usvc_seller data list-tests
+usvc_seller data run-tests
+
+# Preview changes before uploading (recommended)
+cd data
+usvc_seller data upload --dryrun
+
+# If preview looks good, upload all (handles order automatically)
+usvc_seller data upload
+
+# Verify on backend
+usvc_seller services list
+
+# Set credentials for testing (one-time setup, see "usvc_seller services run-tests")
+export UNITYSVC_API_KEY=your-customer-api-key
+export UNITYSVC_API_URL=https://backend.unitysvc.com/v1
+
+# Run tests via gateway
+usvc_seller services list-tests
+usvc_seller services run-tests <service-id>
+
+# Submit for review when ready
+usvc_seller services submit <service-id>
+```
+
+### Update and Re-upload
+
+```bash
+# Edit local files directly (JSON or TOML)
+# e.g., change "status": "draft" to "status": "ready"
+
+# Validate locally
+usvc_seller data validate
+
+# Preview changes
+usvc_seller data upload --dryrun
+
+# Upload changes
+usvc_seller data upload
+```
+
+### Automated Generation
+
+```bash
+# Generate services
+usvc_seller data populate
+
+# Validate and format
+usvc_seller data validate
+usvc_seller data format
+
+# Preview generated data
+cd data
+usvc_seller data upload --dryrun
+
+# Upload all
+usvc_seller data upload
+```
+
+### Managing Test Status
+
+```bash
+# Skip a code example test
+usvc_seller services skip-test <service-id> -t "Demo that requires GPU"
+
+# Re-enable a skipped test
+usvc_seller services unskip-test <service-id> -t "Demo that requires GPU"
+
+# View test details
+usvc_seller services show-test <service-id> -t "Python Example"
+```
+
+## See Also
+
+- [Getting Started](getting-started.md) - First steps tutorial
+- [Workflows](workflows.md) - Common usage patterns
+- [Data Structure](data-structure.md) - File organization rules
+- [Documenting Service Listings](documenting-services.md) - Add documentation to services
+- [Creating Code Examples](code-examples.md) - Develop and test code examples
+- [SDK Reference](sdk-reference.md) - Python `Client` / `AsyncClient` documentation

--- a/docs/code-examples.md
+++ b/docs/code-examples.md
@@ -1,0 +1,1113 @@
+# Creating and Testing Code Examples
+
+This guide explains how to create, test, and publish code examples for your services on the UnitySVC platform.
+
+## Overview
+
+Code examples help users understand how to interact with your services. The UnitySVC Services SDK provides a complete workflow for:
+
+-   Creating executable code examples in multiple languages (Python, JavaScript, Shell)
+-   Using Jinja2 templates for dynamic content
+-   Testing examples against upstream APIs
+-   Validating output automatically
+-   Publishing examples with your service listings
+
+## Gateway Testing Methods
+
+There are two ways to test code examples that access services through the UnitySVC gateway:
+
+### Web-Based Testing (Frontend)
+
+When you click the "Test" button in the UnitySVC web interface (admin panel or seller dashboard), the platform executes your code examples using:
+
+-   **`SERVICE_BASE_URL`**: Automatically set to the service's access interface base URL
+-   **`UNITYSVC_API_KEY`**: Platform's ops customer API key (shared across all sellers)
+
+**Characteristics:**
+
+-   Simple setup - no configuration required from sellers
+-   Limited to basic scripts (curl, Python, JavaScript, bash)
+-   Test execution happens on the platform's backend (Celery worker)
+-   Results are automatically saved to document metadata
+-   Suitable for quick validation and CI/CD integration
+
+**Limitations:**
+
+-   Cannot use complex SDK setups or custom environments
+-   Uses a shared test customer account (ops customer)
+-   Limited execution timeout and resource constraints
+
+### SDK-Based Testing (Local CLI)
+
+When you run tests locally using the `usvc_seller` CLI, you must configure your own environment with a customer API key for gateway access. Follow these steps:
+
+**Step 1: Join the unitysvc-ops team**
+
+Request to join the **unitysvc-ops** team by contacting [support@unitysvc.com](mailto:support@unitysvc.com). You will receive an invitation code.
+
+**Step 2: Apply the invitation code**
+
+In the UnitySVC web interface, go to **Add a Role** → **Join a Team** and enter the invitation code you received.
+
+**Step 3: Create a customer API key**
+
+Navigate to **API Keys** in the web interface (under your team/customer role) and create a new API key.
+
+**Step 4: Set environment variables**
+
+Save the API key and configure the backend URL:
+
+```bash
+# Customer API key (used by test scripts to access services through the gateway)
+export UNITYSVC_API_KEY="svcpass_your_customer_api_key"
+
+# Backend API URL (for fetching test scripts and submitting results)
+export UNITYSVC_API_URL="https://backend.unitysvc.com/v1"
+```
+
+**Note:** `SERVICE_BASE_URL` is automatically set per access interface — you do not need to set it yourself.
+
+**Step 5: Run tests**
+
+With your existing seller credentials (`UNITYSVC_SELLER_API_KEY` and `UNITYSVC_API_URL`) already configured, run tests:
+
+```bash
+# Run all tests for a service
+usvc_seller services run-tests <service_id>
+
+# Run with verbose output
+usvc_seller services run-tests <service_id> --verbose
+
+# Force rerun previously passed tests
+usvc_seller services run-tests <service_id> --force
+```
+
+**Note:** Two API keys are involved:
+
+-   `UNITYSVC_SELLER_API_KEY` (seller key) — authenticates with the backend API to fetch test scripts and submit results
+-   `UNITYSVC_API_KEY` (customer key) — used by test scripts to access services through the gateway
+
+**Characteristics:**
+
+-   Full control over test environment
+-   Can use complex SDK setups, custom libraries, and local tools
+-   Test execution happens on your local machine
+-   Results are submitted back to the platform
+-   Suitable for development, debugging, and advanced testing scenarios
+
+**Benefits:**
+
+-   Use your own customer account for isolated testing
+-   No shared resource constraints
+-   Full access to local debugging tools
+-   Can test with different API keys and configurations
+
+### Comparison
+
+| Feature | Web-Based | SDK-Based (Local) |
+|---------|-----------|-------------------|
+| Setup | None required | Join unitysvc-ops team + create customer API key |
+| `SERVICE_BASE_URL` | Auto-set per interface | Auto-set per interface |
+| `UNITYSVC_API_KEY` | Platform ops customer | Your own customer API key |
+| Execution | Backend (Celery) | Local machine |
+| Script Types | Simple (curl, Python, JS) | Any (including complex SDKs) |
+| Debugging | Limited | Full local access |
+| Use Case | Quick validation | Development & advanced testing |
+
+### Recommended Workflow
+
+1. **One-time setup**: Join the unitysvc-ops team and create a customer API key (see SDK-Based Testing steps above)
+2. **Development**: Use SDK-based local testing for iterative development
+3. **Validation**: Use web-based testing for final validation before publishing
+4. **CI/CD**: Either method works; web-based is simpler, SDK-based offers more control
+
+## Test Environment Variables
+
+Code examples and connectivity tests run in two different contexts, each with different environment variables available.
+
+### Gateway Testing (`usvc_seller services run-tests`)
+
+Tests run through the UnitySVC gateway. Only these variables are available:
+
+| Variable | Source | Description |
+|----------|--------|-------------|
+| `SERVICE_BASE_URL` | `user_access_interfaces.base_url` | Gateway endpoint URL (e.g. `https://api.svcpass.com/u/openai`, `smtp://smtp.svcpass.com:587`) |
+| `UNITYSVC_API_KEY` | Customer API key | Authentication key for the gateway |
+| Routing key entries | `user_access_interfaces.routing_key` | Flattened as uppercased env vars (e.g. `{"username": "foo"}` → `USERNAME=foo`, `{"model": "gpt-4"}` → `MODEL=gpt-4`) |
+
+**No other variables are available.** Customer code examples should only use these variables since they represent what real customers see.
+
+### Local/Upstream Testing (`usvc_seller data run-tests`)
+
+Tests run directly against the upstream service (no gateway). All fields from `upstream_access_config` are available as uppercased environment variables, with two special mappings:
+
+| Variable | Source | Description |
+|----------|--------|-------------|
+| `SERVICE_BASE_URL` | `upstream_access_config.base_url` | Upstream endpoint URL |
+| `UNITYSVC_API_KEY` | `upstream_access_config.api_key` | Upstream API key |
+| `HOST`, `PORT`, etc. | Other `upstream_access_config` fields | Exported as uppercased keys |
+| Routing key entries | `upstream_access_config.routing_key` | Flattened as uppercased env vars |
+
+Secret references (`${ customer_secrets.NAME }`, `${ secrets.NAME }`) are resolved from your local environment variables. Set them in your shell before running tests:
+
+```bash
+export SMTP_HOST=smtp.gmail.com
+export SMTP_PORT=587
+usvc_seller data run-tests
+```
+
+### Writing Tests for Both Contexts
+
+Use the `{% if local_testing %}` Jinja2 condition to handle differences between local and gateway testing. This is necessary when:
+
+- The upstream protocol differs from the gateway protocol
+- Local testing needs credentials not available through the gateway
+- The test needs to parse `SERVICE_BASE_URL` for gateway testing
+
+**Example: SMTP connectivity test**
+
+```bash
+#!/bin/bash
+# Test SMTP connectivity
+{% if local_testing %}
+# Local: HOST and PORT from upstream_access_config
+SMTP_HOST=${HOST:-localhost}
+SMTP_PORT=${PORT:-587}
+{% else %}
+# Gateway: parse SERVICE_BASE_URL (smtp://host:port)
+SMTP_HOST=$(echo "$SERVICE_BASE_URL" | sed -E 's|^smtps?://||' | cut -d: -f1)
+SMTP_PORT=$(echo "$SERVICE_BASE_URL" | sed -E 's|^smtps?://||' | cut -d: -f2 | cut -d/ -f1)
+SMTP_HOST=${SMTP_HOST:-localhost}
+SMTP_PORT=${SMTP_PORT:-587}
+{% endif %}
+(sleep 1; echo "QUIT") | nc -w5 "$SMTP_HOST" "$SMTP_PORT" | grep -q "220" && echo "connectivity ok"
+```
+
+**Example: HTTP API code example (no branching needed)**
+
+When both local and gateway testing use the same `SERVICE_BASE_URL` and `UNITYSVC_API_KEY`, no `local_testing` condition is needed:
+
+```python
+import os, httpx
+
+response = httpx.post(
+    f"{os.environ['SERVICE_BASE_URL']}/chat/completions",
+    headers={"Authorization": f"Bearer {os.environ['UNITYSVC_API_KEY']}"},
+    json={"model": os.environ.get("MODEL", "default"), "messages": [{"role": "user", "content": "test"}]}
+)
+print(response.json())
+```
+
+This works for both contexts because `SERVICE_BASE_URL` and `UNITYSVC_API_KEY` are mapped from `upstream_access_config.base_url`/`api_key` in local testing and from `user_access_interfaces.base_url`/customer API key in gateway testing.
+
+## Basic Concepts
+
+Before diving into creating code examples, understand these fundamental principles:
+
+### 1. Code Examples Should Be Complete
+
+Code examples must be **fully executable** and **self-contained**. Users should be able to run them directly without modifications:
+
+```python
+# ✓ GOOD: Complete, runnable example
+#!/usr/bin/env python3
+import httpx
+import os
+
+response = httpx.post(
+    f"{os.environ['SERVICE_BASE_URL']}/chat/completions",
+    headers={"Authorization": f"Bearer {os.environ['UNITYSVC_API_KEY']}"},
+    json={"model": "gpt-4", "messages": [{"role": "user", "content": "Hello"}]}
+)
+print(response.json())
+
+# ✗ BAD: Incomplete snippet
+response = api.chat(...)  # What is 'api'? How to initialize it?
+```
+
+### 2. Never Include Sensitive Information
+
+**IMPORTANT:** Code examples are public. Never hardcode sensitive information:
+
+```python
+# ✗ BAD: Hardcoded credentials
+UNITYSVC_API_KEY = "sk-abc123xyz789"  # NEVER DO THIS!
+
+# ✓ GOOD: Use environment variables
+UNITYSVC_API_KEY = os.environ.get("UNITYSVC_API_KEY")
+SERVICE_BASE_URL = os.environ.get("SERVICE_BASE_URL")
+```
+
+**Standard Environment Variables:**
+
+The test framework automatically sets these environment variables when running code examples:
+
+-   `UNITYSVC_API_KEY` - API key for authentication
+-   `SERVICE_BASE_URL` - Automatically set to the service's access interface base URL
+
+Your code examples should **always** read credentials from these environment variables. `SERVICE_BASE_URL` is set automatically — users do not configure it.
+
+### 3. Add to Service Listing Documents
+
+Code examples are referenced in your `listing.json` or `listing.toml` file under the `documents` array at the listing level (not inside interfaces). The listing automatically belongs to the offering in the same directory:
+
+```json
+{
+    "schema": "listing_v1",
+    "name": "listing-default",
+    "user_access_interfaces": [
+        {
+            "interface_type": "openai_chat_completions",
+            "base_url": "https://api.example.com/v1"
+        }
+    ],
+    "documents": [
+        {
+            "category": "code_examples",
+            "title": "Python Example",
+            "file_path": "../../docs/example.py.j2",
+            "mime_type": "python",
+            "is_public": true,
+            "meta": {
+                "requirements": ["httpx"],
+                "expect": "✓ Test passed"
+            }
+        }
+    ]
+}
+```
+
+**Required Fields:**
+
+-   **`category`**: Must be `"code_examples"` or `"connectivity_test"` for test framework to discover it
+    -   `code_examples` - User-visible examples shown in documentation
+    -   `connectivity_test` - Internal tests for connectivity and performance metrics (not visible to users)
+-   **`title`**: Descriptive name (e.g., "Python Example", "cURL Example")
+-   **`file_path`**: Path to the code file (relative to the listing file)
+-   **`mime_type`**: File type (`python`, `javascript`, `shell`, etc.)
+-   **`is_public`**: `true` for code examples, `false` for connectivity tests
+
+**Optional but Recommended Fields (in `meta` object):**
+
+-   **`meta.requirements`**: _(User-maintained)_ Package dependencies needed to run the code example
+    -   For Python: PyPI packages (e.g., `["httpx", "openai"]`)
+    -   For JavaScript: npm packages (e.g., `["node-fetch"]`)
+    -   For Shell scripts: commands (e.g., `["curl"]`)
+    -   Helps users understand what to install before running the example
+-   **`meta.expect`**: _(User-maintained)_ Expected substring in stdout for validation
+    -   Examples: `"✓ Test passed"`, `"\"choices\""`, `"Status: 200"`
+    -   If specified, test passes only if stdout contains this string
+    -   Without this field, tests only check exit code (0 = pass, non-zero = fail)
+
+**System-Maintained Fields (in `meta` object):**
+
+-   **`meta.output`**: _(System-maintained)_ Actual output from successful test execution
+    -   Automatically populated by `usvc_seller test run` when a test passes
+    -   Contains the stdout from the last successful test run
+    -   Included in your service listing during `usvc_seller data upload`
+    -   Displayed alongside code examples for documentation
+
+### 4. Use Relative Paths
+
+The `file_path` must be **relative to the listing file**, not absolute:
+
+```
+data/
+└── fireworks/
+    ├── docs/
+    │   └── example.py.j2          # Shared code example
+    └── services/
+        └── llama-3-1-405b/
+            └── listing.json        # References: ../../docs/example.py.j2
+```
+
+```json
+{
+    "file_path": "../../docs/example.py.j2" // ✓ GOOD: Relative path
+}
+```
+
+```json
+{
+    "file_path": "/data/fireworks/docs/example.py.j2" // ✗ BAD: Absolute path
+}
+```
+
+### 5. Templates Work Across Multiple Services
+
+Code examples ending with `.j2` are **Jinja2 templates** that can be reused across multiple service listings:
+
+**Template File: `docs/example.py.j2`**
+
+```python
+#!/usr/bin/env python3
+"""Example for {{ offering.name }} from {{ provider.name }}"""
+import httpx
+import os
+
+response = httpx.post(
+    f"{os.environ['SERVICE_BASE_URL']}/chat/completions",
+    headers={"Authorization": f"Bearer {os.environ['UNITYSVC_API_KEY']}"},
+    json={
+        "model": "{{ offering.name }}",  # Dynamic: changes per service
+        "messages": [{"role": "user", "content": "Hello"}]
+    }
+)
+print(response.json())
+```
+
+**Multiple Listings Reference the Same Template:**
+
+```
+data/fireworks/
+├── docs/
+│   └── example.py.j2              # One template
+└── services/
+    ├── llama-3-1-405b/
+    │   └── listing.json            # References: ../../docs/example.py.j2
+    ├── llama-3-1-70b/
+    │   └── listing.json            # References: ../../docs/example.py.j2
+    └── mixtral-8x7b/
+        └── listing.json            # References: ../../docs/example.py.j2
+```
+
+**Benefits of Templates:**
+
+-   **Write once, use many times** - One template serves all services
+-   **Automatic updates** - Fix the template once, all services benefit
+-   **Dynamic content** - Service-specific values inserted automatically
+-   **Type safety** - Variables validated during testing
+
+See [Template Variables Reference](#template-variables-reference) for complete list.
+
+## Test Command
+
+The `test` command helps validate code examples against upstream APIs before publishing.
+
+### Listing Code Examples
+
+```bash
+# List all available code examples
+usvc_seller test list
+
+# List examples for a specific provider
+usvc_seller test list --provider fireworks
+
+# List examples for specific services (supports wildcards)
+usvc_seller test list --services "llama*,gpt-4*"
+```
+
+The output shows:
+
+-   Service name
+-   Provider name
+-   Example title
+-   File type (.py, .js, .sh, etc.)
+-   Relative file path from data directory
+
+### Running Tests
+
+```bash
+# Run all code examples
+usvc_seller test run
+
+# Run tests for a specific provider
+usvc_seller test run --provider fireworks
+
+# Run tests for specific services (supports wildcards)
+usvc_seller test run --services "code-llama-*"
+
+# Show verbose output including stdout/stderr
+usvc_seller test run --verbose
+
+# Force rerun all tests (ignore cached results)
+usvc_seller test run --force
+
+# Stop on first failure (useful for quick feedback during development)
+usvc_seller test run --fail-fast
+
+# Combine options
+usvc_seller test run --force --fail-fast --verbose
+```
+
+**How tests work:**
+
+1. Test framework discovers code examples from listing files (category = `code_examples`)
+2. **Checks for cached results**: If both `.out` and `.err` files exist in the listing directory, skips the test (unless `--force` is used)
+3. Renders Jinja2 templates with `listing`, `offering`, `provider`, and `seller` data
+4. Sets environment variables (`UNITYSVC_API_KEY`, `SERVICE_BASE_URL`) automatically from provider credentials
+5. Executes the code example using appropriate interpreter (python3, node, bash)
+6. Validates results:
+    - Test passes if exit code is 0 AND (no `meta.expect` field OR expected string found in stdout)
+    - Test fails if exit code is non-zero OR expected string not found
+7. **Saves output**: When a test passes, stdout and stderr are saved to listing directory as `{service}_{listing}_{filename}.{out|err}`
+    - Example: For `listing.json` in `llama-3-1-405b` with code file `test.py`, output is saved as `llama-3-1-405b_listing_test.py.out` and `llama-3-1-405b_listing_test.py.err`
+    - Saved in the same directory as the listing file for easy version control
+    - Used to skip re-running tests on subsequent runs (unless `--force` is specified)
+8. **Fail-fast mode**: If `--fail-fast` is enabled, testing stops immediately after the first failure
+
+**Failed test debugging:**
+
+When a test fails, the rendered content is automatically saved to the current directory:
+
+```bash
+# Example output:
+Testing: llama-3-1-405b - Python code example
+  ✗ Failed - Output validation failed: expected substring '✓ Test passed' not found
+  → Test content saved to: failed_llama-3-1-405b_Python_code_example.py
+
+# The saved file includes:
+# - Environment variables used (UNITYSVC_API_KEY, SERVICE_BASE_URL)
+# - Full rendered template content
+# - You can run it directly to reproduce the issue
+```
+
+## Developing Code Examples
+
+This section provides a step-by-step guide for creating and testing code examples for your services.
+
+### Step 1: Develop and Test the Script Locally
+
+Start by writing a working script using actual values. This allows you to verify the API works correctly before templating.
+
+Note the expected output and find a suitable `expect` word.
+
+**Example: `test.py` (initial version)**
+
+```python
+#!/usr/bin/env python3
+"""Test script for llama-3-1-405b"""
+import httpx
+import os
+
+# Hardcoded values for initial testing
+response = httpx.post(
+    "https://api.fireworks.ai/inference/v1/chat/completions",
+    headers={"Authorization": "Bearer fw_abc123xyz789"},
+    json={
+        "model": "accounts/fireworks/models/llama-v3p1-405b-instruct",
+        "messages": [{"role": "user", "content": "Say hello"}],
+        "max_tokens": 50
+    }
+)
+
+print(response.json())
+if response.status_code == 200 and "choices" in response.json():
+    print("✓ Test passed")
+```
+
+**Test it:**
+
+```bash
+python3 test.py
+# Verify it works and outputs "✓ Test passed"
+```
+
+### Step 2: Use Environment Variables
+
+Replace hardcoded credentials with environment variables to avoid exposing sensitive data.
+
+**Example: `test.py` (with environment variables)**
+
+```python
+#!/usr/bin/env python3
+"""Test script for llama-3-1-405b"""
+import httpx
+import os
+
+# Use environment variables
+UNITYSVC_API_KEY = os.environ.get("UNITYSVC_API_KEY")
+SERVICE_BASE_URL = os.environ.get("SERVICE_BASE_URL")
+
+response = httpx.post(
+    f"{SERVICE_BASE_URL}/chat/completions",
+    headers={"Authorization": f"Bearer {UNITYSVC_API_KEY}"},
+    json={
+        "model": "accounts/fireworks/models/llama-v3p1-405b-instruct",
+        "messages": [{"role": "user", "content": "Say hello"}],
+        "max_tokens": 50
+    }
+)
+
+print(response.json())
+if response.status_code == 200 and "choices" in response.json():
+    print("✓ Test passed")
+```
+
+**Test with environment variables (for manual local testing):**
+
+```bash
+export UNITYSVC_API_KEY="fw_abc123xyz789"
+export SERVICE_BASE_URL="https://api.fireworks.ai/inference/v1"  # Auto-set by test framework
+python3 test.py
+```
+
+### Step 3: Replace Static Values with Template Variables
+
+Convert hardcoded service-specific values to Jinja2 template variables and rename the file to `.j2`.
+
+**Example: `test.py.j2` (templated version)**
+
+```python
+#!/usr/bin/env python3
+"""Test script for {{ offering.name }}"""
+import httpx
+import os
+
+# Use environment variables (set by test framework)
+UNITYSVC_API_KEY = os.environ.get("UNITYSVC_API_KEY")
+SERVICE_BASE_URL = os.environ.get("SERVICE_BASE_URL")
+
+response = httpx.post(
+    f"{SERVICE_BASE_URL}/chat/completions",
+    headers={"Authorization": f"Bearer {UNITYSVC_API_KEY}"},
+    json={
+        "model": "{{ offering.name }}",  # Template variable
+        "messages": [{"role": "user", "content": "Say hello"}],
+        "max_tokens": 50
+    }
+)
+
+print(response.json())
+if response.status_code == 200 and "choices" in response.json():
+    print("✓ Test passed")
+```
+
+**Common template variables:**
+
+-   `{{ listing.name }}` - Service listing name
+-   `{{ offering.name }}` - Model/service name
+-   `{{ provider.name }}` - Provider name
+-   `{{ provider.display_name }}` - Provider name
+-   `{{ seller.name }}` - Seller name
+-   `{{ seller.display_name }}` - Seller name
+
+**File renamed:** `test.py` → `test.py.j2`
+
+### Step 4: Add to Listing Documentation
+
+Reference the code example in your `listing.json` file at the listing level (not inside interfaces). The listing automatically belongs to the offering in the same directory.
+
+**Example: `listing.json`**
+
+```json
+{
+    "schema": "listing_v1",
+    "name": "listing-default",
+    "user_access_interfaces": [
+        {
+            "interface_type": "openai_chat_completions",
+            "base_url": "https://api.example.com/v1"
+        }
+    ],
+    "documents": [
+        {
+            "category": "code_examples",
+            "title": "Python code example",
+            "file_path": "../../docs/test.py.j2",
+            "mime_type": "python",
+            "is_public": true,
+            "meta": {
+                "requirements": ["httpx"],
+                "expect": "✓ Test passed"
+            }
+        }
+    ]
+}
+```
+
+**Important fields:**
+
+-   `category`: Must be `"code_examples"` for test framework to find it
+-   `title`: Descriptive name for the example
+-   `file_path`: Relative path from listing file to your `.j2` template
+-   `mime_type`: File type (`python`, `javascript`, `shell`, etc.)
+-   `is_public`: Should be `true` for code examples
+-   `meta`: **[Optional]** Metadata object containing:
+    -   `requirements`: _(User-maintained)_ List of package dependencies needed to run the code example
+        -   For Python: PyPI packages (e.g., `["httpx", "openai"]`)
+        -   For JavaScript: npm packages (e.g., `["node-fetch"]`)
+        -   For Shell scripts: commands (e.g., `["curl"]`)
+        -   Helps users understand what to install before running the example
+    -   `expect`: _(User-maintained, strongly recommended)_ Expected substring that should appear in stdout when the test passes
+        -   Examples:
+            -   `"✓ Test passed"` - Explicit success message
+            -   `"\"choices\""` - Check for JSON field in API response
+            -   `"Status: 200"` - Check for HTTP status
+        -   Without this field, tests only check exit code (0 = pass, non-zero = fail), which is unreliable
+    -   `output`: _(System-maintained)_ Automatically populated by `usvc_seller test run`
+        -   Contains stdout from the last successful test execution
+        -   Saved to `{listing_stem}_{code_filename}.out` file during test run
+        -   Embedded into `meta.output` during `usvc_seller data upload`
+        -   Displayed alongside code examples in your service listing
+
+### Step 5: Validate and Test Before Uploading
+
+Run the validation and testing commands to ensure everything works correctly.
+
+**Step 5.1: Validate schema and templates**
+
+```bash
+# Validate all files including Jinja2 syntax
+usvc_seller data validate
+
+# Expected output:
+# ✓ All files validated successfully
+```
+
+**Step 5.2: List code examples**
+
+```bash
+# Verify your code example is detected
+usvc_seller test list
+
+# Should show:
+# Service: llama-3-1-405b-instruct
+# Provider: fireworks
+# Title: Python code example
+# Type: .py
+# File Path: fireworks/docs/test.py.j2
+```
+
+pass option `--services` to limit to particular services.
+
+**Step 5.3: Run tests**
+
+```bash
+# Test your specific provider
+usvc_seller test run --provider fireworks
+
+# Or test specific services
+usvc_seller test run --services "llama*"
+
+# Expected output:
+# Testing: llama-3-1-405b-instruct - Python code example
+#   ✓ Success (exit code: 0)
+```
+
+**Step 5.4: Fix any failures**
+
+If tests fail, the rendered content is saved to the current directory for debugging:
+
+```bash
+# If test fails, you'll see:
+#   ✗ Failed - Output validation failed: expected substring '✓ Test passed' not found
+#   → Test content saved to: failed_llama-3-1-405b_Python_code_example.py
+#   (includes environment variables for reproduction)
+
+# Debug the saved file:
+cat failed_llama-3-1-405b_Python_code_example.py
+
+# The file will contain:
+# - Environment variables used (UNITYSVC_API_KEY, SERVICE_BASE_URL)
+# - Full rendered template content
+# - You can run it directly to reproduce the issue
+```
+
+**Step 5.5: Upload when ready**
+
+```bash
+# Only upload after all tests pass
+usvc_seller data upload
+```
+
+## Common Patterns
+
+### Pattern 1: Simple shell script with expect
+
+**File: `test.sh.j2`**
+
+```bash
+#!/bin/bash
+# Simple test that outputs JSON response
+
+curl ${SERVICE_BASE_URL}/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer ${UNITYSVC_API_KEY}" \
+  -d '{"model": "{{ offering.name }}", "messages": [{"role": "user", "content": "test"}]}'
+```
+
+**In `listing.json`:**
+
+```json
+{
+    "category": "code_examples",
+    "title": "Shell Example",
+    "file_path": "test.sh.j2",
+    "mime_type": "bash",
+    "is_public": true,
+    "meta": {
+        "expect": "\"choices\""
+    }
+}
+```
+
+### Pattern 2: Python with validation
+
+**File: `test.py.j2`**
+
+```python
+#!/usr/bin/env python3
+import httpx
+import os
+
+response = httpx.post(
+    f"{os.environ['SERVICE_BASE_URL']}/chat/completions",
+    headers={"Authorization": f"Bearer {os.environ['UNITYSVC_API_KEY']}"},
+    json={"model": "{{ offering.name }}", "messages": [{"role": "user", "content": "test"}]}
+)
+
+data = response.json()
+
+# Print response and validation message
+print(data)
+if "choices" in data:
+    print("✓ Validation passed")  # Will be checked by expect
+```
+
+**In `listing.json`:**
+
+```json
+{
+    "category": "code_examples",
+    "title": "Python Example",
+    "file_path": "test.py.j2",
+    "mime_type": "python",
+    "is_public": true,
+    "meta": {
+        "requirements": ["httpx"],
+        "expect": "✓ Validation passed"
+    }
+}
+```
+
+### Pattern 3: JavaScript/Node.js
+
+**File: `test.js.j2`**
+
+```javascript
+#!/usr/bin/env node
+const response = await fetch(`${process.env.SERVICE_BASE_URL}/chat/completions`, {
+    method: "POST",
+    headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${process.env.UNITYSVC_API_KEY}`,
+    },
+    body: JSON.stringify({
+        model: "{{ offering.name }}",
+        messages: [{ role: "user", content: "test" }],
+    }),
+});
+
+const data = await response.json();
+
+console.log(data);
+if (data.choices) {
+    console.log("✓ Success"); // Will be checked by expect
+}
+```
+
+**In `listing.json`:**
+
+```json
+{
+    "category": "code_examples",
+    "title": "JavaScript Example",
+    "file_path": "test.js.j2",
+    "mime_type": "javascript",
+    "is_public": true,
+    "meta": {
+        "expect": "✓ Success"
+    }
+}
+```
+
+### Pattern 4: Connectivity Test (Internal)
+
+Connectivity tests verify API connectivity and gather performance metrics. They run during testing but are **not visible to users**.
+
+**File: `connectivity-test.py.j2`**
+
+```python
+#!/usr/bin/env python3
+"""Connectivity and performance test for {{ offering.name }}"""
+import httpx
+import os
+import time
+
+UNITYSVC_API_KEY = os.environ.get("UNITYSVC_API_KEY")
+SERVICE_BASE_URL = os.environ.get("SERVICE_BASE_URL")
+
+# Measure response time
+start = time.time()
+response = httpx.post(
+    f"{SERVICE_BASE_URL}/chat/completions",
+    headers={"Authorization": f"Bearer {UNITYSVC_API_KEY}"},
+    json={
+        "model": "{{ offering.name }}",
+        "messages": [{"role": "user", "content": "ping"}],
+        "max_tokens": 5
+    },
+    timeout=30.0
+)
+elapsed = time.time() - start
+
+# Output metrics
+print(f"Status: {response.status_code}")
+print(f"Response Time: {elapsed:.3f}s")
+
+if response.status_code == 200:
+    data = response.json()
+    if "choices" in data:
+        print("✓ Connectivity OK")
+```
+
+**In `listing.json`:**
+
+```json
+{
+    "category": "connectivity_test",
+    "title": "API Connectivity Test",
+    "file_path": "connectivity-test.py.j2",
+    "mime_type": "python",
+    "is_public": false,
+    "meta": {
+        "requirements": ["httpx"],
+        "expect": "✓ Connectivity OK"
+    }
+}
+```
+
+**Key differences from code_examples:**
+
+-   `category`: `"connectivity_test"` instead of `"code_examples"`
+-   `is_public`: `false` - not shown to users in documentation
+-   Purpose: Internal testing and monitoring, not user education
+
+## Template Variables Reference
+
+Templates have access to four data structures:
+
+### listing
+
+The listing data structure (Listing_v1 schema)
+
+-   `listing.name` - Listing identifier
+-   `listing.display_name` - Customer-facing name
+-   `listing.status` - Listing status (draft, ready, deprecated)
+-   All other fields from the listing schema
+
+### offering
+
+Service offering data (Offering_v1 schema)
+
+-   `offering.name` - Service/model name (use this for service name)
+-   `offering.display_name` - Human-readable service name
+-   `offering.service_type` - Service type (llm, embedding, etc.)
+-   All other fields from the offering schema
+
+### provider
+
+Provider metadata (Provider_v1 schema)
+
+-   `provider.name` - Provider name (use this for provider name)
+-   `provider.display_name` - Human-readable provider name
+-   All other fields from the provider schema
+
+Note: For API credentials (`UNITYSVC_API_KEY`, `SERVICE_BASE_URL`), use environment variables instead of template variables. These are set automatically during testing (`SERVICE_BASE_URL` from the access interface, `UNITYSVC_API_KEY` from the user's environment).
+
+### seller
+
+Seller metadata (Seller_v1 schema) - seller is derived from API key during publishing
+
+-   `seller.name` - Seller name
+-   `seller.display_name` - Human-readable seller name
+-   `seller.contact_email` - Contact email
+-   All other fields from the seller schema
+
+**Using defaults:**
+
+If a field might not exist, use Jinja2 defaults:
+
+```jinja2
+{{ listing.optional_field | default('N/A') }}
+{{ offering.description | default('No description available') }}
+```
+
+## Tips for Effective Code Examples
+
+1. **Keep examples short and focused** - Test one thing at a time
+2. **Use `meta.expect` field** - Makes validation automatic and reliable
+3. **Print clear success messages** - Makes debugging easier
+4. **Handle errors gracefully** - Exit with non-zero code on failure
+5. **Test locally first** - Always verify with hardcoded values before templating
+6. **Use meaningful output** - Print enough info to understand what happened
+7. **Add requirements** - List all dependencies in `meta.requirements` field
+
+## Workflow Summary
+
+```bash
+# 1. Develop script with hardcoded values
+vim test.py
+python3 test.py
+
+# 2. Use environment variables (SERVICE_BASE_URL is auto-set by test framework)
+export UNITYSVC_API_KEY="..."
+export SERVICE_BASE_URL="..."  # Only needed for manual local testing
+python3 test.py
+
+# 3. Convert to template
+mv test.py test.py.j2
+vim test.py.j2  # Replace with {{ offering.name }}, etc.
+
+# 4. Add to listing.json with meta fields
+vim listing.json  # Add document entry with meta.requirements and meta.expect
+
+# 5. Validate and test
+usvc_seller data validate
+usvc_seller data list-tests
+usvc_seller data run-tests --provider your-provider
+# ✓ Successful tests create .out and .err files (e.g., servicename_listing_test.py.out)
+# ✓ Subsequent runs skip tests with existing results (use --force to rerun)
+# ✓ Use --fail-fast to stop on first failure for quick feedback
+
+# 6. Debug if needed
+cat failed_*  # Check saved test files (in current directory)
+cat services/*/listing_*.out  # Review successful test outputs (in listing directories)
+
+# 7. Upload - embeds .out files into meta.output
+usvc_seller data upload
+# ✓ Reads .out files from listing directories and adds content to meta.output
+# ✓ Output will appear alongside code examples in your service listing
+```
+
+## Understanding meta.output Workflow
+
+The `meta.output` field follows an automated workflow from test execution to publication:
+
+### 1. Testing Phase: `usvc_seller test run`
+
+When you run tests, successful executions generate `.out` files:
+
+```bash
+$ usvc_seller test run --provider fireworks
+
+Testing: llama-3-1-405b - Python code example
+  ✓ Success (exit code: 0)
+  → Output saved to: /path/to/fireworks/services/llama-3-1-405b/listing_test.py.out
+```
+
+**Output file naming:** `{listing_stem}_{code_filename}.out`
+
+-   `listing_stem`: The listing filename without extension (e.g., "listing" from "listing.json")
+-   `code_filename`: The code filename after template expansion (e.g., "test.py" from "test.py.j2")
+-   Example: `listing_test.py.out`, `svclisting_example.sh.out`
+
+**File location:** Same directory as the listing file that references the code example
+
+### 2. Upload Phase: `usvc_seller data upload`
+
+During upload, the SDK automatically:
+
+1. Expands `.j2` templates for each model if a template is used
+2. Looks for matching `.out` files in the listing's base directory
+3. Reads the output content and embeds it into `meta.output`
+
+**Example published document:**
+
+```json
+{
+    "category": "code_examples",
+    "title": "Python code example",
+    "file_path": "chat-completion.py",
+    "file_content": "#!/usr/bin/env python3\nimport httpx...",
+    "mime_type": "python",
+    "meta": {
+        "requirements": ["httpx"],
+        "expect": "✓ Test passed",
+        "output": "{'id': 'chatcmpl-...', 'choices': [{'message': {'content': 'Hello!'}}]}\n✓ Test passed"
+    }
+}
+```
+
+### 3. Display in Service Listing
+
+After uploading, the output will automatically appear alongside the code example in your service listing documentation, allowing users to see both the code and its expected output together.
+
+### 4. Key Points
+
+-   **`.out` files are model-specific**: Since templates expand per model, each model gets its own output file
+-   **`.out` files location**: Saved in the **same directory as the listing file**, making them easy to find and version control
+-   **`.out` file naming**: Format is `{listing_stem}_{code_filename}.out` to clearly associate output with both listing and code
+-   **Version control**: You **can** commit `.out` files to version control since they're co-located with listings
+-   **Upload is flexible**: `usvc_seller data upload` works even if `.out` files are missing (gracefully skips)
+-   **User vs System fields**:
+    -   `meta.requirements` and `meta.expect` are **user-maintained** (you write these)
+    -   `meta.output` is **system-maintained** (auto-generated by `usvc_seller data run-tests` and `usvc_seller data upload`)
+
+## Interpreter Detection
+
+The test framework automatically detects the appropriate interpreter based on file extension:
+
+-   **`.py` files**: Uses `python3` (falls back to `python` if python3 not available)
+-   **`.js` files**: Uses `node` (Node.js required)
+-   **`.sh` files**: Uses `bash`
+-   **Other files**: Checks shebang line (e.g., `#!/usr/bin/env python3`)
+
+If the required interpreter is not found, the test will fail with a clear error message.
+
+## Troubleshooting
+
+### Template Rendering Errors
+
+**Problem:** `Jinja2 syntax error: unexpected 'end of template'`
+
+**Solution:** Check for unclosed tags (`{{`, `{%`, `{#`)
+
+**Problem:** `undefined variable: listing.field_name`
+
+**Solution:** Verify field exists in Listing_v1 schema or use default filter:
+
+```jinja2
+{{ listing.field_name | default('fallback') }}
+```
+
+### Test Execution Errors
+
+**Problem:** Test fails with "interpreter not found"
+
+**Solution:** Install the required interpreter:
+
+-   Python: `brew install python3` or `apt-get install python3`
+-   Node.js: `brew install node` or download from nodejs.org
+-   Bash: Usually pre-installed on Unix systems
+
+**Problem:** Test passes locally but fails in test framework
+
+**Solution:**
+
+-   Check that you're using environment variables (UNITYSVC_API_KEY, SERVICE_BASE_URL)
+-   Verify template variables are correct
+-   Run `usvc_seller test run --verbose` to see full output
+
+**Problem:** Exit code is 0 but test still fails
+
+**Solution:** Check the `meta.expect` field - test requires the expected string to appear in stdout
+
+### Validation Errors
+
+**Problem:** `usvc_seller data validate` reports Jinja2 syntax errors
+
+**Solution:**
+
+-   Validate template syntax in isolation
+-   Common issues: missing `}`, incorrect variable names
+-   Use a Jinja2 linter or IDE plugin
+
+**Problem:** Code example not found by `usvc_seller data list-tests`
+
+**Solution:**
+
+-   Verify `category` is set to `"code_examples"` in document object
+-   Check that `file_path` is correct relative to listing file
+-   Run `usvc_seller data validate` to check for schema errors

--- a/docs/data-structure.md
+++ b/docs/data-structure.md
@@ -1,0 +1,589 @@
+# Data Directory Structure
+
+## Overview
+
+UnitySVC provides two ways to manage service data:
+
+1. **Web Interface** ([unitysvc.com](https://unitysvc.com)) - Create and edit data visually, then export for SDK use
+2. **SDK** (this tool) - Manage data locally with version control, automation, and CI/CD integration
+
+The SDK follows a **local-first, version-controlled workflow**. All service data is maintained in a local directory (typically called `data/`) that is version-controlled with git. Data can be created via the web interface and exported, or created manually following the schemas.
+
+## The Service Data Model
+
+A **Service** in UnitySVC is an identity layer that connects a seller to three complementary data components. These are organized separately in the filesystem for reusability, but are **uploaded together** as a unified service:
+
+```mermaid
+flowchart TB
+    subgraph Service["Service (Identity Layer)"]
+        direction TB
+        S["<b>Service</b><br/>name, display_name, status<br/><i>derived from components</i>"]
+    end
+
+    subgraph Content["Content Entities (Uploaded Together)"]
+        P["<b>Provider Data</b><br/>WHO provides<br/><i>provider_v1</i>"]
+        O["<b>Offering Data</b><br/>WHAT is provided<br/><i>offering_v1</i>"]
+        L["<b>Listing Data</b><br/>HOW it's sold<br/><i>listing_v1</i>"]
+    end
+
+    S --> P & O & L
+    P --> O --> L
+
+    style S fill:#f3e5f5
+    style P fill:#e3f2fd
+    style O fill:#fff3e0
+    style L fill:#e8f5e9
+```
+
+### Service Identity
+
+When you upload provider, offering, and listing data together, the platform creates a **Service** record that:
+
+-   **Links** the seller to the content (provider, offering, listing)
+-   **Derives its name** from `listing.name`, or `offering.name` if listing name is unspecified
+-   **Derives its display_name** from `listing.display_name`, `offering.display_name`, `listing.name`, or `offering.name` (first non-empty value)
+-   **Derives its status** from the component statuses:
+    - If any component is `draft` → Service is `draft` (upload skipped)
+    - If any component is `deprecated` (none draft) → Service is `deprecated`
+    - If all components are `ready` → Service is `draft` initially, then progresses through review workflow
+
+The Service provides a stable identity that subscriptions reference, while the content entities (Provider, Offering, Listing) are immutable and content-addressed.
+
+### Component Details
+
+| Component | Schema | Location | Purpose |
+|-----------|--------|----------|---------|
+| **Provider Data** | `provider_v1` | `{provider}/provider.json` | Identity of the service provider |
+| **Offering Data** | `offering_v1` | `{provider}/services/{service}/offering.json` | Technical service definition |
+| **Listing Data** | `listing_v1` | `{provider}/services/{service}/listing-*.json` | Customer-facing presentation |
+
+### Why Three Parts?
+
+1. **Provider Data** - Defined once per provider, automatically shared across all their offerings
+2. **Offering Data** - Defined once per service, can have multiple listings (pricing tiers, marketplaces)
+3. **Listing Data** - Defines how each service variant is presented and priced for customers
+
+This separation enables:
+- **Reusability**: Update provider info once, affects all services
+- **Flexibility**: One offering can have basic/premium/enterprise listings
+- **Maintainability**: Clear separation of concerns
+- **Immutability**: Content entities are content-addressed; same content = same ID
+
+### Upload Model
+
+When you run `usvc_seller data upload`, the SDK uses a **listing-centric** approach:
+
+1. Finds all listing files (`listing_v1` schema) in the directory tree
+2. For each listing, locates the **single** offering file (`offering_v1`) in the same directory
+3. Locates the provider file (`provider_v1`) in the parent directory
+4. Uploads all three together as a unified service to `/seller/services`
+
+**Relationship by Location**: The relationship between providers, offerings, and listings is determined entirely by file location:
+- A listing belongs to the offering in the same directory
+- An offering belongs to the provider in the parent directory
+- No explicit linking fields (like `service_name` or `provider_name`) are needed in the data files
+
+```mermaid
+graph TD
+    A[Listing File] -->|same directory| B[Offering File]
+    A -->|parent directory| C[Provider File]
+    A -->|uploaded together| D[Backend API]
+    B -->|uploaded together| D
+    C -->|uploaded together| D
+```
+
+### Service Upload Lifecycle
+
+Understanding how services are created and updated is essential for managing your service catalog:
+
+#### First Upload: New Service Creation
+
+When you upload a listing file for the first time (from a new repository or data directory), **a new Service is always created**, even if the content is identical to an existing service. This is because:
+
+- Each listing file represents a distinct service identity
+- The Service ID is the stable identifier that subscriptions reference
+- Content entities (provider, offering, listing) are content-addressed and may be shared, but the Service itself is unique
+
+```mermaid
+flowchart LR
+    subgraph First["First Upload"]
+        L1["listing.json<br/><i>no service_id</i>"] --> API1[Backend API]
+        API1 --> S1["Creates NEW Service<br/><i>service_id: abc-123</i>"]
+        S1 --> O1["listing.override.json<br/><i>service_id saved</i>"]
+    end
+
+    style L1 fill:#fff3e0
+    style S1 fill:#e8f5e9
+    style O1 fill:#e3f2fd
+```
+
+#### Service ID Persistence
+
+After a successful first upload, the SDK automatically saves the `service_id` to an override file:
+
+```
+listing.json       →  listing.override.json
+listing.toml       →  listing.override.toml
+listing-premium.json → listing-premium.override.json
+```
+
+Example override file content:
+```json
+{
+  "service_id": "550e8400-e29b-41d4-a716-446655440000",
+  "name": "gpt-4-enterprise"
+}
+```
+
+The `service_id` is used to update the correct service on subsequent uploads. The `name` is the backend-resolved service name (`listing.name` if set, otherwise `offering.name`), saved here so sellers have an unambiguous reference — for example, when targeting services in promotion files.
+
+This override file should be:
+- **Committed to version control** - links the local service definition to a specific service on the UnitySVC platform, ensuring consistent identity across team members and CI/CD
+- **Never manually edited** (except when intentionally uploading as new)
+- **Environment-specific** if deploying to multiple environments (staging, production)
+
+You can verify that all services have been linked using:
+```bash
+usvc_seller data validate --has-service-id
+```
+
+#### Subsequent Uploads: Service Updates
+
+On subsequent uploads, the SDK automatically loads the `service_id` from the override file and includes it in the upload request. The behavior depends on the current status of the service on the platform:
+
+**If the service is in draft, pending, or rejected status**, the existing service is updated in place:
+
+```mermaid
+flowchart LR
+    subgraph Update["Update Draft/Pending Service"]
+        O2["listing.override.json<br/><i>service_id: abc-123</i>"] --> L2["listing.json"]
+        L2 --> API2[Backend API]
+        API2 --> S2["Updates EXISTING Service<br/><i>service_id: abc-123</i>"]
+    end
+
+    style O2 fill:#e3f2fd
+    style L2 fill:#fff3e0
+    style S2 fill:#e8f5e9
+```
+
+**If the service is already active**, the upload creates (or updates) a **revision** instead of modifying the active service directly. This ensures the live service remains stable while changes are reviewed:
+
+```mermaid
+flowchart LR
+    subgraph Revision["Upload to Active Service"]
+        O3["listing.override.json<br/><i>service_id: abc-123</i>"] --> L3["listing.json"]
+        L3 --> API3[Backend API]
+        API3 --> S3["Active Service<br/><i>abc-123 (unchanged)</i>"]
+        API3 --> R3["Revision (draft)<br/><i>rev-456</i>"]
+        R3 -.->|"on activation"| S3
+    end
+
+    style O3 fill:#e3f2fd
+    style L3 fill:#fff3e0
+    style S3 fill:#e8f5e9
+    style R3 fill:#fff9c4
+```
+
+When a revision is activated, it replaces the content of the active service but preserves the service ID. The local `service_id` in the override file continues to point to the active service throughout this process — subsequent uploads will update the same revision until it is activated.
+
+When updating:
+- The Service ID remains stable (enrollments and subscriptions continue to work)
+- Content entities are updated or created as needed
+- If content is unchanged, the upload returns "unchanged" status
+
+#### Uploading as New (Ignoring Existing Service)
+
+To upload a service as completely new (ignoring any existing `service_id`), delete the override file before uploading:
+
+```bash
+# Remove override file to upload as new service
+rm listing.override.json
+
+# Upload - will create a NEW service with a new service_id
+usvc_seller data upload --data-path ./my-provider/services/my-service/listing.json
+```
+
+Common use cases for uploading as new:
+- The service was accidentally deleted from the backend
+- Deploying to a different environment (staging vs production)
+- Creating a variant/copy of an existing service
+
+#### Multiple Environments
+
+The SDK only supports a single override file per base file (`<stem>.override.<suffix>`). For deploying to multiple environments, use one of these approaches:
+
+**Option 1: Separate branches**
+```
+main branch:     listing.override.json  # Production service_id
+staging branch:  listing.override.json  # Staging service_id
+```
+
+**Option 2: Separate data directories**
+```
+data-prod/my-provider/services/my-service/listing.override.json
+data-staging/my-provider/services/my-service/listing.override.json
+```
+
+## Required File Structure
+
+The data directory must follow a specific structure with naming conventions and file placement rules:
+
+```
+data/
+├── ${provider_name}/                    # Provider directory (matches provider name)
+│   ├── provider.json or provider.toml   # Required: Provider Data
+│   ├── README.md                        # Optional: Provider documentation
+│   ├── terms-of-service.md             # Optional: Provider ToS
+│   ├── docs/                            # Optional: Shared documentation folder
+│   │   ├── code-example.py             # Can be referenced by multiple services
+│   │   └── api-guide.md                # Shared across services
+│   └── services/                        # Required: Services directory
+│       ├── ${service_name}/             # Service directory (matches service name)
+│       │   ├── offering.json or offering.toml     # Required: Offering Data
+│       │   ├── listing-${variant}.json or .toml  # Required: Listing Data
+│       │   └── specific-example.md      # Optional: Service-specific docs
+│       └── ${another_service}/
+│           ├── offering.json
+│           └── listing-premium.json     # Can reference ../../docs/code-example.py
+├── ${another_provider}/
+│   ├── provider.toml
+│   └── services/
+│       └── ...
+└── promotions/                          # Optional: Seller promotions
+    ├── summer-discount.json             # promotion_v1 schema
+    └── volume-tier.json
+```
+
+**Note:** The `promotions/` directory can live at the top level of the data directory (alongside provider directories). Promotion files use the `promotion_v1` schema and are managed via `usvc_seller promotions` commands. See [CLI Reference](cli-reference.md#usvc_seller-promotions-promotion-management) for details.
+
+## Naming Rules and Restrictions
+
+The SDK discovers files by their `schema` field, not by filename. However, some naming conventions are enforced for consistency.
+
+### What's Actually Required
+
+1. **Schema field**: Every data file must have a `schema` field (`provider_v1`, `offering_v1`, or `listing_v1`)
+2. **Services directory**: The path must contain a `services/` directory for the SDK to resolve provider relationships
+3. **One offering per directory**: Each service directory should have exactly one `offering_v1` file
+4. **Provider name consistency**: For `provider_v1` files, the parent directory name must match the `name` field
+
+### What's Convention (Recommended but Not Enforced)
+
+1. **Filenames**: Any filename works as long as the `schema` field is correct
+2. **Service directory name**: Convention is to match the offering `name` field, but the service name is always read from the offering file
+3. **Listing filename pattern**: `listing-*.json` is convention; any filename with `schema: "listing_v1"` works
+
+### Recommended Structure
+
+Following conventions makes your data easier to navigate:
+
+| Component | Convention | Example |
+|-----------|-----------|---------|
+| Provider directory | Match `name` field | `openai/` for `name: "openai"` |
+| Services directory | Always `services/` | `openai/services/` |
+| Service directory | Match offering `name` | `gpt-4/` for `name: "gpt-4"` |
+| Provider file | `provider.json` or `provider.toml` | `openai/provider.json` |
+| Offering file | `offering.json` or `offering.toml` | `openai/services/gpt-4/offering.json` |
+| Listing files | `listing-{variant}.json` | `listing-premium.json`, `listing-basic.json` |
+
+### Multiple Listings Per Service
+
+When a single offering has multiple listings (different pricing tiers, marketplaces):
+
+-   **Filename as identifier**: If the `name` field is omitted, the filename (without extension) becomes the listing name
+-   **Example**: `listing-premium.json` → `name: "listing-premium"`
+-   **Best practice**: Use descriptive filenames or explicitly set the `name` field
+
+### External Files
+
+-   Documentation, code examples, and images can be placed anywhere
+-   Referenced by **relative paths** from the referencing file
+-   This allows sharing files across multiple services
+
+## File Formats
+
+Both JSON and TOML formats are supported for all data files.
+
+### JSON Format (with JSON5 support)
+
+JSON files are read using JSON5, which allows:
+- Comments (`//` and `/* */`)
+- Trailing commas
+- Unquoted keys
+- Single-quoted strings
+
+```json
+{
+    // This is a comment
+    "schema": "offering_v1",
+    "name": "my-service",
+    "display_name": "My Service",
+    "description": "A high-performance digital service",  // trailing comma OK
+}
+```
+
+**Note:** `usvc_seller data format` outputs standard JSON (no comments), so formatting will strip comments.
+
+### TOML Format
+
+```toml
+# TOML natively supports comments
+schema = "offering_v1"
+name = "my-service"
+display_name = "My Service"
+description = "A high-performance digital service"
+```
+
+## Override Files
+
+Override files provide a way to complement and customize data files without modifying the base files. This is particularly useful when base files are auto-generated by scripts, and you need to manually curate specific values like status, logo URLs, or other metadata.
+
+### Naming Pattern
+
+Override files follow the pattern: `<base_name>.override.<extension>`
+
+Examples:
+
+-   `offering.json` → `service.override.json`
+-   `provider.toml` → `provider.override.toml`
+-   `listing-premium.json` → `listing-premium.override.json`
+
+### How Override Files Work
+
+When any data file is loaded by the SDK:
+
+1. The base file is loaded first
+2. The system checks for a corresponding `.override.*` file
+3. If found, the override file is loaded and **deep-merged** into the base data
+4. Override values take precedence over base values
+
+This merge happens automatically and transparently - you don't need to do anything special.
+
+### Merge Behavior
+
+**Nested Dictionaries**: Recursively merged - override values complement and replace base values
+
+**Example**:
+
+```json
+// Base: offering.json
+{
+  "name": "my-service",
+  "config": {
+    "host": "localhost",
+    "port": 8080,
+    "timeout": 30
+  }
+}
+
+// Override: service.override.json
+{
+  "config": {
+    "port": 9000,
+    "ssl": true
+  },
+  "status": "active"
+}
+
+// Merged Result
+{
+  "name": "my-service",
+  "config": {
+    "host": "localhost",    // preserved from base
+    "port": 9000,           // overridden
+    "timeout": 30,          // preserved from base
+    "ssl": true             // added from override
+  },
+  "status": "active"        // added from override
+}
+```
+
+**Lists and Primitives**: Completely replaced (not merged)
+
+```json
+// Base: offering.json
+{
+  "tags": ["python", "web", "api"],
+  "version": 1
+}
+
+// Override: service.override.json
+{
+  "tags": ["backend", "production"]
+}
+
+// Merged Result
+{
+  "tags": ["backend", "production"],  // completely replaced
+  "version": 1
+}
+```
+
+This replacement behavior for lists is intentional and predictable - if you want to change a list, simply specify the complete desired list in the override file.
+
+### Common Use Cases
+
+**1. Manual curation of auto-generated data**
+
+```json
+// offering.json (auto-generated by script)
+{
+  "schema": "offering_v1",
+  "name": "gpt-4",
+  "description": "Auto-generated description",
+  "status": "draft"
+}
+
+// service.override.json (manually maintained)
+{
+  "status": "active",
+  "logo_url": "https://example.com/custom-logo.png",
+  "featured": true
+}
+```
+
+**2. Environment-specific configuration**
+
+```toml
+# provider.toml (base configuration)
+schema = "provider_v1"
+name = "my-provider"
+base_url = "https://api.example.com"
+
+# provider.override.toml (local testing overrides)
+base_url = "http://localhost:8000"
+debug_mode = true
+```
+
+**3. Maintaining custom metadata**
+
+```json
+// listing-premium.json (generated from template)
+{
+  "schema": "listing_v1",
+  "name": "premium-tier",
+  "pricing": { /* auto-generated */ }
+}
+
+// listing-premium.override.json (manual customization)
+{
+  "featured": true,
+  "promotional_badge": "Best Value",
+  "custom_cta": "Try Premium Now!"
+}
+```
+
+### Version Control
+
+Override files should be committed to version control alongside base files. They are part of your data and represent intentional manual customizations that should be preserved and tracked.
+
+### File Location
+
+Override files must be in the same directory as their corresponding base files, following the directory structure rules described above.
+
+## Schema Requirements
+
+Each file must include a `schema` field identifying its type:
+
+-   **provider.json/toml**: `schema = "provider_v1"`
+-   **offering.json/toml**: `schema = "offering_v1"`
+-   **listing-\*.json/toml**: `schema = "listing_v1"`
+
+## Validation Rules
+
+The validator enforces these rules:
+
+1. **Schema field required**: All data files must have a `schema` field
+2. **Single offering per directory**: Each service directory should have exactly one `offering_v1` file
+3. **Listing location**: Listings must be in the same directory as an `offering_v1` file
+4. **Provider name matching**: `provider_v1` files must have directory name matching the normalized `name` field
+5. **Relationship by location**: Listings belong to the offering in their directory—no explicit linking fields needed
+
+## Shared Documentation Pattern
+
+External files can be shared across multiple services using relative paths:
+
+### Example Structure
+
+```
+data/
+├── openai/
+│   ├── provider.toml
+│   ├── docs/
+│   │   ├── code-example.py        # Shared by multiple services
+│   │   └── api-guide.md
+│   └── services/
+│       ├── gpt-4/
+│       │   ├── offering.json
+│       │   └── listing.json       # References: ../../docs/code-example.py
+│       └── gpt-3.5-turbo/
+│           ├── offering.json
+│           └── listing.json       # References: ../../docs/code-example.py (same file!)
+```
+
+### In Listing Files
+
+```json
+{
+    "schema": "listing_v1",
+    "user_access_interfaces": {
+        "OpenAI API": {
+            "access_method": "http",
+            "base_url": "${API_GATEWAY_BASE_URL}/p/openai"
+        }
+    },
+    "documents": {
+        "Python Code Example": {
+            "file_path": "../../docs/code-example.py",
+            "category": "code_example",
+            "mime_type": "python"
+        }
+    }
+}
+```
+
+**Note:** Both `documents` and `user_access_interfaces` use dict format where the key is the title/name. This enables easy merging via override files.
+
+### Benefits
+
+-   **Reusability**: One code example can be shared by multiple services
+-   **Maintainability**: Update one file, all services reflect the change
+-   **Organization**: Group related documentation at provider level
+-   **Flexibility**: Place files wherever makes sense for your structure
+
+## Complete Example
+
+```
+data/
+├── openai/                              # Provider: "openai"
+│   ├── provider.toml                    # Provider Data: name = "openai"
+│   └── services/
+│       ├── gpt-4/                       # Service: "gpt-4"
+│       │   ├── offering.json             # Offering Data: name = "gpt-4"
+│       │   ├── listing-premium.json     # Listing Data (premium tier)
+│       │   └── listing-basic.json       # Listing Data (basic tier)
+│       └── gpt-3.5-turbo/              # Service: "gpt-3.5-turbo"
+│           ├── offering.json             # Offering Data
+│           └── listing-default.json     # Listing Data
+└── anthropic/                           # Provider: "anthropic"
+    ├── provider.json                    # Provider Data: name = "anthropic"
+    └── services/
+        └── claude-3-opus/               # Service: "claude-3-opus"
+            ├── offering.toml            # Offering Data
+            ├── listing-standard.toml    # Listing Data (standard tier)
+            └── docs/
+                └── usage-guide.md
+```
+
+When uploading, each listing triggers a unified upload:
+- `listing-premium.json` → uploads openai provider + gpt-4 offering + premium listing
+- `listing-basic.json` → uploads openai provider + gpt-4 offering + basic listing
+- etc.
+
+The provider and offering data are sent with each upload but are deduplicated on the backend (unchanged data returns "unchanged" status).
+
+## Next Steps
+
+-   [File Schemas](file-schemas.md) - Detailed schema specifications
+-   [CLI Reference](cli-reference.md#usvc_seller-data-upload-upload-services-to-backend) - Upload command details
+-   [Workflows](workflows.md) - Learn about manual and automated workflows

--- a/docs/documenting-services.md
+++ b/docs/documenting-services.md
@@ -1,0 +1,709 @@
+# Documenting Service Listings
+
+This guide explains how to add documentation and files to your service listings in UnitySVC.
+
+## Overview
+
+Documents in UnitySVC can be in any format (`.md`, `.py`, `.js`, `.sh`, etc.) and are referenced in listing files. Files with an additional `.j2` extension are treated as **Jinja2 templates** and expanded dynamically before use.
+
+## Document Types
+
+### Standard Documents
+
+Regular files are used as-is without any processing:
+
+```
+docs/
+├── description.md          # Markdown documentation
+├── getting-started.md      # Tutorial
+├── api-reference.md        # API documentation
+├── faq.md                  # Frequently asked questions
+```
+
+**Characteristics:**
+
+-   Used exactly as stored
+-   No variable substitution
+-   No template processing
+-   Validated only for file existence
+
+**Example use cases:**
+
+-   Static documentation that doesn't change per service
+-   General guides and tutorials
+-   Privacy policies and terms of service
+-   FAQ documents
+
+### Jinja2 Template Documents
+
+Files ending with `.j2` are processed as Jinja2 templates:
+
+```
+docs/
+├── description.md.j2       # Service-specific description template
+├── quickstart.md.j2        # Quickstart guide with dynamic content
+├── example.py.j2           # Python code example template
+├── example.js.j2           # JavaScript code example template
+└── test.sh.j2              # Shell script template
+```
+
+**Characteristics:**
+
+-   Rendered before use with actual data
+-   Support variable substitution
+-   Access to listing, offering, provider, and seller data
+-   Validated for Jinja2 syntax errors
+-   `.j2` extension is stripped after rendering
+
+**Example use cases:**
+
+-   Service-specific descriptions that include model names
+-   Code examples that reference specific endpoints
+-   Documentation that varies by provider or seller
+-   Dynamic content based on listing data
+
+## File Naming Convention
+
+The file extension determines how the document is processed:
+
+| Filename            | Type                | Rendered As | Processing          |
+| ------------------- | ------------------- | ----------- | ------------------- |
+| `description.md`    | Markdown            | `.md`       | Used as-is          |
+| `description.md.j2` | Markdown template   | `.md`       | Jinja2 → Markdown   |
+| `example.py`        | Python script       | `.py`       | Used as-is          |
+| `example.py.j2`     | Python template     | `.py`       | Jinja2 → Python     |
+| `example.js`        | JavaScript          | `.js`       | Used as-is          |
+| `example.js.j2`     | JavaScript template | `.js`       | Jinja2 → JavaScript |
+| `example.sh`        | Shell script        | `.sh`       | Used as-is          |
+| `example.sh.j2`     | Shell template      | `.sh`       | Jinja2 → Shell      |
+| `api-guide.md`      | Markdown            | `.md`       | Used as-is          |
+| `api-guide.md.j2`   | Markdown template   | `.md`       | Jinja2 → Markdown   |
+
+## Adding Documents to Listings
+
+Documents are added to listings through the `documents` field at the listing level.
+
+### Basic Document Structure
+
+Documents are defined in your listing files at the top level. The listing automatically belongs to the offering in the same directory.
+
+**Example: `listing.json`**
+
+```json
+{
+    "schema": "listing_v1",
+    "name": "listing-default",
+    "user_access_interfaces": {
+        "API Interface": {
+            "access_method": "http",
+            "base_url": "https://api.example.com/v1"
+        }
+    },
+    "documents": {
+        "GPT-4 Overview": {
+            "category": "getting_started",
+            "file_path": "../../docs/gpt4-description.md.j2",
+            "mime_type": "markdown",
+            "is_public": true
+        },
+        "Quick Start Guide": {
+            "category": "getting_started",
+            "file_path": "../../docs/quickstart.md",
+            "mime_type": "markdown",
+            "is_public": true
+        }
+    }
+}
+```
+
+**Note:** Both `documents` and `user_access_interfaces` use dict format where the key becomes the title/name. This enables easy merging via override files.
+
+### Document Fields
+
+-   **`category`** (required): Document category type
+
+    -   `description` - Service descriptions
+    -   `getting_started` - Quickstart guides
+    -   `api_reference` - API documentation
+    -   `code_examples` - Executable code examples (see [Creating Code Examples](code-examples.md))
+    -   `faq` - Frequently asked questions
+    -   `pricing` - Pricing information
+    -   `terms_of_service` - Terms of service
+    -   `privacy_policy` - Privacy policy
+    -   `logo` - Company/service logos
+
+-   **Document key** (required): The dict key serves as the document title (5-255 chars)
+
+-   **`file_path`** (required): Relative path from listing file to the document
+
+    -   Path resolution is relative to the listing file location
+    -   Example: `../../docs/description.md.j2` points to provider-level docs
+    -   Example: `quickstart.md` points to service-level doc in same directory
+
+-   **`mime_type`** (required): Document content type
+
+    -   `markdown` - Markdown documents
+    -   `python` - Python scripts
+    -   `javascript` - JavaScript files
+    -   `shell` - Shell scripts
+    -   `json` - JSON documents
+    -   `pdf` - PDF files
+    -   `png`, `jpeg`, `svg` - Image files
+
+-   **`is_public`** (required): Whether document is publicly accessible
+
+    -   `true` - Available to all users
+    -   `false` - Restricted access
+
+-   **`requirements`** (optional): Package dependencies for code examples
+
+    -   For Python: `["httpx", "openai"]`
+    -   For JavaScript: `["node-fetch", "openai"]`
+
+-   **`expect`** (optional): Expected output for code example validation
+    -   Used by test framework (see [Creating Code Examples](code-examples.md))
+    -   Example: `"✓ Test passed"`
+
+## Template Variables
+
+Templates have access to four main data structures:
+
+### 1. `listing` - Listing Data (Listing_v1)
+
+Full access to the listing data structure:
+
+```jinja2
+{{ listing.name }}                      # Listing identifier
+{{ listing.display_name }}              # Customer-facing name
+{{ listing.status }}                    # Listing status (draft, ready, deprecated)
+{{ listing.user_access_interfaces }}    # Array of interfaces
+{{ listing.list_price }}                # Customer-facing pricing
+```
+
+### 2. `offering` - Service Offering Data (Offering_v1)
+
+Service offering metadata from `offering.json`:
+
+```jinja2
+{{ offering.name }}                     # Service/offering name (use this for service name)
+{{ offering.display_name }}             # Human-readable service name
+{{ offering.service_type }}             # e.g., "llm", "embedding"
+{{ offering.description }}              # Service description
+{{ offering.details }}                  # Technical details
+{{ interface.signature.model }}         # model of a LLM request
+```
+
+### 3. `provider` - Provider Data (Provider_v1)
+
+Provider metadata from `provider.toml` or `provider.json`:
+
+```jinja2
+{{ provider.name }}                     # Provider name (use this for provider name)
+{{ provider.display_name }}             # Human-readable provider name
+{{ provider.contact_email }}            # Contact email
+```
+
+Note: For API credentials, use environment variables (`UNITYSVC_API_KEY`, `SERVICE_BASE_URL`) instead of template variables. `SERVICE_BASE_URL` is automatically set to the access interface base URL during testing.
+
+### 4. `seller` - Seller Data (Seller_v1)
+
+Seller metadata from `seller.json` (seller is derived from API key during publishing):
+
+```jinja2
+{{ seller.name }}                       # Seller name
+{{ seller.display_name }}               # Human-readable seller name
+{{ seller.contact_email }}              # Contact email
+```
+
+### Using Defaults
+
+If a field might not exist, use Jinja2 defaults to prevent errors:
+
+```jinja2
+{{ listing.optional_field | default('N/A') }}
+{{ offering.description | default('No description available') }}
+{{ provider.support_url | default('https://example.com/support') }}
+```
+
+## Document Examples
+
+### Static Markdown Document
+
+**File: `description.md`**
+
+```markdown
+# GPT-4 Overview
+
+GPT-4 is a large multimodal model that can solve complex problems with greater accuracy.
+
+## Features
+
+-   Advanced reasoning capabilities
+-   Multimodal input support
+-   Improved factual accuracy
+-   Better instruction following
+
+## Use Cases
+
+-   Content generation
+-   Code assistance
+-   Data analysis
+-   Question answering
+```
+
+**In `listing.json` documents:**
+
+```json
+"Service Overview": {
+    "category": "getting_started",
+    "file_path": "description.md",
+    "mime_type": "markdown",
+    "is_public": true
+}
+```
+
+### Template Markdown Document
+
+**File: `description.md.j2`**
+
+```markdown
+# {{ offering.name }} Overview
+
+{{ offering.name }} is available through {{ provider.name }} on the {{ seller.name }} platform.
+
+## Service Details
+
+-   **Service Name**: {{ offering.name }}
+-   **Provider**: {{ provider.name }}
+-   **Type**: {{ offering.service_type }}
+-   **Listing Type**: {{ listing.listing_type }}
+
+## Getting Started
+
+To use this service, connect to the API endpoint at:
+`{{ interface.base_url }}`
+
+{% if offering.service_info.description %}
+{{ offering.service_info.description }}
+{% endif %}
+
+## Support
+
+For support inquiries, contact {{ seller.contact_email }}.
+```
+
+**In `listing.json` documents:**
+
+```json
+"Service Overview": {
+    "category": "getting_started",
+    "file_path": "description.md.j2",
+    "mime_type": "markdown",
+    "is_public": true
+}
+```
+
+### Quickstart Guide Template
+
+**File: `quickstart.md.j2`**
+
+````markdown
+# Quick Start: {{ offering.name }}
+
+This guide helps you get started with {{ offering.name }} from {{ provider.name }}.
+
+## Prerequisites
+
+-   API key from {{ provider.name }}
+-   HTTP client library (curl, httpx, etc.)
+
+## Basic Usage
+
+### Using curl
+
+\```bash
+curl {{ interface.base_url }}/chat/completions \
+ -H "Content-Type: application/json" \
+ -H "Authorization: Bearer YOUR_API_KEY" \
+ -d '{
+"model": "{{ offering.name }}",
+"messages": [{"role": "user", "content": "Hello!"}]
+}'
+\```
+
+### Using Python
+
+\```python
+import httpx
+
+response = httpx.post(
+"{{ interface.base_url }}/chat/completions",
+headers={"Authorization": "Bearer YOUR_API_KEY"},
+json={
+"model": "{{ offering.name }}",
+"messages": [{"role": "user", "content": "Hello!"}]
+}
+)
+
+print(response.json())
+\```
+
+## Next Steps
+
+-   Check the [API Reference](#) for detailed documentation
+-   Try the [code examples](#) for your preferred language
+-   Review [best practices](#) for production use
+````
+
+**In `listing.json` documents:**
+
+```json
+"Quick Start Guide": {
+    "category": "getting_started",
+    "file_path": "quickstart.md.j2",
+    "mime_type": "markdown",
+    "is_public": true
+}
+```
+
+## Directory Organization
+
+### Provider-Level Documents (Shared)
+
+Documents shared across all services from a provider:
+
+```
+data/
+└── fireworks/
+    ├── provider.toml
+    ├── docs/                       # Shared documents
+    │   ├── auth-guide.md          # Static auth guide
+    │   ├── base-example.py.j2     # Shared template
+    │   └── quickstart.md.j2       # Shared quickstart
+    └── services/
+        ├── llama-3-1-405b/
+        │   ├── offering.json
+        │   └── listing.json       # References ../docs/
+        └── llama-3-1-70b/
+            ├── offering.json
+            └── listing.json       # References ../docs/
+```
+
+**Benefit:** Update one shared document and all services inherit the change.
+
+### Service-Level Documents (Specific)
+
+Documents unique to a specific service:
+
+```
+data/
+└── fireworks/
+    └── services/
+        └── llama-3-1-405b/
+            ├── offering.json
+            ├── listing.json
+            ├── description.md.j2      # Service-specific description
+            └── examples/
+                ├── basic.py.j2
+                └── advanced.py.j2
+```
+
+**Benefit:** Customize documentation per service when needed.
+
+### Mixed Approach (Recommended)
+
+Combine shared and specific documents:
+
+```
+data/
+└── fireworks/
+    ├── provider.toml
+    ├── docs/                          # Shared templates
+    │   ├── auth-guide.md
+    │   ├── base-example.py.j2
+    │   └── quickstart.md.j2
+    └── services/
+        └── llama-3-1-405b/
+            ├── offering.json
+            ├── listing.json           # References both
+            ├── model-specific.md      # Service-specific doc
+            └── examples/
+                └── use-case.py.j2
+```
+
+## Document Categories Reference
+
+### description
+
+Service overview and feature descriptions. Typically shown first to users.
+
+**Example (in documents dict):**
+
+```json
+"Service Overview": {
+    "category": "getting_started",
+    "file_path": "description.md.j2",
+    "mime_type": "markdown",
+    "is_public": true
+}
+```
+
+### getting_started
+
+Quickstart guides and initial setup instructions.
+
+**Example:**
+
+```json
+"Quick Start Guide": {
+    "category": "getting_started",
+    "file_path": "quickstart.md",
+    "mime_type": "markdown",
+    "is_public": true
+}
+```
+
+### api_reference
+
+Detailed API documentation, endpoint references, and parameter descriptions.
+
+**Example:**
+
+```json
+"API Reference": {
+    "category": "api_reference",
+    "file_path": "api-docs.md",
+    "mime_type": "markdown",
+    "is_public": true
+}
+```
+
+### code_example
+
+Executable code examples in various languages. See [Creating Code Examples](code-examples.md) for detailed guide.
+
+**Example:**
+
+```json
+"Python Example": {
+    "category": "code_example",
+    "file_path": "example.py.j2",
+    "mime_type": "python",
+    "is_public": true,
+    "meta": {
+        "requirements": ["httpx"],
+        "expect": "✓ Test passed"
+    }
+}
+```
+
+### request_template
+
+Default request body for the Test Request playground. When a customer opens the playground on the service details page, this JSON is pre-filled in the body editor, giving them a working starting point.
+
+**Example (LLM service):**
+
+```json
+"Default Request": {
+    "category": "request_template",
+    "file_path": "default-request.json",
+    "mime_type": "json",
+    "is_public": true,
+    "description": "Default chat completion request"
+}
+```
+
+Where `default-request.json` contains:
+
+```json
+{
+    "messages": [{"role": "user", "content": "Hello"}],
+    "max_tokens": 1024
+}
+```
+
+**Example (BYOE with Jinja2 templates):**
+
+```json
+"Default Request": {
+    "category": "request_template",
+    "file_path": "default-request.json.j2",
+    "mime_type": "json",
+    "is_public": true,
+    "description": "Default request with enrollment parameters"
+}
+```
+
+Where `default-request.json.j2` contains:
+
+```json
+{
+    "model": "{{ params.model }}",
+    "messages": [{"role": "user", "content": "Hello"}],
+    "max_tokens": 1024
+}
+```
+
+The playground uses the first `request_template` document as the default body in the editor.
+
+### troubleshooting
+
+Frequently asked questions and troubleshooting guides.
+
+**Example:**
+
+```json
+"Frequently Asked Questions": {
+    "category": "troubleshooting",
+    "file_path": "faq.md",
+    "mime_type": "markdown",
+    "is_public": true
+}
+```
+
+### specification
+
+Pricing information, specifications, and technical details.
+
+**Example:**
+
+```json
+"Pricing Details": {
+    "category": "specification",
+    "file_path": "pricing.md.j2",
+    "mime_type": "markdown",
+    "is_public": true
+}
+```
+
+### terms_of_service
+
+Terms of service for using the service.
+
+**Example:**
+
+```json
+"Terms of Service": {
+    "category": "terms_of_service",
+    "file_path": "terms.md",
+    "mime_type": "markdown",
+    "is_public": true
+}
+```
+
+### logo
+
+Company or service logo images.
+
+**Example:**
+
+```json
+"Company Logo": {
+    "category": "logo",
+    "file_path": "logo.png",
+    "mime_type": "png",
+    "is_public": true
+}
+```
+
+## Validation
+
+### Validating Documents
+
+Use the validate command to check document references and template syntax:
+
+```bash
+# Validate all files including documents
+usvc_seller data validate
+
+# Expected output:
+# ✓ All files validated successfully
+```
+
+**What is validated:**
+
+-   Data files (`.json`, `.toml`) are validated against schemas
+-   Template files (`.j2`) are validated for Jinja2 syntax errors
+-   File references are checked for existence
+-   Document categories are validated against allowed values
+-   Regular documents are checked for file existence only
+
+### Common Validation Errors
+
+**Problem:** `File not found: docs/example.md`
+
+**Solution:** Check that the file_path is correct relative to the listing file.
+
+**Problem:** `Jinja2 syntax error: unexpected 'end of template'`
+
+**Solution:** Check for unclosed tags in your `.j2` template files (`{{`, `{%`, `{#`).
+
+**Problem:** `Invalid category: 'custom_category'`
+
+**Solution:** Use one of the standard categories (description, getting_started, api_reference, code_examples, etc.).
+
+## Best Practices
+
+### 1. Use Templates for Dynamic Content
+
+Use `.j2` templates when content varies by service, provider, or listing:
+
+```jinja2
+# Good: Uses template for dynamic content
+Service {{ offering.name }} from {{ provider.name }}
+
+# Bad: Static content that requires manual updates per service
+Service gpt-4 from OpenAI
+```
+
+### 2. Share Common Documents
+
+Place shared documents at provider level to reduce duplication:
+
+```
+# Good: Shared authentication guide
+fireworks/docs/auth-guide.md
+
+# Bad: Duplicated in every service
+fireworks/services/llama-3-1-405b/auth-guide.md
+fireworks/services/llama-3-1-70b/auth-guide.md (duplicate)
+```
+
+### 3. Organize by Category
+
+Use clear document categories to help users find information:
+
+```json
+"documents": {
+    "Overview": {"category": "getting_started", ...},
+    "Quick Start": {"category": "getting_started", ...},
+    "API Docs": {"category": "api_reference", ...},
+    "Python Example": {"category": "code_example", ...},
+    "Default Request": {"category": "request_template", ...}
+}
+```
+
+### 4. Make Documents Public
+
+Set `is_public: true` for user-facing documentation:
+
+```json
+{
+    "is_public": true // Users can access this
+}
+```
+
+### 5. Validate Before Uploading
+
+Always validate documents before uploading:
+
+```bash
+usvc_seller data validate
+usvc_seller data upload
+```
+
+## Next Steps
+
+-   Learn about [Creating Code Examples](code-examples.md) for testing executable examples
+-   Review [File Schemas](https://unitysvc-sellers.readthedocs.io/en/latest/file-schemas/) for complete field reference
+-   Check [Workflows](https://unitysvc-sellers.readthedocs.io/en/latest/workflows/) for best practices

--- a/docs/file-schemas.md
+++ b/docs/file-schemas.md
@@ -1,0 +1,1220 @@
+# File Schemas
+
+Complete reference for all data file schemas used in the UnitySVC Services SDK.
+
+## Overview
+
+All data files must include a `schema` field identifying their type and version. The SDK currently supports these schemas:
+
+- `provider_v1` - Provider metadata and upstream access configuration
+- `seller_v1` - Seller/marketplace information
+- `offering_v1` - Service offering details (upstream provider perspective)
+- `listing_v1` - Service listing (user-facing marketplace perspective)
+- `service_group_v1` - Service group definitions for organizing services
+
+## Schema: provider_v1
+
+Provider files define the service provider's metadata and access configuration for automated service population.
+
+### Required Fields
+
+| Field           | Type                | Description                                                               |
+| --------------- | ------------------- | ------------------------------------------------------------------------- |
+| `schema`        | string              | Must be `"provider_v1"`                                                   |
+| `name`          | string              | Provider identifier (URL-friendly: lowercase, hyphens, underscores, dots) |
+| `homepage`      | string (URL)        | Provider website URL                                                      |
+| `contact_email` | string (email)      | Contact email address                                                     |
+| `time_created`  | datetime (ISO 8601) | Timestamp when the provider was created                                   |
+
+### Optional Fields
+
+| Field                     | Type                 | Description                                                     |
+| ------------------------- | -------------------- | --------------------------------------------------------------- |
+| `display_name`            | string               | Human-readable provider name (max 200 chars)                    |
+| `description`             | string               | Provider description                                            |
+| `secondary_contact_email` | string (email)       | Secondary contact email                                         |
+| `logo`                    | string/URL           | Path to logo file or URL (converted to document during import)  |
+| `terms_of_service`        | string/URL           | Path to terms file or URL (converted to document during import) |
+| `documents`               | dict of DocumentData | Documents keyed by title                                        |
+| `services_populator`      | object               | Automated service generation configuration                      |
+| `status`                  | enum                 | Provider status: `draft` (default), `ready`, or `deprecated`    |
+
+### services_populator Object
+
+Configuration for automatically populating service data using `usvc_seller data populate`.
+
+| Field          | Type                   | Description                                                                               |
+| -------------- | ---------------------- | ----------------------------------------------------------------------------------------- |
+| `command`      | string or list[string] | Command to execute (string or list of arguments). Relative to provider directory.         |
+| `requirements` | array of strings       | Python packages to install before executing (e.g., `["httpx", "any-llm-sdk[anthropic]"]`) |
+| `envs`         | object                 | Environment variables to set when executing the command (values converted to strings)     |
+
+**Notes:**
+
+- Comment out or omit `command` to disable population for a provider
+- `requirements` packages are installed via pip before running the command
+- `envs` values are converted to strings and set as environment variables
+
+### Example (TOML)
+
+```toml
+schema = "provider_v1"
+name = "openai"
+display_name = "OpenAI"
+description = "Leading AI research laboratory"
+contact_email = "support@openai.com"
+homepage = "https://openai.com"
+time_created = "2024-01-15T10:00:00Z"
+status = "ready"
+
+[services_populator]
+command = "populate_services.py"
+requirements = ["httpx", "openai"]
+
+[services_populator.envs]
+UNITYSVC_API_KEY = "sk-YOUR-API-KEY"
+SERVICE_BASE_URL = "https://api.openai.com/v1"
+```
+
+### Example (JSON)
+
+```json
+{
+    "schema": "provider_v1",
+    "name": "openai",
+    "display_name": "OpenAI",
+    "description": "Leading AI research laboratory",
+    "contact_email": "support@openai.com",
+    "homepage": "https://openai.com",
+    "time_created": "2024-01-15T10:00:00Z",
+    "status": "ready",
+    "services_populator": {
+        "command": "populate_services.py",
+        "requirements": ["httpx", "openai"],
+        "envs": {
+            "UNITYSVC_API_KEY": "sk-YOUR-API-KEY",
+            "SERVICE_BASE_URL": "https://api.openai.com/v1"
+        }
+    }
+}
+```
+
+## Schema: seller_v1
+
+Seller files define the marketplace or reseller information. **Only one seller file per repository.**
+
+### Required Fields
+
+| Field           | Type                | Description                                   |
+| --------------- | ------------------- | --------------------------------------------- |
+| `schema`        | string              | Must be `"seller_v1"`                         |
+| `name`          | string              | Seller identifier (URL-friendly, 2-100 chars) |
+| `contact_email` | string (email)      | Primary contact email                         |
+| `time_created`  | datetime (ISO 8601) | Timestamp when seller was created             |
+
+### Optional Fields
+
+| Field                     | Type                 | Description                                                                       |
+| ------------------------- | -------------------- | --------------------------------------------------------------------------------- |
+| `display_name`            | string               | Human-readable seller name (max 200 chars)                                        |
+| `seller_type`             | enum                 | Seller type: `individual` (default), `organization`, `partnership`, `corporation` |
+| `description`             | string               | Seller description (max 1000 chars)                                               |
+| `homepage`                | string (URL)         | Seller website URL                                                                |
+| `secondary_contact_email` | string (email)       | Secondary contact email                                                           |
+| `account_manager`         | string               | Email/username of account manager (max 100 chars)                                 |
+| `business_registration`   | string               | Business registration number (max 100 chars)                                      |
+| `tax_id`                  | string               | Tax ID (EIN, VAT, etc., max 100 chars)                                            |
+| `stripe_connect_id`       | string               | Stripe Connect account ID (max 255 chars)                                         |
+| `logo`                    | string/URL           | Path to logo file or URL (converted to document)                                  |
+| `documents`               | dict of DocumentData | Documents keyed by title (business registration, tax docs, etc.)                  |
+| `status`                  | enum                 | Seller status: `draft` (default), `ready`, or `deprecated`                        |
+| `is_verified`             | boolean              | KYC/business verification status (default: false)                                 |
+
+### Example (TOML)
+
+```toml
+schema = "seller_v1"
+name = "acme-corp"
+display_name = "ACME Corporation"
+seller_type = "corporation"
+description = "Premium AI services marketplace"
+contact_email = "business@acme.com"
+homepage = "https://acme.com"
+time_created = "2024-01-10T12:00:00Z"
+status = "ready"
+is_verified = true
+```
+
+## Schema: offering_v1
+
+Service files define the service offering from the upstream provider's perspective.
+
+### Required Fields
+
+| Field                        | Type                        | Description                                                                                                                                                                       |
+| ---------------------------- | --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `schema`                     | string                      | Must be `"offering_v1"`                                                                                                                                                           |
+| `name`                       | string                      | Service identifier (must match directory name, allows slashes for hierarchy)                                                                                                      |
+| `service_type`               | enum                        | Service category (see [ServiceTypeEnum values](#servicetype-enum-values))                                                                                                         |
+| `upstream_access_config` | dict of AccessInterfaceData | How to access upstream services, keyed by interface name. Supports Jinja2 templates (e.g. `{{ enrollment_code(6) }}`); expanded at gateway routing time using enrollment context. |
+| `time_created`               | datetime (ISO 8601)         | Timestamp when offering was created                                                                                                                                               |
+
+### Optional Fields
+
+| Field          | Type                  | Description                                                   |
+| -------------- | --------------------- | ------------------------------------------------------------- |
+| `display_name` | string                | Human-readable service name for display (e.g., 'GPT-4 Turbo') |
+| `description`  | string                | Service description                                           |
+| `capabilities` | array of string       | Specific features this service provides (see [Capabilities](#capabilities)) |
+| `logo`         | string/URL            | Path to logo or URL (converted to document)                   |
+| `tagline`      | string                | Short elevator pitch                                          |
+| `tags`         | array of enum         | Service tags (e.g., `["byok"]` for bring-your-own-provider)   |
+| `status`       | enum                  | Offering status: `draft` (default), `ready`, or `deprecated`  |
+| `details`      | object                | Service-specific features and information                     |
+| `payout_price` | [Pricing](pricing.md) | Seller pricing information (what seller charges UnitySVC)     |
+| `documents`    | dict of DocumentData  | Technical specs, documentation, keyed by title                |
+
+### ServiceType Enum Values
+
+- `llm` - Large Language Model
+- `embedding` - Text embedding generation
+- `image_generation` - Image generation from prompts
+- `text_to_image` - Text to image conversion
+- `vision_language_model` - Image description/analysis
+- `speech_to_text` - Audio transcription
+- `text_to_speech` - Voice synthesis
+- `video_generation` - Video generation
+- `text_to_3d` - 3D model generation
+- `streaming_transcription` - Real-time audio transcription
+- `prerecorded_transcription` - Batch audio transcription
+- `prerecorded_translation` - Batch audio translation
+- `undetermined` - Type not yet determined
+
+### Capabilities
+
+The `capabilities` field lists the specific features a service provides. While `service_type` is a single broad category used for UI grouping, `capabilities` is an array that enables discovery and filtering across multiple features.
+
+- `service_type` answers: **"What kind of service is this?"** (e.g., `llm`)
+- `capabilities` answers: **"What can this service do?"** (e.g., `["llm", "vision_language_model"]`)
+
+Capabilities are free-form strings. Well-known values include all `ServiceTypeEnum` values above, plus:
+`recommendation`, `search`, `classification`, `summarization`, `translation`, `code_generation`, `function_calling`, `fine_tuning`
+
+**Examples:**
+
+| Service | `service_type` | `capabilities` |
+|---------|---------------|----------------|
+| OpenAI GPT-4 | `llm` | `["llm", "vision_language_model"]` |
+| Deepgram Nova | `speech_to_text` | `["speech_to_text", "text_to_speech"]` |
+| Gorse Recommender | `undetermined` | `["recommendation"]` |
+
+### Example (TOML)
+
+```toml
+schema = "offering_v1"
+name = "gpt-4"
+display_name = "GPT-4"
+description = "Most capable GPT-4 model for complex reasoning tasks"
+service_type = "llm"
+capabilities = ["llm", "vision_language_model"]
+status = "ready"
+time_created = "2024-01-20T14:00:00Z"
+
+[details]
+context_window = 128000
+max_output_tokens = 4096
+supports_function_calling = true
+supports_vision = true
+
+[upstream_access_config."OpenAI API"]
+access_method = "http"
+base_url = "https://api.openai.com/v1"
+
+[payout_price]
+currency = "USD"
+
+[payout_price.price_data]
+type = "one_million_tokens"
+input = "30.00"
+output = "60.00"
+```
+
+## Schema: listing_v1
+
+Listing files define how a seller presents/sells a service to end users.
+
+**Relationship by Location**: Listings automatically belong to the single offering in the same directory. The provider is determined by the parent directory structure. No explicit linking fields are needed.
+
+### Required Fields
+
+| Field                    | Type                        | Description                                 |
+| ------------------------ | --------------------------- | ------------------------------------------- |
+| `schema`                 | string                      | Must be `"listing_v1"`                      |
+| `user_access_interfaces` | dict of AccessInterfaceData | How users access the service, keyed by name |
+| `time_created`           | datetime (ISO 8601)         | Timestamp when listing was created          |
+
+### Optional Fields
+
+| Field                       | Type                  | Description                                                                                      |
+| --------------------------- | --------------------- | ------------------------------------------------------------------------------------------------ |
+| `name`                      | string                | Listing identifier (defaults to filename without extension, max 255 chars)                       |
+| `display_name`              | string                | Customer-facing name (max 200 chars)                                                             |
+| `status`                    | enum                  | Status: `draft` (skip upload), `ready` (ready for review), `deprecated`                          |
+| `list_price`                | [Pricing](pricing.md) | Customer-facing pricing (what customer pays)                                                     |
+| `documents`                 | dict of DocumentData  | SLAs, documentation, guides, keyed by title                                                      |
+| `user_parameters_schema`    | object                | JSON schema defining user parameters for subscriptions (see [User Parameters](#user-parameters)) |
+| `user_parameters_ui_schema` | object                | UI schema for user parameter form rendering (see [User Parameters](#user-parameters))            |
+| `service_options`           | object                | Service-specific options (see [Service Options](#service-options))                               |
+
+### Service Options
+
+The `service_options` field configures backend behavior for service listings. All fields are optional.
+
+| Field                           | Type    | Description                                                                    |
+| ------------------------------- | ------- | ------------------------------------------------------------------------------ |
+| `ops_testing_parameters`        | object  | Default parameter values for testing (see [User Parameters](#user-parameters)) |
+| `enrollment_vars`               | object  | Per-enrollment variables rendered into code examples and test scripts (see below) |
+| `enrollment_limit`              | integer | Maximum total active enrollments allowed for this service (global limit)       |
+| `enrollment_limit_per_customer` | integer | Maximum active enrollments per customer for this service                       |
+| `enrollment_limit_per_user`     | integer | Maximum active enrollments per user (creator) for this service                 |
+
+**Enrollment Variables (`enrollment_vars`):**
+
+The `enrollment_vars` field defines per-enrollment variables that are rendered and passed to code examples and test scripts during both local testing (`usvc_seller data run-tests`) and gateway testing (`usvc_seller services run-tests`). Values support Jinja2 template syntax with access to enrollment context functions.
+
+```json
+{
+    "service_options": {
+        "enrollment_vars": {
+            "user_id": "{{ enrollment_code(6) }}",
+            "region": "us-east-1"
+        }
+    }
+}
+```
+
+Template functions available in `enrollment_vars` values:
+
+- `{{ enrollment_code(N) }}` — Returns the enrollment's unique code (N = length). The code is stable per enrollment.
+
+Variable names should be lowercase. They are available directly in access interface templates as `{{ var_name }}`.
+
+**Enrollment Limits:**
+
+- Limits apply only to **active** enrollments (cancelled/inactive enrollments don't count)
+- Invalid values (non-integers, zero, negative, or boolean) are treated as "no limit"
+- Limits are checked when creating **new** enrollments (not when updating existing ones)
+- Checks are performed in order: per-customer → per-user → global
+
+**Example (JSON):**
+
+```json
+{
+    "service_options": {
+        "ops_testing_parameters": {
+            "api_key": "${ secrets.SERVICE_API_KEY }",
+            "region": "us-east-1"
+        },
+        "enrollment_vars": {
+            "USER_ID": "{{ enrollment_code(6) }}"
+        },
+        "enrollment_limit": 100,
+        "enrollment_limit_per_customer": 5,
+        "enrollment_limit_per_user": 2
+    }
+}
+```
+
+**Example (TOML):**
+
+```toml
+[service_options]
+enrollment_limit = 100
+enrollment_limit_per_customer = 5
+enrollment_limit_per_user = 2
+
+[service_options.ops_testing_parameters]
+api_key = "${ secrets.SERVICE_API_KEY }"
+region = "us-east-1"
+
+[service_options.enrollment_vars]
+user_id = "{{ enrollment_code(6) }}"
+```
+
+### Listing Name Field
+
+- **Automatic naming**: If `name` is omitted, uses filename (without extension)
+- **Multiple listings**: Use descriptive filenames for different tiers/marketplaces
+- **Example**: `listing-premium.json` → `name = "listing-premium"`
+
+### status Values (Listing)
+
+- `draft` - Work in progress, skipped during upload (default)
+- `ready` - Ready for admin review and testing
+- `deprecated` - No longer offered to new customers
+
+### Gateway Base URL
+
+The `base_url` field in `user_access_interfaces` uses a `${..._GATEWAY_BASE_URL}` placeholder that the platform resolves at runtime. UnitySVC provides multiple protocol-specific gateways, each with its own base URL:
+
+| Gateway | Placeholder | Protocol | Example URL |
+| ------- | ----------- | -------- | ----------- |
+| API Gateway (APISIX) | `${API_GATEWAY_BASE_URL}` | HTTP/HTTPS | `https://api.unitysvc.com` |
+| S3 Gateway | `${S3_GATEWAY_BASE_URL}` | S3 API | `https://s3.unitysvc.com` |
+| SMTP Gateway | `${SMTP_GATEWAY_BASE_URL}` | SMTP | `smtp://smtp.unitysvc.com:587` |
+| SSH Gateway | `${SSH_GATEWAY_BASE_URL}` | SSH | `ssh://ssh.unitysvc.com:22` |
+
+Use the placeholder that matches the `access_method` of your service. Most services use the HTTP API gateway (`${API_GATEWAY_BASE_URL}`).
+
+### Example (TOML)
+
+```toml
+# File: data/openai/services/gpt-4/listing-premium.toml
+# This listing automatically belongs to the gpt-4 offering in the same directory
+# and the openai provider in the parent directory.
+
+schema = "listing_v1"
+name = "listing-premium"
+display_name = "GPT-4 Premium Access"
+status = "ready"
+time_created = "2024-01-25T16:00:00Z"
+
+[user_access_interfaces."OpenAI API Access"]
+access_method = "http"
+base_url = "${API_GATEWAY_BASE_URL}/p/openai"
+
+[user_access_interfaces."OpenAI API Access".routing_key]
+model = "gpt-4"
+
+[list_price]
+currency = "USD"
+
+[list_price.price_data]
+type = "one_million_tokens"
+input = "35.00"
+output = "70.00"
+
+[documents."Quick Start Guide"]
+file_path = "../../docs/quick-start.md"
+category = "getting_started"
+mime_type = "markdown"
+```
+
+## User Parameters
+
+User parameters collect **configuration values** from customers during enrollment. These are real settings the customer chooses (model preferences, regions, feature flags) — not API keys or credentials.
+
+> **Note**: API keys and credentials are handled separately through [Secrets](#secrets-for-sensitive-information), not through user parameters. See [BYOK Services](#byok-services-bring-your-own-key) for how to set up services that require a customer's API key.
+
+### Overview
+
+User parameters enable dynamic service configuration through:
+
+1. **`user_parameters_schema`** - JSON Schema defining parameters, validation rules, and UI components
+2. **`user_parameters_ui_schema`** - UI customization for form rendering
+3. **`service_options.ops_testing_parameters`** - Default values for testing parameters before deployment
+
+Services that define `user_parameters_schema` **require enrollment** — the customer must provide their configuration before using the service.
+
+### user_parameters_schema
+
+Defines the parameters users must provide when enrolling in a service. Uses [JSON Schema](https://json-schema.org/) format with extensions from [react-jsonschema-form](https://rjsf-team.github.io/react-jsonschema-form/).
+
+**Common properties:**
+
+- `type` - Data type: `"string"`, `"number"`, `"boolean"`, `"object"`, `"array"`
+- `title` - Human-readable field label
+- `description` - Help text shown to users
+- `default` - Default value for the field
+- `enum` - List of allowed values (creates dropdown)
+- `required` - Array of required field names
+
+**Example:**
+
+```json
+{
+    "type": "object",
+    "title": "Service Configuration",
+    "properties": {
+        "model": {
+            "type": "string",
+            "title": "Model",
+            "description": "Model to use",
+            "enum": ["gpt-4", "gpt-3.5-turbo"],
+            "default": "gpt-4"
+        },
+        "temperature": {
+            "type": "number",
+            "title": "Temperature",
+            "description": "Sampling temperature (0-2)",
+            "default": 0.7,
+            "minimum": 0,
+            "maximum": 2
+        }
+    },
+    "required": ["model"]
+}
+```
+
+### user_parameters_ui_schema
+
+Customizes how the form is rendered. Controls field order, visibility, widgets, and presentation.
+
+**Common UI options:**
+
+- `ui:widget` - Widget type: `"textarea"`, `"password"`, `"select"`, `"radio"`, `"checkbox"`
+- `ui:placeholder` - Placeholder text
+- `ui:help` - Additional help text
+- `ui:description` - Field description text
+- `ui:disabled` - Disable field
+- `ui:order` - Field display order
+
+**Example:**
+
+```json
+{
+    "model": {
+        "ui:widget": "select"
+    },
+    "temperature": {
+        "ui:widget": "range"
+    },
+    "ui:order": ["model", "temperature"]
+}
+```
+
+### service_options.ops_testing_parameters
+
+Provides default parameter values for testing services before deployment. Required when `user_parameters_schema` defines required parameters without default values.
+
+**Key requirements:**
+
+1. **All required parameters must have defaults** - Each parameter in `user_parameters_schema.required` must have either a `default` in the schema OR a value in `ops_testing_parameters`
+2. **Must be testable** - Values must allow the service to be tested successfully
+
+**Example:**
+
+```json
+{
+    "service_options": {
+        "ops_testing_parameters": {
+            "model": "gpt-4",
+            "temperature": 0.7
+        }
+    }
+}
+```
+
+### Complete Example (JSON)
+
+A service with user-configurable parameters (model, token limits, streaming):
+
+```json
+{
+    "schema": "listing_v1",
+    "display_name": "Custom AI Service",
+    "status": "ready",
+    "user_parameters_schema": {
+        "type": "object",
+        "title": "Service Configuration",
+        "properties": {
+            "model": {
+                "type": "string",
+                "title": "Model",
+                "enum": ["gpt-4", "gpt-4-turbo", "gpt-3.5-turbo"],
+                "default": "gpt-4"
+            },
+            "max_tokens": {
+                "type": "integer",
+                "title": "Max Tokens",
+                "default": 1000,
+                "minimum": 1,
+                "maximum": 4096
+            },
+            "enable_streaming": {
+                "type": "boolean",
+                "title": "Enable Streaming",
+                "default": false
+            }
+        },
+        "required": ["model"]
+    },
+    "user_parameters_ui_schema": {
+        "model": { "ui:widget": "select" },
+        "max_tokens": { "ui:widget": "range" },
+        "enable_streaming": { "ui:widget": "checkbox" },
+        "ui:order": ["model", "max_tokens", "enable_streaming"]
+    },
+    "service_options": {
+        "ops_testing_parameters": {
+            "model": "gpt-4",
+            "max_tokens": 1000,
+            "enable_streaming": false
+        }
+    },
+    "user_access_interfaces": {
+        "API Access": {
+            "access_method": "http",
+            "base_url": "${API_GATEWAY_BASE_URL}/p/my-service"
+        }
+    }
+}
+```
+
+### Validation Rules
+
+The SDK validates user parameters during `usvc_seller data validate`:
+
+1. All parameters in `user_parameters_schema.required` must have either a `default` in the schema or a value in `ops_testing_parameters`
+2. If required parameters exist without defaults, `service_options.ops_testing_parameters` must be defined
+
+```
+✗ Required parameters missing default values in service_options.ops_testing_parameters: ['model']
+```
+
+### Resources
+
+- [react-jsonschema-form Documentation](https://rjsf-team.github.io/react-jsonschema-form/)
+- [JSON Schema Specification](https://json-schema.org/)
+
+## BYOK Services (Bring Your Own Key)
+
+BYOK services require the customer to provide their own API key for the upstream provider. Unlike user parameters, API keys are handled through **secrets** — they are stored in the customer's secret store, not on an enrollment record.
+
+### How it works
+
+1. The `user_access_interfaces` entry includes an `api_key` field referencing a secret
+2. The system auto-detects customer-required secrets by scanning `user_access_interfaces` for `${ secrets.XXX }` references
+3. Services with only secret references (no `user_parameters_schema`) **do not require enrollment** — customers can use the service immediately after storing their secret
+4. If the secret is missing at request time, the platform returns an error indicating which secret is needed
+
+### BYOK listing example (JSON)
+
+```json
+{
+    "schema": "listing_v1",
+    "display_name": "Groq LLaMA 3.3 70B (BYOK)",
+    "status": "ready",
+    "user_access_interfaces": {
+        "Provider API": {
+            "access_method": "http",
+            "base_url": "${API_GATEWAY_BASE_URL}/p/groq",
+            "api_key": "${ secrets.GROQ_API_KEY }",
+            "routing_key": { "model": "llama-3.3-70b-versatile" }
+        }
+    }
+}
+```
+
+That's it — no `user_parameters_schema`, no `user_parameters_ui_schema`, no `ops_testing_parameters` for the API key. The `${ secrets.GROQ_API_KEY }` reference in `user_access_interfaces` tells the platform:
+
+- The customer needs a secret named `GROQ_API_KEY`
+- The marketplace can show a "Bring your own key" badge
+- At routing time, the secret is resolved from the customer's secret store
+
+### BYOK with additional parameters
+
+A BYOK service can also have user parameters (e.g., model selection). In this case, **both** enrollment and a secret are required:
+
+```json
+{
+    "user_access_interfaces": {
+        "Provider API": {
+            "base_url": "${API_GATEWAY_BASE_URL}/p/openai",
+            "api_key": "${ secrets.OPENAI_API_KEY }",
+            "routing_key": { "model": "gpt-4" }
+        }
+    },
+    "user_parameters_schema": {
+        "type": "object",
+        "properties": {
+            "model": {
+                "type": "string",
+                "enum": ["gpt-4", "gpt-4-turbo"],
+                "default": "gpt-4"
+            }
+        },
+        "required": ["model"]
+    }
+}
+```
+
+### Seller-managed vs customer secrets
+
+The `${ secrets.XXX }` syntax is used in both seller and customer contexts. The **location** determines who provides the secret:
+
+| Location | Who provides | Example |
+|----------|-------------|---------|
+| `user_access_interfaces.*.api_key` | **Customer** (BYOK) | `${ secrets.GROQ_API_KEY }` |
+| `upstream_access_config.*.api_key` | **Seller** | `${ secrets.PROVIDER_KEY }` |
+| `service_options.ops_testing_parameters` | **Seller** (for testing) | `${ secrets.TEST_KEY }` |
+| `request_transformer` values | **Seller** | `${ secrets.AUTH_TOKEN }` |
+
+### Local testing
+
+During `usvc_seller data run-tests`, secret references are expanded from **environment variables**:
+
+```bash
+export GROQ_API_KEY="gsk_your_actual_key"
+usvc_seller data run-tests data/groq/services/llama-3.3-70b-versatile-byok
+```
+
+The test runner resolves `${ secrets.GROQ_API_KEY }` → looks up `GROQ_API_KEY` in the shell environment. This works for secrets in all locations (access interfaces, ops_testing_parameters, request transformers).
+
+### Auto-detection
+
+The system automatically extracts customer-required secrets by scanning `user_access_interfaces` for `${ secrets.XXX }` patterns. No separate declaration is needed — the secret references in the spec **are** the declaration. This avoids inconsistencies between declared and actual secret usage.
+
+## Data Types
+
+### AccessInterfaceData Object
+
+The `AccessInterfaceData` object defines how to access a service (used in offerings and listings). The interface name is the dict key, not a field in the object.
+
+| Field                 | Type               | Description                                                                                               |
+| --------------------- | ------------------ | --------------------------------------------------------------------------------------------------------- |
+| `access_method`       | enum               | Access method: `http` (default), `websocket`, `grpc`                                                      |
+| `base_url`            | string             | API endpoint URL (max 500 chars)                                                                          |
+| `api_key`             | string             | API key using secrets format: `${ secrets.VAR_NAME }` (see [Secrets](#secrets-for-sensitive-information)) |
+| `description`         | string             | Interface description (max 500 chars)                                                                     |
+| `request_transformer` | object             | Request transformation config (keys: `proxy_rewrite`, `body_transformer`)                                 |
+| `routing_key`         | object             | Optional routing key for request matching                                                                 |
+| `rate_limits`         | array of RateLimit | Rate limiting rules                                                                                       |
+| `constraints`         | ServiceConstraints | Service constraints                                                                                       |
+| `is_active`           | boolean            | Whether interface is active (default: true)                                                               |
+| `is_primary`          | boolean            | Whether this is primary interface (default: false)                                                        |
+| `sort_order`          | integer            | Display order (default: 0)                                                                                |
+
+**Note:** The interface name is specified as the dict key, not as a field within the object.
+
+#### Jinja2 Template Values
+
+String values in `user_access_interfaces` and `upstream_access_config` can use **Jinja2 template syntax** for dynamic rendering at enrollment time. Templates are rendered with an enrollment context that includes enrollment parameters, customer ID, and enrollment ID.
+
+**Template context variables:**
+
+| Variable                 | Type   | Description               |
+| ------------------------ | ------ | ------------------------- |
+| `enrollment.id`          | string | Enrollment UUID           |
+| `enrollment.customer_id` | string | Customer UUID             |
+| `enrollment.parameters`  | dict   | All enrollment parameters |
+
+**Template functions:**
+
+| Function                    | Returns | Description                                                    |
+| --------------------------- | ------- | -------------------------------------------------------------- |
+| `enrollment_code(length=6)` | string  | Create or retrieve a random code tied to a specific enrollment |
+
+The `enrollment_code` function is idempotent — calling it multiple times for the same enrollment returns the same code. The code is persisted in the `action_code` table and can be referenced from both `user_access_interfaces` and `upstream_access_config` templates.
+
+**Behavior:**
+
+- `user_access_interfaces`: templates are rendered at **enrollment time**, creating enrollment-scoped `AccessInterface` records
+- `upstream_access_config`: templates are rendered at **gateway routing time**, using the enrollment context to resolve the upstream target per-request (no enrollment-scoped records are created)
+- Interfaces without template syntax are treated as static and shared across enrollments (listing-scoped)
+- On template rendering errors, the original string value is preserved
+
+**Example — user access interface (TOML):**
+
+```toml
+[user_access_interfaces.ntfy-gateway]
+access_method = "http"
+base_url = "${API_GATEWAY_BASE_URL}/ntfy/{{ enrollment_code(6) }}"
+description = "Your ntfy notification endpoint"
+```
+
+**Example (JSON):**
+
+```json
+{
+    "user_access_interfaces": {
+        "ntfy-gateway": {
+            "access_method": "http",
+            "base_url": "${API_GATEWAY_BASE_URL}/ntfy/{{ enrollment_code(6) }}",
+            "description": "Your ntfy notification endpoint"
+        }
+    }
+}
+```
+
+After enrollment, the `base_url` is rendered with the generated code (e.g., `${API_GATEWAY_BASE_URL}/ntfy/VTXBNM`), creating an enrollment-scoped access interface visible only to that enrollment.
+
+**Example — upstream access interface with template:**
+
+The corresponding upstream interface in the offering can reference the same `enrollment_code()` to route requests to the correct upstream target:
+
+```json
+{
+    "upstream_access_config": {
+        "ntfy-upstream": {
+            "access_method": "http",
+            "base_url": "https://ntfy.svcpass.com/{{ enrollment_code(6) }}",
+            "description": "Private ntfy instance"
+        }
+    }
+}
+```
+
+Unlike user interfaces, upstream templates are **not** materialized at enrollment time. They are rendered at gateway routing time — the gateway identifies the enrollment from the inbound request, then expands the upstream template with the enrollment's `enrollment_code()` to determine the final upstream URL.
+
+#### Routing Key
+
+The `routing_key` field enables fine-grained request routing when multiple service listings share the same endpoint. The gateway extracts routing information from incoming requests and uses exact matching to find the correct service listing.
+
+**How it works:**
+
+- Gateway extracts routing key from request body (currently the `model` field: `{"model": "value"}`)
+- Performs exact JSON equality match against `routing_key` in access interfaces
+- Only interfaces with matching `routing_key` handle the request
+- If `routing_key` is `null`, matches requests without a routing key
+
+**Example use case:** Multiple GPT models on same endpoint:
+
+```json
+{
+    "user_access_interfaces": {
+        "GPT-4 API": {
+            "base_url": "${API_GATEWAY_BASE_URL}/p/openai",
+            "routing_key": { "model": "gpt-4" }
+        }
+    }
+}
+```
+
+When a request arrives at `/p/openai` with `{"model": "gpt-4", "messages": [...]}`, the gateway extracts `{"model": "gpt-4"}` and routes to the matching listing.
+
+### Pricing Object
+
+Flexible pricing structure for both upstream (`payout_price`) and user-facing (`list_price`) prices.
+
+> **Full documentation:** See [Pricing Specification](pricing.md) for complete details on pricing types, validation rules, and examples.
+
+| Field         | Type         | Description                                                                      |
+| ------------- | ------------ | -------------------------------------------------------------------------------- |
+| `currency`    | string       | ISO currency code (e.g., "USD", "EUR")                                           |
+| `price_data`  | object       | Type-specific price structure (see [Pricing Types](pricing.md#per-request-pricing-types)) |
+| `description` | string       | Pricing model description                                                        |
+| `reference`   | string (URL) | Reference URL to upstream pricing page                                           |
+
+**price_data types:**
+
+| Type                 | Description                                       | Example Fields              |
+| -------------------- | ------------------------------------------------- | --------------------------- |
+| `one_million_tokens` | Per million tokens (for LLMs)                     | `price` or `input`/`output` |
+| `one_second`         | Per second of usage                               | `price`                     |
+| `image`              | Per image generated                               | `price`                     |
+| `step`               | Per step/iteration                                | `price`                     |
+| `revenue_share`      | Percentage of customer charge (payout_price only) | `percentage`                |
+
+**Quick examples:**
+
+```json
+// Unified token pricing
+{"price_data": {"type": "one_million_tokens", "price": "2.50"}}
+
+// Separate input/output pricing (LLM)
+{"price_data": {"type": "one_million_tokens", "input": "10.00", "output": "30.00"}}
+
+// Image generation pricing
+{"price_data": {"type": "image", "price": "0.04"}}
+```
+
+> **Note:** Use string values for prices (e.g., `"2.50"`) to avoid floating-point precision issues.
+
+See [Pricing Specification](pricing.md) for TOML examples, validation rules, and cost calculation details.
+
+### DocumentData Object
+
+Documents associated with entities (providers, offerings, listings). The document title is the dict key, not a field in the object.
+
+| Field          | Type    | Description                                                                                               |
+| -------------- | ------- | --------------------------------------------------------------------------------------------------------- |
+| `mime_type`    | enum    | MIME type: `markdown`, `python`, `javascript`, `bash`, `html`, `text`, `pdf`, `jpeg`, `png`, `svg`, `url` |
+| `category`     | enum    | Document category (see [DocumentCategory values](#documentcategory-enum-values))                          |
+| `description`  | string  | Document description (max 500 chars)                                                                      |
+| `version`      | string  | Document version (max 50 chars)                                                                           |
+| `file_path`    | string  | Relative path to file (max 1000 chars, mutually exclusive with external_url)                              |
+| `external_url` | string  | External URL (max 1000 chars, mutually exclusive with file_path)                                          |
+| `meta`         | object  | Additional metadata (e.g., test results, requirements)                                                    |
+| `sort_order`   | integer | Sort order within category (default: 0)                                                                   |
+| `is_active`    | boolean | Whether document is active (default: true)                                                                |
+| `is_public`    | boolean | Publicly accessible without auth (default: false)                                                         |
+
+**Note:** The document title is specified as the dict key (5-255 chars), not as a field within the object.
+
+### DocumentCategory Enum Values
+
+- `getting_started` - Getting started guides
+- `api_reference` - API reference documentation
+- `tutorial` - Step-by-step tutorials
+- `code_example` - Code examples (visible to users)
+- `code_example_output` - Expected output from code examples
+- `connectivity_test` - Connectivity and performance tests (not visible to users, `is_public: false`)
+- `request_template` - Default request body for the playground (JSON, pre-fills the test request editor)
+- `use_case` - Use case descriptions
+- `troubleshooting` - Troubleshooting guides
+- `changelog` - Version changelogs
+- `best_practice` - Best practices
+- `specification` - Technical specifications
+- `service_level_agreement` - SLAs
+- `terms_of_service` - Terms of service
+- `invoice` - Invoices/receipts
+- `logo` - Logo images
+- `avatar` - Avatar images
+- `other` - Other documents
+
+### RateLimit Object
+
+Rate limiting rules for services.
+
+| Field         | Type    | Description                                                                                   |
+| ------------- | ------- | --------------------------------------------------------------------------------------------- |
+| `limit`       | integer | Maximum allowed in time window                                                                |
+| `unit`        | enum    | What is limited: `requests`, `tokens`, `input_tokens`, `output_tokens`, `bytes`, `concurrent` |
+| `window`      | enum    | Time window: `second`, `minute`, `hour`, `day`, `month`                                       |
+| `description` | string  | Human-readable description (max 255 chars)                                                    |
+| `burst_limit` | integer | Short-term burst allowance                                                                    |
+| `is_active`   | boolean | Whether limit is active (default: true)                                                       |
+
+**Example:**
+
+```json
+{
+    "limit": 10000,
+    "unit": "requests",
+    "window": "hour",
+    "description": "10K requests per hour limit",
+    "burst_limit": 1000
+}
+```
+
+### ServiceConstraints Object
+
+Comprehensive service constraints and policies. All fields are optional.
+
+**Usage Quotas:**
+
+- `monthly_quota`, `daily_quota` - Usage quotas
+- `quota_unit` - Unit for quotas (RateLimitUnitEnum)
+- `quota_reset_cycle` - Reset cycle: `daily`, `weekly`, `monthly`, `yearly`
+- `overage_policy` - Policy when exceeded: `block`, `throttle`, `charge`, `queue`
+
+**Authentication:**
+
+- `auth_methods` - Supported auth methods (array of AuthMethodEnum)
+- `ip_whitelist_required` - IP whitelisting required (boolean)
+- `tls_version_min` - Minimum TLS version (string)
+
+**Request/Response:**
+
+- `max_request_size_bytes`, `max_response_size_bytes` - Size limits
+- `timeout_seconds` - Request timeout
+- `max_batch_size` - Max batch items
+
+**Content:**
+
+- `content_filters` - Content filtering: `adult`, `violence`, `hate_speech`, `profanity`, `pii`
+- `input_languages`, `output_languages` - Supported languages (ISO 639-1)
+- `max_context_length` - Max context tokens
+- `region_restrictions` - Geographic restrictions (ISO country codes)
+
+**Availability:**
+
+- `uptime_sla_percent` - Uptime SLA (e.g., 99.9)
+- `response_time_sla_ms` - Response time SLA
+- `maintenance_windows` - Scheduled maintenance
+
+**Concurrency:**
+
+- `max_concurrent_requests` - Max concurrent requests
+- `connection_timeout_seconds` - Connection timeout
+- `max_connections_per_ip` - Max connections per IP
+
+## Secrets for Sensitive Information
+
+API keys and other sensitive credentials must **never** be stored as plain text in data files. Instead, use the secrets reference format to specify credentials that will be securely retrieved at runtime.
+
+### Creating Secrets
+
+Before referencing secrets in your data files, you must create them in the UnitySVC platform:
+
+1. Log in to the UnitySVC website
+2. Navigate to **Seller Dashboard** → **Secrets**
+3. Click **Create Secret**
+4. Enter a name (e.g., `OPENAI_API_KEY`) and the secret value
+5. Save the secret
+
+Secret names must:
+
+- Start with a letter or underscore
+- Contain only letters, numbers, and underscores
+- Be unique within your seller account
+
+### Referencing Secrets in Data Files
+
+Use the `${ secrets.VAR_NAME }` format to reference secrets. Spaces around the variable name are optional.
+
+**Valid formats:**
+
+```
+${ secrets.OPENAI_API_KEY }
+${secrets.OPENAI_API_KEY}
+${ secrets.MY_PROVIDER_KEY }
+```
+
+### API Key Fields
+
+The following fields require secrets references (plain text API keys are not allowed):
+
+- `upstream_access_config.<name>.api_key` - API keys for upstream provider access
+- `user_access_interfaces.<name>.api_key` - API keys for user-facing interfaces
+- `service_options.ops_testing_parameters.api_key` - Ops testing API key parameters
+
+### Example Usage
+
+**TOML:**
+
+```toml
+[upstream_access_config."OpenAI API"]
+access_method = "http"
+base_url = "https://api.openai.com/v1"
+api_key = "${ secrets.OPENAI_API_KEY }"
+```
+
+**JSON:**
+
+```json
+{
+    "upstream_access_config": {
+        "OpenAI API": {
+            "access_method": "http",
+            "base_url": "https://api.openai.com/v1",
+            "api_key": "${ secrets.OPENAI_API_KEY }"
+        }
+    }
+}
+```
+
+### How Secrets Work
+
+1. **Upload**: When you upload data files, the `${ secrets.VAR_NAME }` references are validated for correct format and the secret's existence is verified by the backend
+2. **Storage**: The reference string is stored as-is in the database (secrets are NOT expanded during upload)
+3. **Runtime**: When the API key is actually needed, the platform retrieves the decrypted value from the secure secrets storage
+
+This approach ensures that:
+
+- Sensitive credentials are never exposed in version-controlled files
+- Secrets can be rotated without re-uploading data files
+- Access to secrets is controlled through the seller dashboard
+
+## Validation Rules
+
+The SDK enforces these validation rules:
+
+1. **Schema field required**: All files must have `schema` field
+2. **Schema version**: Only supported schema versions allowed
+3. **Required fields**: All required fields must be present
+4. **Name format**: Names must be URL-friendly (lowercase, hyphens, underscores, dots)
+    - Provider/Seller: No slashes allowed
+    - Service/Listing: Slashes allowed for hierarchical names
+5. **Time created**: Must be valid ISO 8601 datetime
+6. **Email validation**: Email fields must be valid email addresses
+7. **URL validation**: URL fields must be valid URLs
+8. **File paths**: Document paths must be relative and exist
+9. **Enum values**: Must use valid enum values
+10. **Mutual exclusivity**: Some fields are mutually exclusive (e.g., `file_path` and `external_url` in documents)
+
+## Format Support
+
+Both JSON and TOML formats are supported for all schemas:
+
+### JSON
+
+- Uses 2-space indentation
+- Keys sorted alphabetically
+- Files end with single newline
+
+### TOML
+
+- Standard TOML syntax
+- Sections use `[header]` notation
+- Arrays of objects use `[[header]]` notation
+
+The SDK preserves the original format when updating files.
+
+## See Also
+
+- [Service Options](#service-options) - Configure subscription limits and backend behavior
+- [User Parameters](#user-parameters) - Define and collect subscription configuration
+- [Service Groups](#schema-service_group_v1) - Organize services with rule-based membership
+- [Pricing Specification](pricing.md) - Complete pricing documentation
+- [Data Structure](data-structure.md) - File organization rules
+- [CLI Reference](cli-reference.md#usvc_seller-data-validate-validate-data) - Validation command
+- [Getting Started](getting-started.md) - Create your first files
+
+---
+
+## Schema: service_group_v1
+
+Service group files define collections of services for organization and
+promotion targeting. Groups use rule-based membership to automatically
+include/exclude services based on their properties.
+
+> **Note:** Seller-defined service groups are currently used primarily for
+> promotion targeting (see [Promotions](cli-reference.md#usvc_seller-promotions-promotion-management)).
+> Groups created by sellers are nested under an auto-created root group
+> (`seller:{seller_name}`).
+
+### Required Fields
+
+| Field          | Type   | Description                                                      |
+| -------------- | ------ | ---------------------------------------------------------------- |
+| `schema`       | string | Must be `"service_group_v1"`                                     |
+| `name`         | string | URL-friendly slug (max 100 chars, lowercase with hyphens/colons) |
+| `display_name` | string | Human-readable name (max 200 chars)                              |
+
+### Optional Fields
+
+| Field              | Type   | Default   | Description                                              |
+| ------------------ | ------ | --------- | -------------------------------------------------------- |
+| `description`      | string | `null`    | Detailed description (max 2000 chars)                    |
+| `status`           | string | `"draft"` | Lifecycle status: `draft`, `active`, `private`, `archived` |
+| `parent_group_name`| string | `null`    | Parent group name for hierarchy                          |
+| `membership_rules` | object | `null`    | Rule-based membership (see below)                        |
+| `sort_order`       | int    | `0`       | Display order within parent level                        |
+
+### Status Values
+
+| Status     | Description                                          |
+| ---------- | ---------------------------------------------------- |
+| `draft`    | Being configured, not active                         |
+| `active`   | Live and visible in marketplace                      |
+| `private`  | Live but hidden from marketplace (for promotions)    |
+| `archived` | No longer available                                  |
+
+### Membership Rules
+
+Membership rules automatically include services based on their properties.
+The `expression` field is a Python expression evaluated against each service.
+
+**Available variables:**
+
+| Variable        | Type   | Description                                 |
+| --------------- | ------ | ------------------------------------------- |
+| `service_id`    | string | Service UUID                                |
+| `seller_id`     | string | Seller UUID                                 |
+| `provider_id`   | string | Provider UUID                               |
+| `seller_name`   | string | Seller name                                 |
+| `provider_name` | string | Provider name (e.g., `"openai"`)            |
+| `name`          | string | Service name                                |
+| `display_name`  | string | Service display name                        |
+| `service_type`  | string | Type: `"llm"`, `"embedding"`, `"tts"`, etc. |
+| `status`        | string | Service status                              |
+| `listing_type`  | string | `"regular"`, `"byok"`, `"self_hosted"`      |
+| `tags`          | list   | List of tag strings                         |
+| `is_featured`   | bool   | Whether service is featured                 |
+
+**Example expressions:**
+
+```python
+# All LLM services
+"service_type == 'llm'"
+
+# Services from a specific provider
+"provider_name == 'openai'"
+
+# Multiple types
+"service_type in ('llm', 'embedding', 'tts')"
+
+# Combined conditions
+"provider_name == 'fireworks' and service_type == 'llm'"
+
+# Tag-based
+"'premium' in tags"
+```
+
+### Example Files
+
+**Basic group with membership rules:**
+```json
+{
+    "schema": "service_group_v1",
+    "name": "my-llm-services",
+    "display_name": "My LLM Services",
+    "description": "All LLM services for targeted promotions",
+    "membership_rules": {
+        "expression": "service_type == 'llm'"
+    },
+    "status": "private"
+}
+```
+
+**Group targeting a specific provider:**
+```json
+{
+    "schema": "service_group_v1",
+    "name": "openai-models",
+    "display_name": "OpenAI Models",
+    "description": "All services from OpenAI",
+    "membership_rules": {
+        "expression": "provider_name == 'openai'"
+    },
+    "status": "active"
+}
+```
+
+### CLI Commands
+
+**Upload groups:**
+```bash
+# Upload all group files in directory
+usvc_seller data upload --type groups
+
+# Upload a specific file
+usvc_seller data upload data/groups/my-llm-services.json
+
+# Dry run (validate without uploading)
+usvc_seller data upload --type groups --dryrun
+```
+
+**Validate groups:**
+```bash
+usvc_seller data validate data/groups/
+```
+
+### File Organization
+
+Place group files in a `groups/` directory within your data directory:
+
+```
+data/
+├── providers/
+│   └── my-provider/
+│       ├── provider.toml
+│       └── services/
+│           └── ...
+├── promotions/
+│   └── summer-sale.json
+└── groups/
+    ├── my-llm-services.json
+    └── premium-models.json
+```
+
+### Using Groups with Promotions
+
+Groups are referenced in promotion scope to target services:
+
+```json
+{
+    "schema": "promotion_v1",
+    "name": "LLM Discount",
+    "pricing": {"type": "multiply", "factor": "0.80"},
+    "scope": {
+        "services": ["my-llm-services"]
+    }
+}
+```
+
+This applies the 20% discount to all services in the `my-llm-services` group.
+As services join or leave the group (based on membership rules), the promotion
+automatically applies to the current members.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,253 @@
+# Getting Started
+
+This guide will help you get started with managing your UnitySVC seller service data.
+
+## Two Ways to Manage Service Data
+
+UnitySVC provides two complementary approaches:
+
+### 1. Web Interface (Recommended for Getting Started)
+
+The [UnitySVC web platform](https://unitysvc.com) provides a user-friendly interface to:
+
+- Create, edit, and manage providers, offerings, and listings
+- Validate data with instant feedback
+- Preview how services appear to customers
+- Export data for use with the SDK
+
+### 2. SDK (This Package)
+
+The SDK enables a **local-first, version-controlled workflow** with key advantages:
+
+- **Version Control** - Track all changes in git, review diffs, roll back mistakes
+- **Script-Based Generation** - Programmatically generate services from provider APIs
+- **CI/CD Automation** - Automatically upload updates and manage service lifecycle via GitHub Actions
+- **Offline Work** - Edit locally, validate without network, upload when ready
+- **Code Review** - Use pull requests to review service changes before uploading
+- **Service Lifecycle** - Submit services for review, deprecate outdated services, withdraw services from marketplace
+
+**Recommended workflow**: Start with the web interface to create initial data, then use the SDK for ongoing management and automation.
+
+## Installation
+
+### Requirements
+
+- Python 3.11 or later
+- pip or uv package manager
+
+### Install from PyPI
+
+```bash
+pip install unitysvc-sellers
+```
+
+### Verify Installation
+
+```bash
+usvc_seller --help
+# Or using the full command name:
+unitysvc_sellers --help
+```
+
+You should see the command-line interface help output.
+
+**Note:** The command `unitysvc_sellers` can be invoked using the shorter alias `usvc_seller`. All examples below use the shorter `usvc_seller` alias.
+
+## Prerequisites: Create Your Seller Account
+
+Before uploading services, you need a seller role on the UnitySVC platform:
+
+1. **Sign up** at [https://unitysvc.com](https://unitysvc.com)
+2. **Add a seller role** - go to "Add a role", select "Become a seller", and wait for approval
+3. **Generate a seller API key** - this key contains your seller identity
+
+The seller API key is used for all upload and service management operations. The platform automatically associates your providers, offerings, and listings with your seller account.
+
+## Understanding the Service Data Model
+
+Before creating your first service, understand how UnitySVC structures service data:
+
+```mermaid
+flowchart TB
+    subgraph Service["Uploaded Together"]
+        P["<b>Provider Data</b><br/>WHO provides<br/><i>provider_v1</i>"]
+        O["<b>Offering Data</b><br/>WHAT is provided<br/><i>offering_v1</i>"]
+        L["<b>Listing Data</b><br/>HOW it's sold<br/><i>listing_v1</i>"]
+    end
+
+    P --> O --> L
+
+    style P fill:#e3f2fd
+    style O fill:#fff3e0
+    style L fill:#e8f5e9
+```
+
+These three parts are **organized separately** for reusability but **uploaded together** as a unified service:
+
+| Component         | Purpose                                             | Reusability                                 |
+| ----------------- | --------------------------------------------------- | ------------------------------------------- |
+| **Provider Data** | Identity, contact info, terms of service            | One per provider, shared by all offerings   |
+| **Offering Data** | Service definition, API endpoints, upstream pricing | One per service, can have multiple listings |
+| **Listing Data**  | Customer-facing info, documentation, pricing        | One per pricing tier or marketplace         |
+
+## Quick Start: Your First Service
+
+```mermaid
+flowchart TD
+    subgraph local["Local (usvc_seller data ...)"]
+        S1["1. Create repo"]
+        S2["2. Define service data"]
+        S3["3. Validate & format"]
+        S4["4. Run local tests"]
+        S5["5. Upload"]
+        S1 --> S2 --> S3 --> S4 --> S5
+    end
+
+    S5 --> S6
+
+    subgraph remote["Remote (usvc_seller services ...)"]
+        S6["6. Run remote tests"]
+        S7["7. Submit for review"]
+        S6 --> S7
+    end
+
+    S7 -. "rejected / failed" .-> S2
+
+    style local fill:#e3f2fd,stroke:#1565c0
+    style remote fill:#e8f5e9,stroke:#2e7d32
+```
+
+### Step 1: Create a Local Repository
+
+Create a new repository from the [unitysvc-sellers-template](https://github.com/unitysvc/unitysvc-sellers-template), which provides the directory structure, CI/CD workflows, and example files. Alternatively, fork any of the publicly available service repositories under the [unitysvc GitHub organization](https://github.com/unitysvc) (e.g., `unitysvc-sellers-openai`, `unitysvc-sellers-groq`) and adapt them to your provider.
+
+Your repository should follow this structure:
+
+```
+data/
+└── my-provider/
+    ├── provider.toml          # Provider Data
+    └── services/
+        └── my-service/
+            ├── offering.toml  # Offering Data
+            └── listing.toml   # Listing Data
+```
+
+### Step 2: Define Your Service Data
+
+There are several ways to create and edit your provider, offering, and listing files:
+
+1. **Manually** — follow the [File Schemas](file-schemas.md) reference and existing examples in the template or forked repository
+2. **Web interface** — use the [UnitySVC web platform](https://unitysvc.com) to fill in forms for your provider, offering, and listing, then export as JSON/TOML files
+3. **AI-assisted** — ask Claude Code or another AI assistant to familiarize itself with the [unitysvc-sellers documentation](https://unitysvc-sellers.readthedocs.io) (or even the SDK source code), then have it prepare the data files for you
+
+### Step 3: Validate and Format
+
+```bash
+# Validate your data against schemas
+usvc_seller data validate
+
+# Optional: auto-format for consistent style (helps with cleaner git diffs)
+usvc_seller data format
+```
+
+Fix any validation errors before proceeding.
+
+### Step 4: Run Local Tests (Required)
+
+```bash
+usvc_seller data run-tests
+```
+
+Local tests run your code examples and connectivity checks against real upstream endpoints. Provide any required secrets as environment variables:
+
+```bash
+# For managed services
+export PROVIDER_API_KEY="sk-..."
+usvc_seller data run-tests
+
+# For BYOK services
+export GROQ_API_KEY="gsk_..."
+usvc_seller data run-tests data/groq/services/llama-3.3-70b-versatile-byok
+```
+
+All tests must pass before uploading.
+
+### Step 5: Upload to UnitySVC Platform
+
+Set your credentials using your **seller API key**:
+
+```bash
+export UNITYSVC_API_URL="https://api.unitysvc.com/v1"
+export UNITYSVC_SELLER_API_KEY="svcpass_your_seller_api_key"
+```
+
+Upload your services:
+
+```bash
+usvc_seller data upload
+
+# Or specify path
+usvc_seller data upload --data-path ./data
+
+# Or upload a single listing
+usvc_seller data upload --data-path ./data/my-provider/services/my-service/listing.toml
+```
+
+### Step 6: Run Remote Tests (Required)
+
+```bash
+usvc_seller services run-tests <service-id>
+```
+
+Remote tests run against the live platform, verifying that the service works end-to-end through the gateway. Tests must pass (or be explicitly skipped) before submission.
+
+### Step 7: Submit for Review
+
+```bash
+usvc_seller services submit <service-id>
+```
+
+This submits your service for platform review. Once approved, the service goes live on the marketplace.
+
+!!! tip "Iterate until approved"
+    If any step fails or the submission is rejected, fix the issues and repeat from the relevant step. The typical cycle is: edit → validate → test locally → upload → test remotely → submit.
+
+## Next Steps
+
+- **[Data Structure](data-structure.md)** - Learn about the Service Data model and file organization
+- **[Workflows](workflows.md)** - Explore manual and automated workflows
+- **[CLI Reference](cli-reference.md)** - Browse all available commands
+
+## Troubleshooting
+
+### Validation Errors
+
+- Check that directory names match normalized field values
+- Ensure all required fields are present
+- Verify file paths are correct (relative paths)
+
+### Upload Errors
+
+- Verify API credentials are set correctly
+- Ensure backend URL is accessible
+- Check that listing files have corresponding offering and provider files
+- Check that you're running from the correct directory or using `--data-path`
+
+### "Provider not found" Errors
+
+This typically means:
+
+- The provider file is missing or not in the expected location (parent of `services/`)
+- The provider file has `status: draft` (draft providers are skipped)
+
+### Format Issues
+
+- Run `usvc_seller data format --check` to see what would change
+- Use `usvc_seller data format` to auto-fix formatting
+
+## Getting Help
+
+- Check the [CLI Reference](cli-reference.md) for command details
+- Review [Data Structure](data-structure.md) for file organization rules
+- Open an issue on [GitHub](https://github.com/unitysvc/unitysvc-sellers/issues)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,109 @@
+# UnitySVC Seller SDK Documentation
+
+Welcome to the UnitySVC Seller SDK documentation. The
+`unitysvc-sellers` package gives digital service providers two
+complementary ways to manage their catalog on the UnitySVC platform:
+
+-   The **`usvc_seller` CLI** — a local-first, version-controlled
+    workflow for authoring, validating, uploading, and testing
+    seller catalogs from the command line.
+-   The **Python SDK** (`unitysvc_sellers.Client` / `AsyncClient`) — a
+    typed HTTP client that powers the CLI and can be embedded in
+    your own scripts, CI/CD jobs, or applications.
+
+Both talk to the same `/v1/seller/*` HTTP API, so you can mix and
+match freely.
+
+## Quick Links
+
+-   **[Getting Started](getting-started.md)** - Installation and first steps
+-   **[Data Structure](data-structure.md)** - Understanding the Service Data model
+-   **[CLI Reference](cli-reference.md)** - Complete command-line interface guide
+-   **[SDK Reference](sdk-reference.md)** - Python `Client` / `AsyncClient`, resources, and examples
+-   **[Workflows](workflows.md)** - Common usage patterns and best practices
+
+## What the package gives you
+
+-   **Define** service offerings and listings using schema-validated files
+-   **Manage** service data locally in version-controlled repositories
+-   **Validate** data against JSON schemas before uploading
+-   **Upload** services to the UnitySVC platform (CLI or SDK)
+-   **Manage Lifecycle** - Submit services for review, deprecate, or withdraw
+-   **Automate** — embed catalog operations into your own scripts via
+    the typed Python SDK
+
+## Types of Services
+
+The UnitySVC platform can route a wide variety of digital services, such as AI/ML APIs, email delivery, file/media content, compute environments, database access, monitoring, and scheduled tasks — across HTTP, S3, SMTP, and SSH protocols. See [Service Types](service-types.md) for full specification and examples.
+
+| Type | Description | Enrollment? | Examples |
+|------|-------------|:-----------:|---------|
+| **Managed** | Seller provides upstream credentials | No | LLM inference (OpenAI, Anthropic), embedding APIs, image generation, translation |
+| **BYOK** (Bring Your Own Key) | Customer provides their own API key for a cloud provider | No | Groq, Together AI, Fireworks with customer's own account |
+| **BYOE** (Bring Your Own Endpoint) | Customer provides the URL of their self-hosted instance | Yes | Self-hosted Ollama/vLLM, on-premise inference, private deployments |
+| **With User Parameters** | Customer provides configuration during enrollment; combinable with any type above | Yes | Model preferences, region selection, custom labels |
+| **Recurrent** | Scheduled execution at configured intervals; combinable with any type above | Yes | Uptime monitoring, daily ETL sync, weekly report generation |
+
+Services can be **stateless** (each request independent — most inference APIs) or **stateful** (maintaining history across requests — e.g., recommendation models, conversation context, analytics). In all cases, **no customer credentials or identity are passed to the upstream provider** — the gateway authenticates the customer separately and forwards only the request payload and upstream credentials.
+
+UnitySVC handles **enrollment**, **service delivery via the API gateway**, and **billing** so that service providers can focus entirely on building and operating their digital services. Sellers do not need to build authentication, payment processing, usage metering, or customer management — the platform provides all of this. Sellers define their service endpoints, pricing, and parameters; UnitySVC takes care of routing requests, tracking usage, generating invoices, and processing payouts.
+
+UnitySVC supports flexible seller business models, including **metered payouts** (sellers earn based on actual usage), **proportional payouts** (a percentage of what customers pay), **promotions** (reducing customer pricing via price rules), and **seller-funded incentives** (sellers pay the platform to offer free or discounted access for service testing and customer acquisition).
+
+## The Service Data Model
+
+Sellers provide services through UnitySVC by uploading service specifications using this SDK. A service specification consists of three complementary data components that work together:
+
+| Component | Schema | Purpose | Reusability |
+|-----------|--------|---------|-------------|
+| **Provider Data** | `provider_v1` | WHO provides the service | One per provider, shared by all offerings |
+| **Offering Data** | `offering_v1` | WHAT is being provided | One per service, can have multiple listings |
+| **Listing Data** | `listing_v1` | HOW it's sold to customers | One per pricing tier/marketplace |
+
+These three parts are **organized separately** in the file system for reusability, but are **uploaded together** as a unified service to the UnitySVC platform.
+
+### Why This Structure?
+
+-   **Provider Data** contains identity, contact info, and terms of service - defined once and reused
+-   **Offering Data** defines the service itself, API endpoints, and upstream pricing
+-   **Listing Data** defines customer-facing presentation, documentation, and pricing
+
+This enables scenarios like:
+- One provider with multiple service offerings
+- One offering with multiple listings (e.g., basic/premium tiers)
+- Shared documentation across services
+
+## Key Features
+
+-   **Unified Upload** — Provider, offering, and listing uploaded together atomically
+-   **Service Lifecycle** — Submit for review, deprecate, or withdraw services
+-   **Typed SDK** — `Client` / `AsyncClient` with fully typed request/response models generated from the seller OpenAPI spec
+-   **Data Validation** — Comprehensive schema validation before upload
+-   **Local-First CLI** — Work offline, commit to git, upload when ready
+-   **Automation** — Script-based service generation and CI/CD integration
+-   **Multiple Formats** — Support for JSON and TOML catalog files
+-   **Smart Routing** — Request routing based on routing keys (e.g., model-specific endpoints)
+
+## Documentation Overview
+
+### For New Users
+
+1. [**Getting Started**](getting-started.md) - Install the package, create your first service, and upload it
+2. [**Data Structure**](data-structure.md) - Learn about the Service Data model and file organization
+3. [**Workflows**](workflows.md) - Manual, web-assisted, and automated catalog-authoring patterns
+
+### For Reference
+
+-   [**CLI Reference**](cli-reference.md) - All `usvc_seller` commands and options
+-   [**SDK Reference**](sdk-reference.md) - `Client`, `AsyncClient`, resource namespaces, and end-to-end examples
+-   [**File Schemas**](file-schemas.md) - Detailed schema specifications for provider / offering / listing files
+
+## Community & Support
+
+-   **GitHub**: [unitysvc/unitysvc-sellers](https://github.com/unitysvc/unitysvc-sellers)
+-   **Issues**: [Report bugs or request features](https://github.com/unitysvc/unitysvc-sellers/issues)
+-   **PyPI**: [unitysvc-sellers](https://pypi.org/project/unitysvc-sellers/)
+
+## License
+
+This project is licensed under the MIT License.

--- a/docs/pricing.md
+++ b/docs/pricing.md
@@ -1,0 +1,1190 @@
+# Pricing Specification
+
+This document describes the pricing structure used for `payout_price` (in service files) and `list_price` (in listing files).
+
+## Overview
+
+UnitySVC uses a two-tier pricing model:
+
+- **Seller Price** (`payout_price` in `offering_v1`): The agreed rate between the seller and UnitySVC. This is what the seller charges UnitySVC for each unit of service usage.
+- **Customer Price** (`list_price` in `listing_v1`): The price shown to customers on the marketplace. This is what the customer pays for each unit of service usage.
+
+Both use the same `Pricing` structure, which supports multiple pricing types through a discriminated union based on the `type` field.
+
+> **Important: Use String Values for Prices**
+>
+> All price values (`price`, `input`, `output`) should be specified as **strings** (e.g., `"0.50"`) rather than floating-point numbers. This avoids floating-point precision issues where values like `2.0` might become `1.9999999` when saved and loaded.
+
+## Multi-Currency Support
+
+Currency is specified at the **service/listing level**, not inside the pricing object:
+
+- **Service** (ServiceOffering): Has ONE `payout_price` with ONE currency
+- **Listing** (ServiceListing): Has ONE `list_price` with ONE currency
+- **Multiple currencies**: Create multiple listings pointing to the same service
+
+```
+ServiceOffering (gpt-4-turbo)
+├── payout_price (USD)
+
+ServiceListing (gpt-4-turbo-usd)
+├── currency: USD
+└── list_price
+
+ServiceListing (gpt-4-turbo-eur)
+├── currency: EUR
+└── list_price
+```
+
+### Currency Field Location
+
+| Level           | Field      | Description                                     |
+| --------------- | ---------- | ----------------------------------------------- |
+| ServiceOffering | `currency` | Currency for payout_price                       |
+| ServiceListing  | `currency` | Currency for list_price (indexed for filtering) |
+
+## Pricing Object Structure
+
+Acceptable fields of the Pricing object are based on the `type` field.
+
+```
+Pricing
+├── type          (required) - Pricing type discriminator
+├── description   (optional) - Human-readable pricing description
+├── reference     (optional) - URL to upstream pricing page
+└── [type-specific fields]
+```
+
+### Common Fields
+
+| Field         | Type   | Required | Description                                     |
+| ------------- | ------ | -------- | ----------------------------------------------- |
+| `type`        | string | **Yes**  | Pricing type (discriminator)                    |
+| `description` | string | No       | Human-readable description of the pricing model |
+| `reference`   | string | No       | URL to upstream provider's pricing page         |
+
+---
+
+## Per-Request Pricing Types
+
+These pricing types calculate cost based on usage data from a single API request. They are suitable for both `list_price` and `payout_price`.
+
+**Available metrics for per-request pricing:**
+
+| Metric               | Equivalence Group | Description                   | Source    |
+| -------------------- | ----------------- | ----------------------------- | --------- |
+| `input_tokens`       | —                 | Number of input tokens        | UsageData |
+| `output_tokens`      | —                 | Number of output tokens       | UsageData |
+| `total_tokens`       | —                 | Total tokens (input + output) | UsageData |
+| `one_token`          | tokens            | Token count (raw)             | UsageData |
+| `one_thousand_tokens`| tokens            | Token count (in thousands)    | UsageData |
+| `one_million_tokens` | tokens            | Token count (in millions)     | UsageData |
+| `seconds`            | time              | Duration in seconds           | UsageData |
+| `one_second`         | time              | Duration in seconds           | UsageData |
+| `one_minute`         | time              | Duration in minutes           | UsageData |
+| `one_hour`           | time              | Duration in hours             | UsageData |
+| `one_day`            | time              | Duration in days              | UsageData |
+| `one_month`          | time              | Duration in months (30 days)  | UsageData |
+| `one_byte`           | data              | Data volume in bytes          | UsageData |
+| `one_kilobyte`       | data              | Data volume in KB (1024 B)    | UsageData |
+| `one_megabyte`       | data              | Data volume in MB             | UsageData |
+| `one_gigabyte`       | data              | Data volume in GB             | UsageData |
+| `count`              | count             | Count (images, steps, etc.)   | UsageData |
+| `one_thousand`       | count             | Count in thousands            | UsageData |
+| `one_million`        | count             | Count in millions             | UsageData |
+
+> **Equivalence Groups:** Metrics in the same equivalence group measure the same dimension and convert automatically. For example, pricing in `one_hour` accepts usage provided in `one_minute` or `seconds`. See [Equivalence Groups](#equivalence-groups) for details.
+
+### Token-Based Pricing (`one_million_tokens`, `one_thousand_tokens`, `one_token`)
+
+For LLM and text-based services. Prices are per unit of tokens at the chosen scale.
+
+**Allowed types:** `one_million_tokens` (default), `one_thousand_tokens`, `one_token`
+
+These types belong to the **tokens** equivalence group — usage provided in any token unit is converted automatically.
+
+**Fields:**
+
+| Field          | Type   | Required    | Description                                         |
+| -------------- | ------ | ----------- | --------------------------------------------------- |
+| `type`         | string | **Yes**     | `"one_million_tokens"`, `"one_thousand_tokens"`, or `"one_token"` |
+| `price`        | string | Auto-computed | Summary price for marketplace comparison and sorting |
+| `input`        | string | \*          | Price per unit of input tokens                      |
+| `output`       | string | \*          | Price per unit of output tokens                     |
+| `cached_input` | string | No          | Price per unit of cached input tokens (discounted)  |
+
+**Pricing modes:**
+
+1. **Unified pricing**: Set `price` only — same rate for all token types. Used for billing.
+2. **Separate pricing**: Set `input` and `output` (and optionally `cached_input`). The `price` field is auto-computed as a summary for marketplace comparison if not explicitly set.
+
+**Summary price auto-computation:**
+
+When `input` and `output` are specified without `price`, the system automatically computes:
+
+```
+price = (input + 4 × output) / 5
+```
+
+This formula weights output tokens 4× higher than input, reflecting typical LLM usage where output tokens are more expensive and represent the dominant cost. Sellers can override by setting `price` explicitly.
+
+**Validation Rules:**
+
+- Must specify either `price` (unified) or both `input` and `output` (separate)
+- When using separate pricing, `price` is auto-computed if not set
+- Negative values are allowed for `payout_price` (seller-funded incentives)
+
+**Example - Unified Pricing:**
+
+```json
+{
+    "type": "one_million_tokens",
+    "price": "2.50",
+    "description": "Per million tokens"
+}
+```
+
+**Example - Separate Input/Output Pricing:**
+
+```json
+{
+    "type": "one_million_tokens",
+    "input": "3.00",
+    "output": "15.00",
+    "description": "Claude Sonnet pricing"
+}
+```
+
+In this example, `price` is auto-computed as `(3 + 4×15) / 5 = 12.60`. The marketplace displays **$12.60 / 1M tokens** for sorting and comparison.
+
+**Example - With Explicit Summary Price:**
+
+```json
+{
+    "type": "one_million_tokens",
+    "price": "9.00",
+    "input": "3.00",
+    "output": "15.00",
+    "description": "Seller-chosen comparison price"
+}
+```
+
+**Example - Negative Payout (Seller-Funded Incentive):**
+
+```json
+{
+    "type": "one_million_tokens",
+    "input": "-1.00",
+    "output": "-5.00",
+    "description": "Seller pays platform for free customer access"
+}
+```
+
+**TOML Example:**
+
+```toml
+[list_price]
+type = "one_million_tokens"
+input = "12.00"
+output = "36.00"
+description = "Customer token pricing"
+# price auto-computed as (12 + 4×36) / 5 = 31.20
+```
+
+### Time-Based Pricing (`one_second`, `one_minute`, `one_hour`, `one_day`, `one_month`)
+
+For audio/video processing, compute time, alias duration, and other time-based services.
+
+**Allowed types:** `one_second`, `one_minute`, `one_hour`, `one_day`, `one_month` (30 days)
+
+These types belong to the **time** equivalence group — usage provided in any time unit is converted automatically.
+
+**Fields:**
+
+| Field   | Type   | Required | Description                             |
+| ------- | ------ | -------- | --------------------------------------- |
+| `type`  | string | **Yes**  | One of the time unit types listed above |
+| `price` | string | **Yes**  | Price per one unit of the specified type |
+
+**Example - Per Second:**
+
+```json
+{
+    "type": "one_second",
+    "price": "0.006",
+    "description": "Audio transcription per second"
+}
+```
+
+**Example - Per Month (with cross-unit usage):**
+
+```json
+{
+    "type": "one_month",
+    "price": "1.00",
+    "description": "Alias fee per month, prorated by active seconds"
+}
+```
+
+Usage of `UsageData(one_hour=360)` with this pricing auto-converts: 360 hours / 720 hours per month = 0.5 months = $0.50.
+
+### Image Pricing (`image`)
+
+For image generation, processing, and analysis services.
+
+**Fields:**
+
+| Field   | Type   | Required | Description       |
+| ------- | ------ | -------- | ----------------- |
+| `type`  | string | **Yes**  | Must be `"image"` |
+| `price` | string | **Yes**  | Price per image   |
+
+**Example:**
+
+```json
+{
+    "type": "image",
+    "price": "0.04",
+    "description": "DALL-E 3 image generation"
+}
+```
+
+### Step-Based Pricing (`step`)
+
+For diffusion models, iterative processes, and other step-based services.
+
+**Fields:**
+
+| Field   | Type   | Required | Description              |
+| ------- | ------ | -------- | ------------------------ |
+| `type`  | string | **Yes**  | Must be `"step"`         |
+| `price` | string | **Yes**  | Price per step/iteration |
+
+**Example:**
+
+```json
+{
+    "type": "step",
+    "price": "0.001",
+    "description": "Diffusion model steps"
+}
+```
+
+### Data-Volume Pricing (`one_byte`, `one_kilobyte`, `one_megabyte`, `one_gigabyte`)
+
+For bandwidth, storage, transfer, and other data-volume services. Uses binary units (1 KB = 1024 bytes).
+
+**Allowed types:** `one_byte`, `one_kilobyte`, `one_megabyte` (default), `one_gigabyte`
+
+These types belong to the **data** equivalence group — usage provided in any data unit is converted automatically.
+
+**Fields:**
+
+| Field   | Type   | Required | Description                             |
+| ------- | ------ | -------- | --------------------------------------- |
+| `type`  | string | **Yes**  | One of the data unit types listed above |
+| `price` | string | **Yes**  | Price per one unit of the specified type |
+
+**Example:**
+
+```json
+{
+    "type": "one_gigabyte",
+    "price": "0.10",
+    "description": "Data transfer per GB"
+}
+```
+
+### Count-Scaled Pricing (`one_thousand`, `one_million`)
+
+For API calls, events, requests, and other count-based services at scale. For simple per-item count pricing, use `image` or `step` instead.
+
+**Allowed types:** `one_thousand`, `one_million`
+
+These types belong to the **count** equivalence group (along with `count`) — usage provided as `count`, `one_thousand`, or `one_million` is converted automatically.
+
+**Fields:**
+
+| Field   | Type   | Required | Description                              |
+| ------- | ------ | -------- | ---------------------------------------- |
+| `type`  | string | **Yes**  | `"one_thousand"` or `"one_million"`      |
+| `price` | string | **Yes**  | Price per one unit of the specified type  |
+
+**Example:**
+
+```json
+{
+    "type": "one_thousand",
+    "price": "0.50",
+    "description": "Per 1,000 API requests"
+}
+```
+
+### Constant Pricing (`constant`)
+
+A fixed price per request that doesn't depend on usage metrics.
+
+> **Note:** When used for `list_price`, this price is charged **per API request**. For example, `"price": "0.01"` means the customer pays $0.01 for each request they make.
+
+**Fields:**
+
+| Field    | Type   | Required | Description                                              |
+| -------- | ------ | -------- | -------------------------------------------------------- |
+| `type`   | string | **Yes**  | Must be `"constant"`                                     |
+| `price`  | string | **Yes**  | Fixed price (positive for charge, negative for discount) |
+
+**Example - Per-Request Fee:**
+
+```json
+{
+    "type": "constant",
+    "price": "0.01",
+    "description": "Per-request fee"
+}
+```
+
+---
+
+## Equivalence Groups
+
+Units within the same equivalence group measure the same dimension and convert to each other automatically. When a pricing type specifies one unit (e.g., `one_hour`) but usage data provides a different unit from the same group (e.g., `one_minute`), the system converts automatically before calculating cost.
+
+This applies both to direct pricing types (e.g., `TimePriceData`) and to the `based_on` field in tiered/graduated pricing.
+
+| Group      | Units                                                           | Base Unit | Conversion                |
+| ---------- | --------------------------------------------------------------- | --------- | ------------------------- |
+| **time**   | `seconds`, `one_second`, `one_minute`, `one_hour`, `one_day`, `one_month` | seconds   | Standard time factors     |
+| **tokens** | `one_token`, `one_thousand_tokens`, `one_million_tokens`        | tokens    | ×1, ×1,000, ×1,000,000    |
+| **data**   | `one_byte`, `one_kilobyte`, `one_megabyte`, `one_gigabyte`      | bytes     | Binary (×1024 per step)   |
+| **count**  | `count`, `one_thousand`, `one_million`                          | 1         | ×1, ×1,000, ×1,000,000    |
+
+**Cross-group conversion is not allowed.** Providing time usage with data pricing (or any other mismatch) raises a `ValueError`.
+
+**Example — graduated pricing in minutes, usage in hours:**
+
+```json
+{
+    "type": "graduated",
+    "based_on": "one_minute",
+    "tiers": [
+        { "up_to": 60, "unit_price": "0" },
+        { "up_to": null, "unit_price": "0.10" }
+    ]
+}
+```
+
+With `UsageData(one_hour=2)`: 2 hours = 120 minutes. First 60 free, next 60 at $0.10 = $6.00.
+
+---
+
+## Volume Pricing Types
+
+These pricing types are designed for `payout_price` to handle volume-based billing over a billing period. They use aggregate metrics like `request_count` (total requests in billing period) or combine multiple pricing components.
+
+> **Note:** While `add` and `multiply` can technically be used for `list_price` when wrapping per-request types, `tiered` and `graduated` with `based_on: "request_count"` are seller-only.
+
+**Additional metrics available for volume pricing:**
+
+| Metric          | Description                              | Availability |
+| --------------- | ---------------------------------------- | ------------ |
+| `request_count` | Number of API requests in billing period | Seller only  |
+
+### Constant Pricing (`constant`) - Billing Period
+
+When used in volume pricing contexts (e.g., inside `tiered` tiers or combined with `add`), `constant` represents a fixed amount for the billing period rather than per request.
+
+**Example - Flat monthly fee based on tier:**
+
+```json
+{
+    "type": "tiered",
+    "based_on": "request_count",
+    "tiers": [
+        { "up_to": 1000, "price": { "type": "constant", "price": "10.00" } },
+        { "up_to": 10000, "price": { "type": "constant", "price": "50.00" } },
+        { "up_to": null, "price": { "type": "constant", "price": "200.00" } }
+    ],
+    "description": "Flat monthly fee based on request volume"
+}
+```
+
+### Add Pricing (`add`)
+
+Combines multiple pricing components by summing them together. Useful for base price + fees, or combining different pricing models.
+
+**Fields:**
+
+| Field    | Type   | Required | Description                             |
+| -------- | ------ | -------- | --------------------------------------- |
+| `type`   | string | **Yes**  | Must be `"add"`                         |
+| `prices` | array  | **Yes**  | List of pricing objects to sum together |
+
+**Example - Token pricing with per-request fee:**
+
+```json
+{
+    "type": "add",
+    "prices": [
+        { "type": "one_million_tokens", "input": "0.50", "output": "1.50" },
+        {
+            "type": "constant",
+            "price": "0.001",
+            "description": "Per-request fee"
+        }
+    ]
+}
+```
+
+**Example - Graduated pricing for both input and output tokens:**
+
+```json
+{
+    "type": "add",
+    "prices": [
+        {
+            "type": "graduated",
+            "based_on": "input_tokens",
+            "tiers": [
+                { "up_to": 1000000, "unit_price": "0.000001" },
+                { "up_to": null, "unit_price": "0.0000005" }
+            ]
+        },
+        {
+            "type": "graduated",
+            "based_on": "output_tokens",
+            "tiers": [
+                { "up_to": 1000000, "unit_price": "0.000003" },
+                { "up_to": null, "unit_price": "0.0000015" }
+            ]
+        }
+    ],
+    "description": "Graduated token pricing with separate input/output rates"
+}
+```
+
+### Multiply Pricing (`multiply`)
+
+Applies a multiplier to a base pricing model. Useful for percentage-based adjustments.
+
+**Fields:**
+
+| Field    | Type   | Required | Description                                  |
+| -------- | ------ | -------- | -------------------------------------------- |
+| `type`   | string | **Yes**  | Must be `"multiply"`                         |
+| `factor` | string | **Yes**  | Multiplication factor (e.g., "0.70" for 70%) |
+| `base`   | object | **Yes**  | Base pricing object to multiply              |
+
+**Example - 70% of standard pricing:**
+
+```json
+{
+    "type": "multiply",
+    "factor": "0.70",
+    "base": { "type": "one_million_tokens", "input": "1.00", "output": "2.00" },
+    "description": "Partner discount (30% off)"
+}
+```
+
+### Max Pricing (`max`)
+
+Charges the **highest** cost among multiple pricing calculations. Useful for "charge by count OR by duration, whichever is higher" patterns.
+
+**Lenient:** Children that can't process the usage (e.g., missing metric) are silently skipped. At least one child must succeed.
+
+**Fields:**
+
+| Field    | Type   | Required | Description                                         |
+| -------- | ------ | -------- | --------------------------------------------------- |
+| `type`   | string | **Yes**  | Must be `"max"`                                     |
+| `prices` | array  | **Yes**  | List of pricing objects — the highest result is used |
+
+**Example — charge per-count OR per-duration, whichever is higher:**
+
+```json
+{
+    "type": "max",
+    "prices": [
+        { "type": "image", "price": "0.05" },
+        { "type": "one_second", "price": "0.01" }
+    ],
+    "description": "Higher of per-image or per-second charge"
+}
+```
+
+### Min Pricing (`min`)
+
+Charges the **lowest** cost among multiple pricing calculations. Useful for price caps — usage-based pricing but never more than a flat rate.
+
+**Lenient:** Children that can't process the usage are silently skipped.
+
+**Fields:**
+
+| Field    | Type   | Required | Description                                        |
+| -------- | ------ | -------- | -------------------------------------------------- |
+| `type`   | string | **Yes**  | Must be `"min"`                                    |
+| `prices` | array  | **Yes**  | List of pricing objects — the lowest result is used |
+
+**Example — usage-based pricing capped at $100:**
+
+```json
+{
+    "type": "min",
+    "prices": [
+        { "type": "one_second", "price": "0.10" },
+        { "type": "constant", "price": "100.00" }
+    ],
+    "description": "Per-second pricing capped at $100"
+}
+```
+
+### First Pricing (`first`)
+
+Returns the cost from the **first** child pricing that can handle the usage. Tries each child in order; the first one that succeeds wins.
+
+**Lenient:** Children that raise errors are skipped until one succeeds.
+
+Useful when pricing should adapt to whatever metric the caller provides (duration OR count, etc.).
+
+**Fields:**
+
+| Field    | Type   | Required | Description                                                  |
+| -------- | ------ | -------- | ------------------------------------------------------------ |
+| `type`   | string | **Yes**  | Must be `"first"`                                            |
+| `prices` | array  | **Yes**  | List of pricing objects — the first successful result is used |
+
+**Example — charge by duration if available, otherwise by count:**
+
+```json
+{
+    "type": "first",
+    "prices": [
+        { "type": "one_second", "price": "0.01" },
+        { "type": "image", "price": "0.05" }
+    ],
+    "description": "Duration-based if available, otherwise per-image"
+}
+```
+
+### Tiered Pricing (`tiered`)
+
+Volume-based pricing where the tier determines the price for ALL usage. Once you cross a threshold, all units are priced at that tier's rate.
+
+**Fields:**
+
+| Field      | Type   | Required | Description                              |
+| ---------- | ------ | -------- | ---------------------------------------- |
+| `type`     | string | **Yes**  | Must be `"tiered"`                       |
+| `based_on` | string | **Yes**  | Metric for tier selection                |
+| `tiers`    | array  | **Yes**  | List of tier objects, ordered by `up_to` |
+
+**Tier Object:**
+
+| Field   | Type    | Required | Description                                      |
+| ------- | ------- | -------- | ------------------------------------------------ |
+| `up_to` | integer | **Yes**  | Upper limit for this tier (`null` for unlimited) |
+| `price` | object  | **Yes**  | Pricing object for this tier                     |
+
+**Example - Fixed price tiers based on request volume:**
+
+```json
+{
+    "type": "tiered",
+    "based_on": "request_count",
+    "tiers": [
+        { "up_to": 1000, "price": { "type": "constant", "price": "10.00" } },
+        { "up_to": 10000, "price": { "type": "constant", "price": "80.00" } },
+        { "up_to": null, "price": { "type": "constant", "price": "500.00" } }
+    ],
+    "description": "Volume-based flat pricing"
+}
+```
+
+**How it works:**
+
+- 500 requests → Tier 1 → $10.00
+- 5,000 requests → Tier 2 → $80.00
+- 50,000 requests → Tier 3 → $500.00
+
+**Example - Different token rates based on request volume:**
+
+```json
+{
+    "type": "tiered",
+    "based_on": "request_count",
+    "tiers": [
+        {
+            "up_to": 1000,
+            "price": {
+                "type": "one_million_tokens",
+                "input": "3.00",
+                "output": "15.00"
+            }
+        },
+        {
+            "up_to": null,
+            "price": {
+                "type": "one_million_tokens",
+                "input": "1.50",
+                "output": "7.50"
+            }
+        }
+    ],
+    "description": "Volume discount on token pricing"
+}
+```
+
+### Graduated Pricing (`graduated`)
+
+AWS-style pricing where each tier's units are priced at that tier's rate. You always pay the higher rate for the first N units, regardless of total volume.
+
+**Fields:**
+
+| Field      | Type   | Required | Description                              |
+| ---------- | ------ | -------- | ---------------------------------------- |
+| `type`     | string | **Yes**  | Must be `"graduated"`                    |
+| `based_on` | string | **Yes**  | Metric for tier calculation              |
+| `tiers`    | array  | **Yes**  | List of tier objects, ordered by `up_to` |
+
+**Graduated Tier Object:**
+
+| Field        | Type    | Required | Description                                      |
+| ------------ | ------- | -------- | ------------------------------------------------ |
+| `up_to`      | integer | **Yes**  | Upper limit for this tier (`null` for unlimited) |
+| `unit_price` | string  | **Yes**  | Price per unit in this tier                      |
+
+**Example - Per-request graduated pricing:**
+
+```json
+{
+    "type": "graduated",
+    "based_on": "request_count",
+    "tiers": [
+        { "up_to": 1000, "unit_price": "0.01" },
+        { "up_to": 10000, "unit_price": "0.008" },
+        { "up_to": null, "unit_price": "0.005" }
+    ],
+    "description": "Graduated per-request pricing"
+}
+```
+
+**How it works (5,000 requests):**
+
+- First 1,000 × $0.01 = $10.00
+- Next 4,000 × $0.008 = $32.00
+- **Total = $42.00**
+
+**Example - First 1 million requests free, then pay per request:**
+
+```json
+{
+    "type": "graduated",
+    "based_on": "request_count",
+    "tiers": [
+        { "up_to": 1000000, "unit_price": "0" },
+        { "up_to": null, "unit_price": "0.00001" }
+    ],
+    "description": "First 1M requests free, then $0.00001 per request"
+}
+```
+
+### Tiered vs Graduated: Key Difference
+
+| Model         | 5,000 requests                    | Result     |
+| ------------- | --------------------------------- | ---------- |
+| **Tiered**    | All 5,000 at tier 2 rate ($0.008) | **$40.00** |
+| **Graduated** | 1,000 × $0.01 + 4,000 × $0.008    | **$42.00** |
+
+- **Tiered (Volume)**: Rewards high volume - once you reach a tier, ALL units get that rate
+- **Graduated**: Each portion pays its tier's rate - first units always cost more
+
+### Expression-Based `based_on`
+
+Both `tiered` and `graduated` pricing support arithmetic expressions in the `based_on` field, enabling complex tier selection logic based on computed values rather than single metrics.
+
+**Supported Operations:**
+
+| Operation      | Example                              | Description                     |
+| -------------- | ------------------------------------ | ------------------------------- |
+| Addition       | `input_tokens + output_tokens`       | Sum of two metrics              |
+| Subtraction    | `total_tokens - input_tokens`        | Difference between metrics      |
+| Multiplication | `output_tokens * 4`                  | Metric multiplied by a factor   |
+| Division       | `input_tokens / 1000`                | Metric divided by a factor      |
+| Parentheses    | `(input_tokens + output_tokens) * 2` | Group operations for precedence |
+| Unary minus    | `input_tokens - -100`                | Negation                        |
+
+**Example - Weighted Token Pricing (output tokens cost 4x more):**
+
+```json
+{
+    "type": "tiered",
+    "based_on": "input_tokens + output_tokens * 4",
+    "tiers": [
+        { "up_to": 10000, "price": { "type": "constant", "price": "1.00" } },
+        { "up_to": null, "price": { "type": "constant", "price": "10.00" } }
+    ],
+    "description": "Higher tier when weighted token usage exceeds 10k"
+}
+```
+
+How it works:
+
+- 5000 input + 1000 output → 5000 + 4000 = 9000 → Tier 1 ($1.00)
+- 5000 input + 2000 output → 5000 + 8000 = 13000 → Tier 2 ($10.00)
+
+**Example - Combine Request Count and Token Usage:**
+
+```json
+{
+    "type": "tiered",
+    "based_on": "request_count * 100 + input_tokens",
+    "tiers": [
+        { "up_to": 10000, "price": { "type": "constant", "price": "1.00" } },
+        { "up_to": null, "price": { "type": "constant", "price": "5.00" } }
+    ],
+    "description": "Tier based on weighted combination of requests and tokens"
+}
+```
+
+**Error Handling:**
+
+Invalid expressions will raise errors at calculation time:
+
+- **Invalid syntax**: `"input_tokens +"` → `Invalid expression syntax`
+- **Unknown metric**: `"input_tokens + unknown_field"` → `Unknown metric: unknown_field`
+- **Unsupported operator**: `"input_tokens ** 2"` → `Unsupported operator: Pow`
+
+---
+
+## Seller-Only Pricing Types
+
+These pricing types use `customer_charge`, which is only available for `payout_price` calculations. This metric represents what the customer was charged and is used for revenue-sharing arrangements.
+
+> **Important:** These pricing types should **only** be used for `payout_price`. Using them for `list_price` will result in errors or undefined behavior.
+
+**Additional metrics available for seller pricing:**
+
+| Metric            | Description                          | Availability |
+| ----------------- | ------------------------------------ | ------------ |
+| `customer_charge` | Total amount charged to the customer | Seller only  |
+
+### Revenue Share Pricing (`revenue_share`)
+
+For revenue-sharing arrangements where the seller receives a percentage of the customer charge.
+
+**Fields:**
+
+| Field        | Type   | Required | Description                                          |
+| ------------ | ------ | -------- | ---------------------------------------------------- |
+| `type`       | string | **Yes**  | Must be `"revenue_share"`                            |
+| `percentage` | string | **Yes**  | Percentage of customer charge for the seller (0-100) |
+
+**How it works:**
+
+The `percentage` field represents the seller's share of whatever the customer pays. For example:
+
+- If `percentage` is `"70"` and the customer pays $10, the seller receives $7
+- If `percentage` is `"85.5"` and the customer pays $100, the seller receives $85.50
+
+**Example:**
+
+```json
+{
+    "type": "revenue_share",
+    "percentage": "70.00",
+    "description": "70% revenue share"
+}
+```
+
+**TOML Example:**
+
+```toml
+[payout_price]
+type = "revenue_share"
+percentage = "70.00"
+description = "70% revenue share"
+```
+
+**Use Cases:**
+
+- Marketplace arrangements where sellers want a fixed percentage rather than per-unit pricing
+- Reseller agreements with variable customer pricing
+- Partner programs with revenue-sharing terms
+
+### Expression Pricing (`expr`)
+
+Expression-based pricing that evaluates an arbitrary arithmetic expression using usage metrics. This is useful when the upstream provider's pricing involves complex calculations that can't be expressed with basic pricing types.
+
+**Fields:**
+
+| Field  | Type   | Required | Description                               |
+| ------ | ------ | -------- | ----------------------------------------- |
+| `type` | string | **Yes**  | Must be `"expr"`                          |
+| `expr` | string | **Yes**  | Arithmetic expression using usage metrics |
+
+**Available Metrics:**
+
+- `input_tokens`, `output_tokens`, `total_tokens` - Token counts
+- `seconds` - Time-based usage
+- `count` - Generic count (images, steps, etc.)
+- `request_count` - Number of API requests (seller only)
+- `customer_charge` - What the customer paid (seller only)
+
+**Supported Operations:**
+
+- Addition: `+`
+- Subtraction: `-`
+- Multiplication: `*`
+- Division: `/`
+- Parentheses: `(` `)`
+- Numeric literals: `1000000`, `0.5`, etc.
+
+**Example - Token Pricing with Different Rates:**
+
+```json
+{
+    "type": "expr",
+    "expr": "input_tokens / 1000000 * 0.50 + output_tokens / 1000000 * 1.50",
+    "description": "Custom token pricing"
+}
+```
+
+**Example - Complex Weighted Pricing:**
+
+```json
+{
+    "type": "expr",
+    "expr": "(input_tokens + output_tokens * 4) / 1000000 * 2.00",
+    "description": "Output tokens weighted 4x"
+}
+```
+
+**Example - Revenue Share as Expression:**
+
+```json
+{
+    "type": "expr",
+    "expr": "customer_charge * 0.70",
+    "description": "70% revenue share"
+}
+```
+
+**Example - Per-Request Fee:**
+
+```json
+{
+    "type": "expr",
+    "expr": "request_count * 0.001 + input_tokens / 1000000 * 0.50",
+    "description": "Per-request fee plus token cost"
+}
+```
+
+**TOML Example:**
+
+```toml
+[payout_price]
+type = "expr"
+expr = "input_tokens / 1000000 * 0.50 + output_tokens / 1000000 * 1.50"
+description = "Custom token pricing for seller"
+```
+
+---
+
+## Nested Composite Pricing
+
+Composite pricing types can be nested for complex scenarios:
+
+**Example - Graduated pricing with minimum fee:**
+
+```json
+{
+    "type": "add",
+    "prices": [
+        {
+            "type": "graduated",
+            "based_on": "request_count",
+            "tiers": [
+                { "up_to": 1000, "unit_price": "0.01" },
+                { "up_to": null, "unit_price": "0.005" }
+            ]
+        },
+        {
+            "type": "constant",
+            "price": "5.00",
+            "description": "Minimum monthly fee"
+        }
+    ]
+}
+```
+
+**Example - Tiered pricing with partner discount:**
+
+```json
+{
+    "type": "multiply",
+    "factor": "0.80",
+    "base": {
+        "type": "tiered",
+        "based_on": "request_count",
+        "tiers": [
+            {
+                "up_to": 10000,
+                "price": {
+                    "type": "one_million_tokens",
+                    "input": "1.00",
+                    "output": "2.00"
+                }
+            },
+            {
+                "up_to": null,
+                "price": {
+                    "type": "one_million_tokens",
+                    "input": "0.50",
+                    "output": "1.00"
+                }
+            }
+        ]
+    },
+    "description": "Partner pricing (20% discount on tiered rates)"
+}
+```
+
+---
+
+## Complete Examples
+
+### Service File with Seller Price (JSON)
+
+```json
+{
+    "schema": "offering_v1",
+    "name": "gpt-4-turbo",
+    "display_name": "GPT-4 Turbo",
+    "description": "OpenAI's most advanced model",
+    "service_type": "llm",
+    "currency": "USD",
+    "time_created": "2024-01-15T10:00:00Z",
+    "details": {
+        "context_window": 128000,
+        "max_output_tokens": 4096
+    },
+    "upstream_access_config": {
+        "OpenAI Chat API": {
+            "access_method": "http",
+            "base_url": "https://api.openai.com/v1/chat/completions"
+        }
+    },
+    "payout_price": {
+        "type": "one_million_tokens",
+        "input": "10.00",
+        "output": "30.00",
+        "description": "OpenAI GPT-4 Turbo pricing",
+        "reference": "https://openai.com/pricing"
+    }
+}
+```
+
+### Service File with Seller Price (TOML)
+
+```toml
+schema = "offering_v1"
+name = "whisper-large"
+display_name = "Whisper Large V3"
+description = "Audio transcription model"
+service_type = "audio_transcription"
+currency = "USD"
+time_created = "2024-01-15T10:00:00Z"
+
+[upstream_access_config."OpenAI Audio API"]
+access_method = "http"
+base_url = "https://api.openai.com/v1/audio/transcriptions"
+
+[payout_price]
+type = "one_second"
+price = "0.006"
+description = "Per second of audio"
+reference = "https://openai.com/pricing"
+```
+
+### Listing File with Customer Price (TOML)
+
+```toml
+schema = "listing_v1"
+name = "gpt-4-turbo-premium-usd"
+service_name = "gpt-4-turbo"
+display_name = "GPT-4 Turbo Premium Access"
+status = "ready"
+currency = "USD"
+time_created = "2024-02-01T12:00:00Z"
+
+[[user_access_interfaces]]
+access_method = "http"
+base_url = "${API_GATEWAY_BASE_URL}/v1/chat/completions"
+name = "Chat Completions API"
+
+[user_access_interfaces.routing_key]
+model = "gpt-4-turbo"
+
+[list_price]
+type = "one_million_tokens"
+input = "12.00"
+output = "36.00"
+description = "Premium access with priority support"
+```
+
+### Image Generation Service (JSON)
+
+```json
+{
+    "schema": "offering_v1",
+    "name": "flux-pro",
+    "display_name": "FLUX Pro",
+    "description": "High-quality image generation",
+    "service_type": "image_generation",
+    "currency": "USD",
+    "time_created": "2024-03-15T10:30:00Z",
+    "details": {
+        "max_resolution": "2048x2048",
+        "supported_formats": ["PNG", "JPEG", "WEBP"]
+    },
+    "upstream_access_config": {
+        "Image Generation API": {
+            "access_method": "http",
+            "base_url": "https://api.provider.com/v1/images/generate"
+        }
+    },
+    "payout_price": {
+        "type": "image",
+        "price": "0.04",
+        "description": "Per image pricing"
+    }
+}
+```
+
+---
+
+## Pricing Type Selection Guide
+
+### Per-Request Pricing Types (for `list_price` and `payout_price`)
+
+| Service Type                | Recommended Pricing Type | Example Use Cases              |
+| --------------------------- | ------------------------ | ------------------------------ |
+| LLM, Chat, Completion       | `one_million_tokens`     | GPT-4, Claude, Llama           |
+| Embedding                   | `one_million_tokens`     | text-embedding-ada-002         |
+| Cheap token services        | `one_thousand_tokens`    | Lightweight models             |
+| Audio Transcription         | `one_second`             | Whisper, Deepgram              |
+| Text-to-Speech              | `one_second`             | ElevenLabs, Azure TTS          |
+| Video Processing            | `one_second`             | Video transcription, analysis  |
+| Alias / subscription        | `one_month`              | URL aliases, reserved slots    |
+| Image Generation            | `image`                  | DALL-E, Stable Diffusion, FLUX |
+| Image Analysis              | `image`                  | GPT-4 Vision (per image)       |
+| Diffusion with Step Control | `step`                   | Custom diffusion pipelines     |
+| Data transfer / storage     | `one_gigabyte`           | CDN, object storage            |
+| High-volume API calls       | `one_thousand`           | Logging, analytics events      |
+| Per-request fees/discounts  | `constant`               | Fixed fee per API request      |
+
+### Volume Pricing Types (for `payout_price` - uses `request_count`)
+
+| Use Case                | Recommended Type | Description                          |
+| ----------------------- | ---------------- | ------------------------------------ |
+| Flat billing period fee | `constant`       | Fixed amount per billing period      |
+| Combined pricing        | `add`            | Sum of multiple pricing components   |
+| Percentage adjustments  | `multiply`       | Apply discount/markup factor         |
+| Charge the higher of    | `max`            | Highest of multiple calculations     |
+| Price cap               | `min`            | Lowest of multiple (cap at flat fee) |
+| Flexible metric         | `first`          | Use whichever metric is available    |
+| Request-based tiers     | `tiered`         | Tiers based on `request_count`       |
+| Request-based graduated | `graduated`      | Graduated pricing by `request_count` |
+
+### Seller-Only Pricing Types (for `payout_price` - uses `customer_charge`)
+
+| Use Case            | Recommended Type | Description                      |
+| ------------------- | ---------------- | -------------------------------- |
+| Revenue sharing     | `revenue_share`  | Percentage of customer charge    |
+| Complex expressions | `expr`           | Arbitrary arithmetic expressions |
+
+---
+
+## Validation
+
+When you run `usvc_seller data validate`, the pricing structure is validated:
+
+1. **JSON Schema Validation**: Ensures the structure matches the expected format
+2. **Pydantic Model Validation**: Enforces business rules:
+    - `type` must be a valid pricing type
+    - Token pricing requires either `price` (unified) or both `input`/`output` (separate)
+    - When `input`/`output` are set without `price`, `price` is auto-computed
+    - Negative values are allowed (for seller-funded incentives via `payout_price`)
+    - Extra fields are rejected
+
+### Common Validation Errors
+
+**Invalid: Missing output price**
+
+```json
+{
+    "type": "one_million_tokens",
+    "input": "0.50"
+}
+```
+
+Error: "Both 'input' and 'output' must be specified for separate pricing"
+
+**Invalid: Unknown pricing type**
+
+```json
+{
+    "type": "per_request",
+    "price": "0.001"
+}
+```
+
+Error: "Invalid pricing type. Valid types: 'one_million_tokens', 'one_thousand_tokens', 'one_token', 'one_second', 'one_minute', 'one_hour', 'one_day', 'one_month', 'one_byte', 'one_kilobyte', 'one_megabyte', 'one_gigabyte', 'one_thousand', 'one_million', 'image', 'step', 'revenue_share', 'constant', 'add', 'multiply', 'tiered', 'graduated', 'expr'"
+
+---
+
+## Cost Calculation
+
+The backend calculates costs using these formulas:
+
+### Per-Request Pricing Types
+
+| Pricing Type                   | Cost Formula                                                            |
+| ------------------------------ | ----------------------------------------------------------------------- |
+| `one_million_tokens` (separate) | (input_tokens × input + cached_input_tokens × cached_input + output_tokens × output) / 1,000,000 |
+| `one_million_tokens` (unified)  | total_tokens × price / 1,000,000                                        |
+| `one_thousand_tokens`          | Same as above with divisor 1,000                                        |
+| `one_token`                    | Same as above with divisor 1                                            |
+| `one_second` / `one_minute` / `one_hour` / `one_day` / `one_month` | usage (converted to pricing unit) × price |
+| `one_byte` / `one_kilobyte` / `one_megabyte` / `one_gigabyte` | usage (converted to pricing unit) × price |
+| `one_thousand` / `one_million` | usage (converted to pricing unit) × price                               |
+| `image`                        | count × price                                                           |
+| `step`                         | count × price                                                           |
+| `constant`                     | amount (fixed value per request)                                        |
+
+### Volume Pricing Types
+
+| Pricing Type | Cost Formula                                                       |
+| ------------ | ------------------------------------------------------------------ |
+| `constant`   | amount (fixed value per billing period)                            |
+| `add`        | sum(price.calculate_cost() for each price in prices)               |
+| `multiply`   | base.calculate_cost() × factor                                     |
+| `max`        | max(price.calculate_cost() for each applicable price)              |
+| `min`        | min(price.calculate_cost() for each applicable price)              |
+| `first`      | First price.calculate_cost() that succeeds                         |
+| `tiered`     | Find tier where metric ≤ up_to, return tier.price.calculate_cost() |
+| `graduated`  | Sum of (units_in_tier × unit_price) for each tier                  |
+
+### Seller-Only Pricing Types
+
+| Pricing Type    | Cost Formula                           |
+| --------------- | -------------------------------------- |
+| `revenue_share` | customer_charge × percentage / 100     |
+| `expr`          | Evaluate expression with usage metrics |
+
+---
+
+## See Also
+
+- [File Schemas](file-schemas.md) - Complete schema reference
+- [Data Structure](data-structure.md) - File organization
+- [CLI Reference](cli-reference.md#usvc_seller-data-validate-validate-data) - Validation command

--- a/docs/sdk-reference.md
+++ b/docs/sdk-reference.md
@@ -1,0 +1,522 @@
+# Python SDK Reference
+
+`unitysvc-sellers` ships a typed Python SDK that the `usvc_seller`
+CLI is itself built on. Anything the CLI can do — upload a catalog,
+list services, mutate promotions, run connectivity tests — you can
+do programmatically via `unitysvc_sellers.Client` (sync) or
+`unitysvc_sellers.AsyncClient` (async).
+
+The SDK is generated from the seller OpenAPI spec, so request and
+response models are fully typed: your editor will autocomplete
+fields and your type checker will catch mistakes before they hit
+the wire.
+
+## Installation
+
+```bash
+pip install unitysvc-sellers
+```
+
+## Authentication
+
+Both `Client` and `AsyncClient` read credentials from the
+environment by default:
+
+| Variable                  | Purpose                                                                        |
+| ------------------------- | ------------------------------------------------------------------------------ |
+| `UNITYSVC_SELLER_API_KEY` | Seller API key (`svcpass_…`). Get one from the UnitySVC dashboard.             |
+| `UNITYSVC_SELLER_API_URL` | Base URL for the seller API. Defaults to `https://seller.staging.unitysvc.com/v1`. |
+
+```python
+from unitysvc_sellers import Client
+
+client = Client()              # reads both env vars, raises if key missing
+client = Client(api_key="...") # explicit key, env URL (or default)
+client = Client(api_key="...", base_url="https://seller.unitysvc.com/v1")
+```
+
+The seller context is encoded entirely in the API key — there is no
+`seller_id` argument to pass. Both clients are safe to use as
+context managers and will close their underlying `httpx` session on
+exit:
+
+```python
+from unitysvc_sellers import Client
+
+with Client() as client:
+    for svc in client.services.list().data:
+        print(svc.name)
+```
+
+## Sync vs async: when to use which
+
+| You are writing…                                           | Use           |
+| ---------------------------------------------------------- | ------------- |
+| A one-off script or a Jupyter notebook                     | `Client`      |
+| A Celery task or other already-sync worker                 | `Client`      |
+| An `async def` function, FastAPI handler, or asyncio app   | `AsyncClient` |
+| A CLI tool where you want to overlap multiple requests     | `AsyncClient` |
+
+The two are a one-to-one mirror: every sync method has an async
+counterpart with the same name and signature, just `await`able.
+
+### Sync example
+
+```python
+from unitysvc_sellers import Client
+
+with Client() as client:
+    page = client.services.list(limit=50)
+    for svc in page.data:
+        print(svc.id, svc.name, svc.status)
+```
+
+### Async example
+
+```python
+import asyncio
+from unitysvc_sellers import AsyncClient
+
+async def main():
+    async with AsyncClient() as client:
+        page = await client.services.list(limit=50)
+        for svc in page.data:
+            print(svc.id, svc.name, svc.status)
+
+asyncio.run(main())
+```
+
+## Resource namespaces
+
+Both clients expose the same five resource namespaces as lazy
+properties:
+
+| Namespace            | Underlying endpoints                                          | Purpose                                                                 |
+| -------------------- | ------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `client.services`    | `/seller/services/*`                                          | List, get, upload, mutate status / routing / pricing, delete services   |
+| `client.promotions`  | `/seller/promotions/*`                                        | CRUD on seller-funded promotion codes                                   |
+| `client.groups`      | `/seller/service-groups/*`                                    | CRUD on service groups                                                  |
+| `client.documents`   | `/seller/documents/*`                                         | Fetch document file content, execute (gateway dispatch), update test    |
+| `client.tasks`       | `/seller/tasks/*`                                             | Poll Celery task state for async operations (notably service upload)   |
+
+The async client exposes the same namespaces with `Async` prefixes
+on the resource classes (`AsyncServicesResource`, etc.), but the
+attribute names on the client are identical — so you can rename
+`Client` to `AsyncClient` in a code snippet and the rest just needs
+`await`s.
+
+## `client.services`
+
+The services resource covers the full seller-catalog lifecycle.
+
+| Method                           | Description                                                                     |
+| -------------------------------- | ------------------------------------------------------------------------------- |
+| `list(cursor=, limit=, …)`       | Cursor-paged list with optional `status` / `service_type` / `name` filters.     |
+| `get(service_id)`                | Full service detail including interfaces, documents, upstream config.           |
+| `get_test_env(service_id)`       | Environment variables for local connectivity testing (`SERVICE_BASE_URL`, …).   |
+| `upload(body, dryrun=False)`     | POST provider + offering + listing bundle. Backend responds with a task id.     |
+| `set_status(service_id, body)`   | Change lifecycle status (`draft` → `pending` for review, etc.).                 |
+| `set_routing_vars(…)`            | Update the routing variables used by the gateway plugin.                        |
+| `set_list_price(…)`              | Update the customer-facing price on an active service.                          |
+| `delete(service_id)`             | Remove a service. (Most flows should use `set_status` → `deprecated` instead.)  |
+
+### Listing services
+
+```python
+with Client() as client:
+    page = client.services.list(limit=100, status="active")
+    while True:
+        for svc in page.data:
+            print(svc.id, svc.name, svc.service_type)
+        if not page.has_more:
+            break
+        page = client.services.list(cursor=page.next_cursor, limit=100)
+```
+
+### Fetching one service
+
+```python
+svc = client.services.get("be098e7d-59e1-498a-bc4f-e389eb61c70b")
+print(svc.service_name, svc.status)
+for iface in svc.interfaces:
+    print(" iface:", iface.name, iface.base_url)
+for doc in svc.documents or []:
+    print(" doc:", doc.title, doc.category, doc.test_status)
+```
+
+### Mutating status
+
+```python
+# Submit a draft service for review. Omit run_tests to skip the
+# backend's auto-queue of the full connectivity test suite (useful
+# when the CLI has already run those tests locally).
+client.services.set_status(
+    "be098e7d-59e1-498a-bc4f-e389eb61c70b",
+    {"status": "pending", "run_tests": True},
+)
+```
+
+## `client.promotions`
+
+Seller-funded promotion codes — discounts the seller pays for, to
+bootstrap demand or reward specific customers.
+
+```python
+from unitysvc_sellers import Client
+
+with Client() as client:
+    # Create or update by name.
+    client.promotions.upsert({
+        "name": "summer2026",
+        "code": "SUMMER2026",
+        "pricing": {"type": "percentage_off", "percentage": "25.00"},
+        "scope": {"service_type": "llm"},
+        "apply_at": "request",
+        "priority": 10,
+        "status": "active",
+    })
+
+    # List active promotions.
+    for promo in client.promotions.list(limit=100).data:
+        print(promo.code, promo.status)
+
+    # Deactivate.
+    client.promotions.update("summer2026", {"status": "paused"})
+```
+
+## `client.groups`
+
+Service groups bundle related services together for routing,
+discovery, or group-wide pricing.
+
+```python
+with Client() as client:
+    client.groups.upsert({
+        "name": "premium-llms",
+        "display_name": "Premium LLMs",
+        "owner_type": "seller",
+        "membership_rules": {
+            "include_tags": ["premium", "llm"],
+        },
+    })
+
+    for grp in client.groups.list().data:
+        print(grp.name, grp.display_name)
+```
+
+## `client.documents`
+
+Operate on documents attached to a service (code examples,
+connectivity tests, terms, logos).
+
+```python
+with Client() as client:
+    doc = client.documents.get("5c937b4a-980a-4a69-bb90-a1f93816de1d")
+    print(doc.title, doc.mime_type)
+    if doc.file_content:
+        print(doc.file_content[:200])
+
+    # Record an externally-run test result. Useful when the CLI or
+    # an in-house CI ran the script locally and wants to POST the
+    # per-interface outcome back.
+    client.documents.update_test(
+        doc.id,
+        {
+            "status": "success",
+            "tests": {
+                "default": {"status": "success", "exit_code": 0},
+            },
+        },
+    )
+```
+
+`client.documents.execute(doc_id, force=True)` dispatches the
+document to the backend Celery worker for execution against the
+gateway. The CLI's `usvc_seller services run-tests` command, in
+contrast, runs the scripts **locally** on the seller's machine —
+see [Running connectivity tests locally](#running-connectivity-tests-locally)
+below for the recommended pattern.
+
+## `client.tasks`
+
+Several seller endpoints are fire-and-forget: they accept your
+request, queue a Celery task, and return a `task_id`. The tasks
+resource lets you poll for the real outcome.
+
+| Method                                | Description                                                              |
+| ------------------------------------- | ------------------------------------------------------------------------ |
+| `get(task_id)`                        | One-shot status for a single task.                                       |
+| `batch_status(task_ids)`              | One request, many tasks. Preferred for uploads that yield N tasks.       |
+| `wait(task_id, timeout=, poll=)`      | Block until the task reaches a terminal state or times out.              |
+| `wait_batch(ids, timeout=, poll=)`    | Wait for every id in a batch; returns a dict of final states.            |
+
+Terminal Celery states the SDK recognises are `completed` and
+`failed`. `wait_batch` polls with exponential-friendly delays and
+returns a dict keyed by `task_id`, where each entry has `state`,
+`status`, `result`, and (for failures) `error` fields.
+
+```python
+with Client() as client:
+    result = client.services.upload({"services": [...]})
+    task_id = result.task_id
+
+    final = client.tasks.wait(task_id, timeout=300, poll_interval=2)
+    if final["status"] == "completed":
+        print("service_id =", final["result"]["service_id"])
+    else:
+        print("failed:", final.get("error") or final.get("message"))
+```
+
+## `upload_directory` — full catalog upload helper
+
+For the common case of "upload a whole seller catalog directory,
+wait for every task, write `.override.json` files so the next run
+knows what already exists", use the `upload_directory` helper from
+`unitysvc_sellers.resources.upload`. This is the same code path the
+`usvc_seller data upload` CLI command uses.
+
+```python
+from pathlib import Path
+from unitysvc_sellers import Client
+from unitysvc_sellers.resources.upload import upload_directory
+
+with Client() as client:
+    result = upload_directory(
+        client,
+        data_dir=Path("./data"),
+        dryrun=False,
+        task_wait_timeout=600.0,
+        task_poll_interval=2.0,
+    )
+
+print(f"services: {result.services.success}/{result.services.total}")
+print(f"promotions: {result.promotions.success}/{result.promotions.total}")
+print(f"groups: {result.groups.success}/{result.groups.total}")
+
+for err in result.services.errors:
+    print(" FAILED", err["file"], "→", err["error"])
+
+if result.total_failed:
+    raise SystemExit(1)
+```
+
+Useful keyword arguments:
+
+-   `dryrun=True` — call every endpoint with the dryrun flag where
+    supported; skips task polling entirely (dryrun runs
+    synchronously on the backend).
+-   `upload_services=False` / `upload_promotions=False` /
+    `upload_groups=False` — upload only a subset of the catalog.
+-   `on_progress=callable` — a hook that fires on every state
+    transition. Signature is `on_progress(kind, status, name,
+    detail)`, where `kind` is `"service"`, `"promotion"`, or
+    `"group"` and `status` transitions through `"queued"` →
+    (`"ok"` or `"error"` or `"dryrun"`). Useful when embedding the
+    upload into a larger progress bar or web UI.
+-   `task_wait_timeout` / `task_poll_interval` — control how long
+    the helper is willing to wait for the async ingest tasks to
+    finish.
+
+Returns an `UploadResult` dataclass with per-resource `services` /
+`promotions` / `groups` counts (total / success / failed / errors).
+
+## Running connectivity tests locally
+
+The `usvc_seller services run-tests` CLI runs each service's
+connectivity test scripts on the seller's own machine, against the
+public gateway URL, using the seller's `UNITYSVC_API_KEY` from the
+local environment. The SDK exposes everything you need to do the
+same thing programmatically.
+
+The flow is:
+
+1.  Fetch the service detail (for its interfaces + documents).
+2.  If the service is in `draft` or `rejected`, elevate it to
+    `pending` with `run_tests=False` so the backend does not
+    auto-queue its own full test suite.
+3.  For each executable document, pull its expanded `file_content`.
+4.  Run the script locally (per interface) with
+    `execute_script_content`, injecting `SERVICE_BASE_URL` /
+    `UNITYSVC_API_KEY` / routing_key env vars.
+5.  POST the per-interface results back via `documents.update_test`.
+6.  Restore the original status on exit.
+
+```python
+import os
+from unitysvc_sellers import AsyncClient
+from unitysvc_sellers.utils import execute_script_content
+
+EXECUTABLE = {"code_example", "connectivity_test"}
+ROUTABLE = {"pending", "review", "active"}
+
+
+async def run_tests(service_id: str) -> int:
+    user_api_key = os.environ.get("UNITYSVC_API_KEY", "")
+    failed = 0
+    async with AsyncClient() as client:
+        svc = await client.services.get(service_id)
+        original_status = svc.status
+        elevated = original_status in ("draft", "rejected")
+        try:
+            if elevated:
+                await client.services.set_status(
+                    service_id, {"status": "pending", "run_tests": False}
+                )
+            docs = [d for d in (svc.documents or []) if d.category in EXECUTABLE]
+
+            for doc in docs:
+                full = await client.documents.get(doc.id)
+                if not full.file_content:
+                    continue
+                per_iface = {}
+                for iface in svc.interfaces or []:
+                    if not iface.is_active:
+                        continue
+                    env = {
+                        "SERVICE_BASE_URL": iface.base_url or "",
+                        "UNITYSVC_API_KEY": user_api_key,
+                    }
+                    for k, v in (iface.routing_key or {}).items():
+                        env[k.upper()] = str(v)
+                    result = execute_script_content(
+                        script=full.file_content,
+                        mime_type=full.mime_type or "",
+                        env_vars=env,
+                        timeout=30,
+                    )
+                    per_iface[iface.name] = {
+                        "status": result["status"],
+                        "exit_code": result.get("exit_code"),
+                        "stdout": (result.get("stdout") or "")[:10_000],
+                        "stderr": (result.get("stderr") or "")[:10_000],
+                        "error": result.get("error"),
+                    }
+                worst = next(
+                    (r["status"] for r in per_iface.values() if r["status"] != "success"),
+                    "success",
+                )
+                if worst != "success":
+                    failed += 1
+                await client.documents.update_test(
+                    doc.id, {"status": worst, "tests": per_iface}
+                )
+        finally:
+            if elevated:
+                await client.services.set_status(
+                    service_id, {"status": original_status, "run_tests": False}
+                )
+    return failed
+```
+
+## Exceptions
+
+All SDK errors derive from `SellerSDKError`. The subclasses map
+directly to HTTP status classes so you can catch them narrowly:
+
+| Exception              | Raised when…                                          |
+| ---------------------- | ----------------------------------------------------- |
+| `AuthenticationError`  | 401 — key missing, invalid, or expired                |
+| `PermissionError`      | 403 — key is valid but not authorised for this action |
+| `NotFoundError`        | 404 — resource does not exist                         |
+| `ValidationError`      | 400 / 422 — request body failed server validation     |
+| `ConflictError`        | 409 — e.g., service name already taken                |
+| `RateLimitError`       | 429 — retry with the `Retry-After` hint               |
+| `ServerError`          | 5xx — backend trouble                                 |
+| `APIError`             | Catch-all parent of the above                         |
+| `SellerSDKError`       | Root. Also covers non-HTTP failures (config, auth).   |
+
+```python
+from unitysvc_sellers import (
+    Client,
+    NotFoundError,
+    ValidationError,
+    APIError,
+)
+
+try:
+    svc = client.services.get("00000000-0000-0000-0000-000000000000")
+except NotFoundError:
+    print("service does not exist")
+except ValidationError as exc:
+    print("bad request:", exc.detail)
+except APIError as exc:
+    print(f"HTTP {exc.status_code}:", exc)
+```
+
+Every `APIError` carries:
+
+-   `status_code` (int)
+-   `detail` (the parsed `ErrorResponse` from the backend, usually a
+    dict, or the raw text for non-JSON responses)
+-   `response_body` (the raw bytes, for debugging)
+
+## End-to-end example: mirror a catalog into CI
+
+Combine the pieces into a CI-friendly script that uploads a catalog,
+waits for all ingest tasks, and fails the build on any per-service
+errors:
+
+```python
+#!/usr/bin/env python3
+"""CI entrypoint: upload the catalog under ./data and report results."""
+
+import sys
+from pathlib import Path
+
+from unitysvc_sellers import Client
+from unitysvc_sellers.resources.upload import upload_directory
+
+
+def main() -> int:
+    data_dir = Path("./data").resolve()
+
+    def progress(kind: str, status: str, name: str, detail: str = "") -> None:
+        icon = {"queued": "·", "ok": "✓", "error": "✗", "dryrun": "→"}.get(status, "?")
+        print(f"  {icon} {kind}: {name} [{status}] {detail}")
+
+    with Client() as client:
+        result = upload_directory(
+            client,
+            data_dir=data_dir,
+            on_progress=progress,
+            task_wait_timeout=900.0,
+            task_poll_interval=3.0,
+        )
+
+    print()
+    print(f"services:   {result.services.success}/{result.services.total} ok")
+    print(f"promotions: {result.promotions.success}/{result.promotions.total} ok")
+    print(f"groups:     {result.groups.success}/{result.groups.total} ok")
+
+    for err in (*result.services.errors, *result.promotions.errors, *result.groups.errors):
+        print(f"  FAILED {err.get('file', '?')} → {err.get('error')}")
+
+    return 1 if result.total_failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+Drop that in `scripts/upload_catalog.py`, wire
+`UNITYSVC_SELLER_API_KEY` and `UNITYSVC_SELLER_API_URL` into your
+CI secrets, and call it from a GitHub Actions workflow:
+
+```yaml
+- name: Upload catalog
+  env:
+    UNITYSVC_SELLER_API_KEY: ${{ secrets.UNITYSVC_SELLER_API_KEY }}
+    UNITYSVC_SELLER_API_URL: ${{ secrets.UNITYSVC_SELLER_API_URL }}
+  run: python scripts/upload_catalog.py
+```
+
+## See also
+
+-   [Getting Started](getting-started.md) — install, configure, and
+    upload your first catalog.
+-   [CLI Reference](cli-reference.md) — every `usvc_seller` command,
+    much of which is implemented on top of the APIs above.
+-   [Workflows](workflows.md) — higher-level patterns for manual,
+    web-assisted, and automated catalog authoring.
+-   [File Schemas](file-schemas.md) — the provider / offering /
+    listing payload shapes the SDK accepts.

--- a/docs/seller-lifecycle.md
+++ b/docs/seller-lifecycle.md
@@ -1,0 +1,248 @@
+# Seller Lifecycle
+
+This guide explains what happens after you upload your services to UnitySVC - from approval through invoicing and payouts.
+
+## Overview
+
+```mermaid
+flowchart TD
+    subgraph Upload["1. Upload"]
+        A[ServiceOffering<br/>What seller offers TO UnitySVC]
+        B[ServiceListing<br/>What seller offers TO Users]
+    end
+
+    subgraph Review["2. Review"]
+        C{UnitySVC Reviews<br/>& Approves}
+    end
+
+    subgraph Active["3. Active Service"]
+        D[Service goes live]
+        E[Usage tracked per request]
+    end
+
+    subgraph Billing["4. Monthly Billing"]
+        F[Invoice generated]
+        G{Seller Reviews}
+        H[Invoice finalized]
+    end
+
+    subgraph Payout["5. Payout"]
+        I[Payout window]
+        J[Balance available]
+        K[Payment processed]
+    end
+
+    A --> C
+    B --> C
+    C -->|Approved| D
+    D --> E
+    E --> F
+    F --> G
+    G -->|No dispute| H
+    G -->|Dispute| G
+    H --> I
+    I --> J
+    J --> K
+```
+
+## 1. Upload & Approval
+
+When you run `usvc_seller data upload`, you submit:
+
+| Data Type           | Purpose                    | Key Fields                                    |
+| ------------------- | -------------------------- | --------------------------------------------- |
+| **ServiceOffering** | What you offer TO UnitySVC | Provider info, API access, `payout_price`     |
+| **ServiceListing**  | What you offer TO Users    | User-facing info, `list_price`, documentation |
+
+**Pricing Model:**
+
+```mermaid
+flowchart LR
+    subgraph YourCost["Your Cost (Trade Secret)"]
+        A[Provider pricing<br/>e.g., OpenAI rates]
+    end
+
+    subgraph Agreement["Seller ↔ UnitySVC"]
+        B[payout_price<br/>What you charge UnitySVC]
+    end
+
+    subgraph Customer["Customer Facing"]
+        C[list_price<br/>What UnitySVC charges users]
+    end
+
+    A -.->|Your margin| B
+    B -->|UnitySVC margin| C
+```
+
+-   **payout_price** is the agreed rate between you and UnitySVC
+-   Your actual provider costs are your trade secret - UnitySVC doesn't need to know
+-   **list_price** is what end users pay
+
+## 2. Active Service
+
+Once approved, your service goes live:
+
+-   **Listed on marketplace** - Users can discover and subscribe
+-   **API routing configured** - Requests flow through UnitySVC gateway
+-   **Usage metering** - Every request is tracked in real-time
+
+## 3. Monthly Invoicing
+
+At the end of each month, UnitySVC generates your invoice:
+
+```mermaid
+flowchart LR
+    A[Usage Data] --> B[Calculate:<br/>usage × payout_price]
+    B --> C[Generate Invoice]
+    C --> D{Dispute Window<br/>1-2 weeks}
+    D -->|No Dispute| E[finalized]
+    D -->|Dispute| F[Submit Revision]
+    F --> G{UnitySVC Reviews}
+    G -->|Accept| E
+    G -->|Negotiate| F
+    E -->|Payout window expires| H[funds_released]
+```
+
+### Invoice Contents
+
+Your monthly invoice includes:
+
+| Field               | Description                                |
+| ------------------- | ------------------------------------------ |
+| **Billing Period**  | Start and end dates (e.g., Jan 1 - Jan 31) |
+| **Opening Balance** | Carried forward from previous invoice      |
+| **Seller Payout**   | Sum of (usage × payout_price) per service  |
+| **Adjustments**     | Any credits or debits applied              |
+| **Closing Balance** | Total owed to you                          |
+
+### Line Items
+
+Each service shows:
+
+-   Request count
+-   Token usage (input/output)
+-   Seller price applied
+-   Calculated payout
+
+### Dispute Window
+
+You have **1-2 weeks** to review the invoice:
+
+-   **No action needed** if the invoice is correct - it auto-finalizes
+-   **Dispute** if you see issues - submit a revised invoice with justification
+
+**Valid dispute reasons:**
+
+| Reason        | Example                             |
+| ------------- | ----------------------------------- |
+| Rate change   | "We agreed to lower rate mid-month" |
+| Service issue | "Service was down for 2 days"       |
+| Billing error | "Usage count looks incorrect"       |
+
+## 4. Payout Process
+
+Invoices track earnings. Actual payouts are handled separately - you can request payouts from your available balance at any time.
+
+```mermaid
+flowchart TB
+    subgraph Finalize["Invoice: finalized"]
+        A[Update current_balance]
+    end
+
+    subgraph Window["Payout Window (1-2 months)"]
+        B[Balance held for<br/>customer chargebacks]
+        C{Any issues?}
+        D[Deduct chargebacks]
+        E[Window expires]
+    end
+
+    subgraph Released["Invoice: funds_released"]
+        F[Update available_payout]
+    end
+
+    subgraph Payout["Payout (separate from invoices)"]
+        G{Payout Trigger}
+        H[On-demand request]
+        I[Automatic payout]
+        J[SellerPayout created]
+        K[Payment processed]
+    end
+
+    A --> B
+    B --> C
+    C -->|Chargeback| D
+    C -->|No issues| E
+    D --> E
+    E --> F
+    F --> G
+    G --> H
+    G --> I
+    H --> J
+    I --> J
+    J --> K
+```
+
+### Invoice Statuses
+
+| Status           | Description                           | Balance Updated    |
+| ---------------- | ------------------------------------- | ------------------ |
+| `generated`      | Invoice created, in dispute window    | -                  |
+| `disputed`       | You disputed, awaiting review         | -                  |
+| `resolved`       | Dispute resolved                      | -                  |
+| `finalized`      | Invoice closed                        | `current_balance`  |
+| `funds_released` | Payout window expired                 | `available_payout` |
+| `voided`         | Invoice voided (fraud/abuse detected) | -                  |
+
+### Balance Fields
+
+Your seller account tracks two balances:
+
+| Field                | Description                                          |
+| -------------------- | ---------------------------------------------------- |
+| **current_balance**  | Total earnings (closing balance from latest invoice) |
+| **available_payout** | Amount available for immediate payout                |
+
+### Payout Window
+
+The payout window (default 2 months) provides time for:
+
+-   Customer dispute resolution
+-   Chargeback handling
+-   Fraud detection
+
+**Trusted sellers** may receive a shorter payout window as an incentive.
+
+### Payout Modes
+
+| Mode                      | Description                                |
+| ------------------------- | ------------------------------------------ |
+| **On-demand**             | You request payout of available balance    |
+| **Automatic (threshold)** | Payout when balance exceeds your threshold |
+| **Automatic (scheduled)** | Payout on your configured schedule         |
+
+### Timeline Example
+
+| Date   | Event                                     | current_balance | available_payout |
+| ------ | ----------------------------------------- | --------------- | ---------------- |
+| Feb 1  | January invoice generated ($1,000)        | -               | -                |
+| Feb 14 | Dispute deadline passes                   | -               | -                |
+| Feb 15 | Invoice finalized                         | $1,000          | $0               |
+| Mar 15 | February invoice finalized ($1,200)       | $2,200          | $0               |
+| Apr 1  | January payout window expires (2 months)  | $2,200          | $1,000           |
+| Apr 20 | You request $500 payout                   | $1,700          | $500             |
+| May 1  | February payout window expires (2 months) | $1,700          | $1,700           |
+
+## Summary
+
+1. **Publish** your ServiceOffering and ServiceListing
+2. **UnitySVC reviews** and approves your submission
+3. **Service goes live** and usage is tracked
+4. **Monthly invoice** generated based on usage × payout_price
+5. **Dispute window** gives you time to review (1-2 weeks)
+6. **Payout window** protects against chargebacks (1-2 months)
+7. **Payout** when balance becomes available
+
+## Questions?
+
+-   Contact your UnitySVC account manager for billing questions
+-   Open an issue on [GitHub](https://github.com/unitysvc/unitysvc-sellers/issues) for SDK questions

--- a/docs/service-types.md
+++ b/docs/service-types.md
@@ -1,0 +1,201 @@
+# Service Types
+
+UnitySVC is a multi-protocol service marketplace. Sellers list services, and the platform handles discovery, authentication, routing, metering, and billing. This guide covers what types of services the platform supports and how they are delivered.
+
+## Service Categories
+
+The platform supports services across multiple protocols and use cases:
+
+| Category | Protocol | Gateway | Examples |
+|----------|----------|---------|----------|
+| **AI / ML** | HTTP | API Gateway | Chat APIs, embeddings, image generation, transcription, translation |
+| **Email delivery** | SMTP | SMTP Gateway | Transactional email, bulk email, email verification |
+| **Content / media** | HTTP or S3 | API Gateway or S3 Gateway | Stock media, datasets, video courses, software distribution |
+| **Compute environments** | SSH / WireGuard | SSH Gateway | GPU instances, licensed software, dev environments |
+| **Database access** | SSH tunnel | SSH Gateway | Managed Postgres, Redis, Elasticsearch |
+| **Monitoring** | HTTP (platform-triggered) | API Gateway | Uptime checks, SSL monitoring, DNS monitoring |
+| **Scheduled tasks** | HTTP (platform-triggered) | API Gateway | Cron-as-a-service, data collection, report generation |
+| **Webhook relay** | HTTP | API Gateway | Webhook buffering, retry, fan-out, transformation |
+| **Notifications** | HTTP | API Gateway | Push notifications, alerting |
+
+### AI and machine learning
+
+Language models, embeddings, image generators, speech-to-text, and more. Customers access them through a unified HTTP API with the same API key. The platform supports intelligent routing across providers and automatic failover.
+
+**Service types**: `llm`, `embedding`, `rerank`, `image_generation`, `speech_to_text`, `text_to_speech`, `video_generation`, `text_to_image`, `vision_language_model`, `streaming_transcription`, `prerecorded_transcription`, `prerecorded_translation`, `text_to_3d`
+
+### Email delivery
+
+Sellers wrap SMTP providers (SendGrid, Mailgun, SES) as marketplace services. Customers point their app's SMTP settings at `smtp.unitysvc.com` and send. The seller's SMTP credentials are hidden — customers authenticate with their UnitySVC API key.
+
+**Service types**: `smtp_relay`
+
+### Content and media
+
+Sellers host files on S3, GCS, R2, or other storage. Customers browse and download through the S3 gateway (`s3.unitysvc.com`) using standard S3 tools (boto3, aws-cli, rclone). The platform meters downloads and hides the seller's storage credentials.
+
+For video/audio streaming (HLS, DASH), the HTTP API gateway serves manifest files and media segments — standard HTTP, no special infrastructure needed.
+
+**Service types**: `content_delivery`, `video_streaming`, `audio_streaming`, `data_feed`
+
+### Compute environments
+
+Sellers offer on-demand computing environments (GPU instances, licensed software, analysis tools). Customers enroll, connect via SSH tunnel or WireGuard VPN, use the environment, and disconnect. Time-based billing charges only for active usage.
+
+**Service types**: `compute`
+
+### Monitoring and scheduled tasks
+
+The platform triggers actions on a schedule on behalf of customers. Sellers provide the checking/action logic; the platform handles scheduling, alerting, and billing. Uses the existing RecurrentRequest infrastructure.
+
+**Service types**: `uptime_monitoring`, `ssl_monitoring`, `dns_monitoring`, `cron`, `webhook_relay`
+
+## Service Delivery Patterns
+
+Orthogonal to the service category, each service uses one of these delivery patterns. The pattern determines **who provides upstream credentials** and **whether enrollment is required**.
+
+| Pattern | Who pays provider? | Enrollment? | Customer action |
+|---------|-------------------|-------------|-----------------|
+| **Managed** | Seller | No | None — use immediately |
+| **Managed + parameters** | Seller | Yes | Enroll and configure |
+| **BYOK** | Customer | No | Store API key as a secret |
+| **BYOE** | Customer (self-hosted) | Yes | Enroll with endpoint URL |
+| **Recurrent** | Any of the above | Yes | Enroll and configure schedule |
+| **Subscription** | Seller | Yes | Enroll; platform charges daily/hourly via heartbeat |
+
+### Managed services
+
+The seller provides upstream credentials. All customers share the same upstream endpoint. No enrollment required.
+
+```toml
+# Offering — seller's upstream credentials
+[upstream_access_config."OpenAI API"]
+base_url = "https://api.openai.com/v1"
+api_key = "${ secrets.OPENAI_API_KEY }"
+
+# Listing — customer-facing gateway path
+[user_access_interfaces."OpenAI API Access"]
+access_method = "http"
+base_url = "${API_GATEWAY_BASE_URL}/p/openai"
+
+[user_access_interfaces."OpenAI API Access".routing_key]
+model = "gpt-4"
+```
+
+Request flow: `Customer → API key → Gateway → seller's upstream creds → Provider`
+
+### BYOK (Bring Your Own Key)
+
+The customer provides their own API key. No enrollment required — the key is stored in the customer's secret store.
+
+```toml
+# Offering — references customer's secret
+[upstream_access_config."Groq API"]
+base_url = "https://api.groq.com/openai/v1"
+api_key = "${ customer_secrets.GROQ_API_KEY }"
+```
+
+The `${ ... }` pattern distinguishes secret ownership:
+
+| Pattern | Owner | Resolved from |
+|---------|-------|---------------|
+| `${ secrets.NAME }` | Seller | Seller's secret store |
+| `${ customer_secrets.NAME }` | Customer | Customer's secret store |
+
+Customer secrets are auto-detected by scanning `upstream_access_config` for `${ customer_secrets.XXX }` patterns. No separate declaration needed.
+
+### BYOE (Bring Your Own Endpoint)
+
+The customer provides the URL of their own service instance (e.g., self-hosted Ollama). Enrollment required.
+
+```toml
+# Offering — templates resolve from enrollment parameters
+[upstream_access_config."Ollama API"]
+base_url = "{{ base_url }}"
+api_key = "${ customer_secrets.{{ api_key_secret }} }"
+```
+
+Two-phase resolution:
+1. **Jinja rendering**: `{{ base_url }}` → `http://my-server:11434`
+2. **Secret resolution**: `${ customer_secrets.MY_KEY }` → actual key value
+
+### Recurrent services
+
+The platform triggers requests on a schedule. Recurrence is orthogonal to delivery pattern — any service type can be recurrent.
+
+```toml
+[service_options]
+prompt_recurrence = true
+recurrence_min_interval_seconds = 300    # minimum 5 minutes
+recurrence_max_interval_seconds = 86400  # maximum 1 day
+recurrence_allow_cron = true
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `prompt_recurrence` | bool | `false` | Prompt for recurrence parameters during enrollment |
+| `recurrence_min_interval_seconds` | int | `60` | Minimum interval |
+| `recurrence_max_interval_seconds` | int | `604800` | Maximum interval (7 days) |
+| `recurrence_allow_cron` | bool | `true` | Allow cron expressions |
+
+### Subscription (time-based billing)
+
+For services where customers pay for duration (compute, content libraries), the platform creates a daily/hourly heartbeat request via RecurrentRequest. Charges accrue while enrolled; cancellation stops charges. No new billing model — uses existing `constant` pricing + scheduled requests.
+
+### Enrollment variables
+
+When per-enrollment values are needed in URLs (e.g., unique topic codes):
+
+```toml
+[service_options.enrollment_vars]
+topic = "{{ enrollment_code(6) }}"
+
+[user_access_interfaces.gateway]
+access_method = "http"
+base_url = "${API_GATEWAY_BASE_URL}/ntfy/{{ topic }}"
+```
+
+Rendering happens in two phases:
+1. `enrollment_vars` rendered first — `{{ enrollment_code(6) }}` → `VTXBNM`
+2. Access interface URL rendered — `{{ topic }}` → `VTXBNM`
+
+See [User Access Interface Templates](tech-notes/user-access-interface-template.md) for details.
+
+## Comparison Table
+
+| Aspect | Managed | BYOK | BYOE | Recurrent | Subscription |
+|--------|---------|------|------|-----------|-------------|
+| **upstream api_key** | `${ secrets.X }` | `${ customer_secrets.X }` | `${ customer_secrets.{{ param }} }` | Same as base | Same as base |
+| **upstream base_url** | Static URL | Static URL | `{{ base_url }}` | Same as base | Same as base |
+| **Enrollment?** | No | No | Yes | Yes | Yes |
+| **Customer provides** | Nothing | API key | Endpoint URL | Schedule | Nothing |
+| **Pricing** | Per-request/token | Per-request/token | Per-request/token | Per-request/token | Time-based (daily/hourly) |
+
+## What Requires Enrollment?
+
+| Condition | Why |
+|-----------|-----|
+| `user_parameters_schema` is non-empty | Customer must provide configuration |
+| `enrollment_vars` is non-empty | Per-enrollment URL templating |
+| `prompt_recurrence` is true | Per-enrollment schedule |
+| Subscription pricing | Heartbeat linked to enrollment lifecycle |
+
+Conditions that do **not** require enrollment:
+
+| Condition | Why |
+|-----------|-----|
+| BYOK (`${ customer_secrets.X }`) | Resolved from secret store at routing time |
+| Seller secrets (`${ secrets.X }`) | Seller-level, resolved at routing time |
+| Shared access interfaces | Same URL for all customers |
+
+## Service Groups
+
+Services can be organized into [service groups](data-structure.md) for unified routing. A customer sends a request to a group path (e.g., `/g/llm/v1/chat/completions`), and the platform routes to the best available service using weighted selection.
+
+Groups can contain a mix of delivery patterns:
+
+- **Managed services** — always available
+- **BYOK services** — skipped if the customer hasn't stored the required secret
+- **BYOE services** — skipped if the customer hasn't enrolled
+
+This enables fallback patterns: route to the customer's BYOK key first, fall back to a seller-managed service if the key is missing.

--- a/docs/tech-notes/user-access-interface-template.md
+++ b/docs/tech-notes/user-access-interface-template.md
@@ -1,0 +1,105 @@
+# User Access Interface Templates
+
+> **Issue**: [unitysvc-bridge-ntfy#1 — Restrict users to enrollment-specific topics](https://github.com/unitysvc/unitysvc-bridge-ntfy/issues/1)
+> **Related PR**: [unitysvc#437 — ntfy service integration](https://github.com/unitysvc/unitysvc/pull/437)
+> **Date**: 2026-02-10
+> **Status**: Implemented
+
+## Overview
+
+String values in `user_access_interfaces` (and `upstream_access_config`) support **Jinja2 template syntax** for dynamic rendering at enrollment time. This enables per-enrollment access interfaces — for example, generating unique endpoint URLs or routing keys for each subscriber.
+
+Interfaces containing template syntax (`{{` or `{%`) are rendered per-enrollment and create enrollment-scoped `AccessInterface` records. Static interfaces (no template syntax) are shared across all enrollments at the listing level.
+
+## Template Context
+
+Templates are rendered with these variables:
+
+| Variable                     | Type   | Description                     |
+| ---------------------------- | ------ | ------------------------------- |
+| `enrollment.id`              | string | Enrollment UUID                 |
+| `enrollment.customer_id`     | string | Customer UUID                   |
+| `enrollment.parameters`      | dict   | All enrollment parameters       |
+
+## Template Functions
+
+### `enrollment_code(length=6)`
+
+Creates or retrieves a random code tied to a specific enrollment. The function is **idempotent** — repeated calls for the same enrollment return the same code (looked up by `entity_id` and `code_type=enrollment` in the `action_code` table). This allows both `user_access_interfaces` and `upstream_access_config` to reference the same enrollment-specific code.
+
+```jinja2
+{{ enrollment_code() }}      {# 6-character uppercase token, e.g. VTXBNM #}
+{{ enrollment_code(8) }}     {# 8-character token #}
+```
+
+## Example: ntfy Service
+
+The ntfy service exposes a notification gateway where each enrollment gets a unique topic code.
+
+### Configuration
+
+```toml
+# listing.toml — user-facing endpoint with per-enrollment topic
+[user_access_interfaces.ntfy-gateway]
+access_method = "http"
+base_url = "${API_GATEWAY_BASE_URL}/ntfy/{{ enrollment_code(6) }}"
+description = "Your ntfy notification endpoint"
+```
+
+```toml
+# offering.toml — upstream endpoint with same enrollment code
+[upstream_access_config.ntfy-upstream]
+access_method = "http"
+base_url = "https://ntfy.svcpass.com/{{ enrollment_code(6) }}"
+description = "Private ntfy instance"
+```
+
+Both templates call `enrollment_code(6)` and resolve to the same code (e.g. `VTXBNM`) for a given enrollment.
+
+### After Enrollment
+
+- Topic code `VTXBNM` is generated and persisted in the `action_code` table
+- An enrollment-scoped `AccessInterface` is created with `base_url = "${API_GATEWAY_BASE_URL}/ntfy/VTXBNM"`
+- The user sees their complete, personalized endpoint
+- At gateway routing time, the upstream template resolves to `https://ntfy.svcpass.com/VTXBNM`
+- Gateway forwards the request to the correct upstream topic
+
+### Access Control
+
+Enrollment-scoped `AccessInterface` records are only visible to the enrollment that generated them:
+
+| `AccessInterface` scope | Who can access | Linked via |
+|-------------------------|----------------|------------|
+| Listing-level (no template) | All enrolled customers | ServiceEnrollment |
+| Group-scoped (`group_id` set) | Customers with GroupEnrollment | GroupEnrollment |
+| Enrollment-scoped (from template) | Only that specific enrollment | enrollment_id match |
+
+## How It Works
+
+### User access interfaces (enrollment time)
+
+1. During enrollment creation or activation, the backend checks `listing.user_access_interfaces`
+2. Each interface is classified:
+   - **Template** (contains `{{` or `{%`): rendered per-enrollment, creates enrollment-scoped `AccessInterface`
+   - **Static** (no template syntax): shared listing-scoped `AccessInterface` (idempotent)
+3. Template rendering uses `jinja2.Environment(enable_async=True)` with `render_async()`, which auto-awaits async functions like `enrollment_code()`
+4. Rendered values are validated as `AccessInterfaceData` and persisted via upsert
+
+### Upstream access interfaces (gateway routing time)
+
+1. When a request arrives, the gateway identifies the enrollment from the user access interface match
+2. If the offering's `upstream_access_config` contain template syntax, they are rendered using the enrollment context
+3. `enrollment_code()` resolves to the same code that was created at enrollment time (idempotent lookup)
+4. The resolved upstream URL is used to forward the request — no upstream `AccessInterface` records are created per enrollment
+
+## Consistency with Service Groups
+
+This mechanism mirrors the existing service group template pattern:
+
+| Aspect | Service Groups | Enrollment Templates |
+|--------|---------------|---------------------|
+| Template language | Jinja2 | Jinja2 |
+| Trigger | Service joins group | User enrolls in service |
+| Context | Service metadata | Enrollment + parameters |
+| Output | `AccessInterfaceData` | `AccessInterfaceData` |
+| Scope link | `AccessInterface.group_id` | `AccessInterface.entity_id` (enrollment) |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,93 @@
+# Usage
+
+`unitysvc-sellers` gives you two ways to manage seller catalogs on the
+UnitySVC platform:
+
+-   **CLI** — `usvc_seller` — the primary workflow for day-to-day
+    catalog authoring, validation, upload, and testing. Read the
+    [Getting Started](getting-started.md) guide first, then the full
+    [CLI Reference](cli-reference.md).
+-   **Python SDK** — `unitysvc_sellers.Client` / `AsyncClient` — a typed
+    HTTP client the CLI itself is built on. Use it when you want to
+    embed catalog management into your own scripts, CI/CD jobs, or
+    applications. See the [SDK Reference](sdk-reference.md).
+
+Both front-ends talk to the same `/v1/seller/*` HTTP API, so anything
+you can do from the CLI you can also do from the SDK.
+
+## Which one should I use?
+
+| You want to…                                              | Use        |
+| --------------------------------------------------------- | ---------- |
+| Author a seller catalog in local files and upload it      | CLI        |
+| Run connectivity tests against your services              | CLI        |
+| Inspect, promote, or deprecate services                   | CLI or SDK |
+| Embed "upload seller catalog" into a build script         | SDK        |
+| Bulk-generate services from an external data source       | SDK        |
+| Write an application that manages promotions or groups    | SDK        |
+| One-off operations where a shell command is faster        | CLI        |
+
+## Authentication
+
+Both the CLI and the SDK authenticate with a seller API key. Get one
+from the UnitySVC dashboard → **Settings → API Keys**, then export it:
+
+```bash
+export UNITYSVC_SELLER_API_KEY="svcpass_..."
+export UNITYSVC_SELLER_API_URL="https://seller.staging.unitysvc.com/v1"
+```
+
+The seller context is encoded entirely in the key — there is no
+separate `seller_id` to pass. For one-off overrides, every CLI command
+accepts `--api-key` / `--base-url` flags, and both `Client` and
+`AsyncClient` accept `api_key=` / `base_url=` constructor arguments.
+
+## Minimal examples
+
+**CLI**
+
+```bash
+usvc_seller data validate
+usvc_seller data upload --dryrun
+usvc_seller data upload
+usvc_seller services list
+```
+
+**SDK (sync)**
+
+```python
+from unitysvc_sellers import Client
+
+with Client() as client:
+    page = client.services.list(limit=50)
+    for svc in page.data:
+        print(svc.id, svc.name, svc.status)
+```
+
+**SDK (async)**
+
+```python
+import asyncio
+from unitysvc_sellers import AsyncClient
+
+async def main():
+    async with AsyncClient() as client:
+        page = await client.services.list(limit=50)
+        for svc in page.data:
+            print(svc.id, svc.name, svc.status)
+
+asyncio.run(main())
+```
+
+## Next steps
+
+-   [Getting Started](getting-started.md) — installation, seller
+    onboarding, and your first upload.
+-   [Data Structure](data-structure.md) — how a seller catalog is
+    organized on disk.
+-   [CLI Reference](cli-reference.md) — every command, option, and
+    subcommand of `usvc_seller`.
+-   [SDK Reference](sdk-reference.md) — `Client`, `AsyncClient`, resource
+    namespaces, exceptions, and end-to-end examples.
+-   [Workflows](workflows.md) — manual, web-assisted, and automated
+    catalog-authoring patterns.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -1,0 +1,866 @@
+# Workflows
+
+This guide explains the different workflows for managing service data with the UnitySVC Seller SDK.
+
+**Note:** All examples use the `usvc_seller` CLI (installed as a console entry point by the `unitysvc-sellers` package). For programmatic access to the same operations, see the [SDK Reference](sdk-reference.md).
+
+## Overview
+
+UnitySVC provides two ways to create and manage service data:
+
+1. **Web Interface** ([unitysvc.com](https://unitysvc.com)) - Create and edit data visually
+2. **SDK** (this tool) - Manage data locally with version control and automation
+
+The SDK supports these workflows:
+
+1. **Web-to-SDK Workflow** - Start with web interface, export to SDK for version control
+2. **Manual Workflow** - Create/edit files locally for small catalogs
+3. **Automated Workflow** - Script-based generation for large or dynamic catalogs
+
+```mermaid
+flowchart TB
+    subgraph WebStart["Getting Started"]
+        W1[Web Interface] --> W2[Export Data]
+        W2 --> W3[Local Files]
+    end
+
+    subgraph Manual["Manual/Ongoing"]
+        W3 --> A2[Edit Files]
+        A2 --> A3[usvc_seller data validate]
+        A3 --> A4[usvc_seller data format]
+        A4 --> A5[usvc_seller data upload]
+    end
+
+    subgraph Automated["Automated Workflow"]
+        B1[Configure populate script] --> B2[usvc_seller data populate]
+        B2 --> B3[usvc_seller data validate]
+        B3 --> B4[usvc_seller data format]
+        B4 --> B5[usvc_seller data upload]
+    end
+
+    subgraph Platform["UnitySVC Platform"]
+        A5 --> C[Backend API]
+        B5 --> C
+        C --> D[Service Available]
+    end
+```
+
+## Web-to-SDK Workflow
+
+**Recommended for getting started.** Use the web interface for initial setup, then transition to SDK for version control.
+
+### Step-by-Step Process
+
+#### 1. Create Data via Web Interface
+
+1. Go to [unitysvc.com](https://unitysvc.com) and sign in
+2. Create your Provider, Offerings, and Listings using the visual editor
+3. Export your data as JSON/TOML files
+
+#### 2. Set Up Local Directory
+
+Place exported files in the expected structure:
+
+```
+data/
+└── my-provider/
+    ├── provider.json
+    └── services/
+        └── my-service/
+            ├── offering.json
+            └── listing.json
+```
+
+#### 3. Validate and Upload
+
+```bash
+usvc_seller data validate
+usvc_seller data format
+usvc_seller data upload
+```
+
+#### 4. Ongoing Management
+
+After initial setup, manage changes locally:
+
+- Edit files directly
+- Use `usvc_seller data validate` to check changes
+- Commit to git for version control
+- Use CI/CD for automated uploads
+
+## Manual Workflow
+
+Best for:
+
+- Small number of services (< 20)
+- Teams comfortable editing JSON/TOML directly
+- Situations where web interface isn't preferred
+
+### Step-by-Step Process
+
+#### 1. Create Files Manually
+
+Create files following the [File Schemas](file-schemas.md) documentation:
+
+```
+data/
+└── my-provider/
+    ├── provider.json          # See provider_v1 schema
+    └── services/
+        └── my-service/
+            ├── offering.json  # See offering_v1 schema
+            └── listing.json   # See listing_v1 schema
+```
+
+#### 2. Edit Your Files
+
+Fill in your service details:
+
+- Provider information (name, contact, metadata)
+- Service offering details (API endpoints, pricing, capabilities)
+- Service listing details (user-facing info, documentation)
+
+#### 3. Validate Data
+
+```bash
+usvc_seller data validate
+```
+
+Fix any validation errors. Common issues:
+
+- Directory names not matching field values
+- Missing required fields
+- Invalid file paths
+
+#### 4. Format Files (Optional)
+
+```bash
+usvc_seller data format
+```
+
+This ensures:
+
+- JSON files have 2-space indentation
+- Files end with single newline
+- No trailing whitespace
+
+#### 5. Edit Local Files as Needed
+
+Edit JSON/TOML files directly to update service status or other fields. The file-based approach gives you full control and integrates naturally with version control.
+
+#### 6. Upload to Platform
+
+```bash
+# Set credentials
+export UNITYSVC_API_URL="https://api.unitysvc.com/v1"
+export UNITYSVC_SELLER_API_KEY="your-api-key"
+
+# Upload all services
+cd data
+usvc_seller data upload
+
+# Or from parent directory
+usvc_seller data upload --data-path ./data
+```
+
+#### 7. Verify on Platform
+
+```bash
+# List your services
+usvc_seller services list
+
+# Or list with custom fields for focused output
+usvc_seller services list --fields id,name,status
+
+# Filter by status
+usvc_seller services list --status active
+```
+
+### Version Control Integration
+
+```bash
+# After creating/updating files
+git add data/
+git commit -m "Add new service: my-service"
+git push
+
+# Upload from CI/CD
+usvc_seller data validate
+usvc_seller data upload --data-path ./data
+```
+
+## Automated Workflow (Template-Based)
+
+Best for providers with:
+
+- Large service catalogs (> 20 services)
+- Frequently changing services
+- Dynamic pricing or availability
+- Services added/deprecated automatically
+
+### How It Works
+
+The template-based approach separates **structure** (Jinja2 templates) from **data** (a populator script):
+
+```mermaid
+flowchart LR
+    subgraph "One-Time Setup"
+        A[Create service on unitysvc.com] --> B[Export offering.json & listing.json]
+        B --> C[Save as .j2 templates]
+        C --> D[Replace variables with {{ placeholders }}]
+    end
+
+    subgraph "Ongoing Population"
+        E[Populator script reads upstream API] --> F[Renders templates per service]
+        D --> F
+        F --> G[services/model-name/offering.json]
+        F --> H[services/model-name/listing.json]
+    end
+```
+
+The script is invoked by `usvc_seller data populate`, which reads a
+`[services_populator]` section in `provider.toml` to decide what to
+run. The script itself can be written in any language — Python,
+Node, shell — and just needs to write the generated files into
+`services/{name}/` under the provider directory.
+
+### Step-by-Step Process
+
+#### 1. Create a Working Service on unitysvc.com
+
+Start by creating a single service through the web interface:
+
+1. Go to [unitysvc.com](https://unitysvc.com) and sign in
+2. Create your Provider and one Service manually
+3. Configure all fields, test that it works end-to-end
+4. Export the working `offering.json` and `listing.json` files
+
+#### 2. Convert Exported Files to Templates
+
+Create `data/my-provider/templates/` directory and save the exported files as `.j2` templates:
+
+```
+data/my-provider/
+├── provider.toml
+├── templates/
+│   ├── offering.json.j2    # Template for offering
+│   └── listing.json.j2     # Template for listing
+├── scripts/
+│   └── update_services.py  # Yields model dictionaries
+└── services/               # Generated output
+```
+
+#### 3. Replace Variable Parts with Template Variables
+
+Edit the `.j2` files to replace model-specific values with Jinja2 placeholders:
+
+**`templates/offering.json.j2`**:
+```jinja2
+{
+  "schema": "offering_v1",
+  "name": "{{ name }}",
+{%- if display_name %}
+  "display_name": "{{ display_name }}",
+{%- endif %}
+  "description": "{{ description | default('', true) }}",
+  "service_type": "{{ service_type }}",
+  "status": "{{ status | default('ready') }}",
+  "currency": "USD",
+  "details": {
+    "model_name": "{{ model_name }}"
+{%- for key, value in details.items() %},
+    "{{ key }}": {{ value | tojson }}
+{%- endfor %}
+  },
+  "payout_price": {
+    "type": "revenue_share",
+    "percentage": "100.00"
+  },
+  "upstream_access_config": {
+    "{{ provider_display_name }} API": {
+      "access_method": "http",
+      "api_key": "${ secrets.{{ api_key_secret }} }",
+      "base_url": "{{ api_base_url }}"
+    }
+  }
+}
+```
+
+**`templates/listing.json.j2`**:
+```jinja2
+{
+  "schema": "listing_v1",
+  "display_name": "{{ display_name | default(name) }}",
+  "status": "{{ listing_status | default('ready') }}",
+  "currency": "USD",
+{%- if pricing %}
+  "list_price": {
+    "type": "{{ pricing.type }}"
+{%- if pricing.input is defined %},
+    "input": "{{ pricing.input }}",
+    "output": "{{ pricing.output }}"
+{%- elif pricing.price is defined %},
+    "price": "{{ pricing.price }}"
+{%- endif %}
+  },
+{%- endif %}
+  "user_access_interfaces": {
+    "Provider API": {
+      "access_method": "http",
+      "base_url": "${API_GATEWAY_BASE_URL}/p/{{ gateway_path }}"
+    }
+  },
+  "documents": {
+{%- if service_type == 'image_generation' %}
+    "Python code example": {
+      "category": "code_example",
+      "file_path": "../../docs/code_example_image.py.j2",
+      "mime_type": "python",
+      "is_public": true
+    }
+{%- else %}
+    "Python code example": {
+      "category": "code_example",
+      "file_path": "../../docs/code_example.py.j2",
+      "mime_type": "python",
+      "is_public": true
+    }
+{%- endif %}
+  }
+}
+```
+
+#### 4. Write Script to Generate Service Files
+
+Create `scripts/update_services.py` that fetches from your API,
+renders the templates, and writes one pair of files per service
+into `services/{name}/`:
+
+```python
+#!/usr/bin/env python3
+"""Generate services from upstream API + Jinja2 templates.
+
+This script is invoked by `usvc_seller data populate`. It reads the
+provider's upstream API, renders the local .j2 templates for every
+service, and writes the results into services/{name}/ under the
+provider directory.
+"""
+
+import json
+import os
+from pathlib import Path
+
+import jinja2
+import requests
+
+PROVIDER_DIR = Path(__file__).resolve().parent.parent
+TEMPLATES_DIR = PROVIDER_DIR / "templates"
+SERVICES_DIR = PROVIDER_DIR / "services"
+
+
+def fetch_models() -> list[dict]:
+    """Fetch models from the provider's upstream API."""
+    api_key = os.environ["MY_PROVIDER_API_KEY"]
+    resp = requests.get(
+        "https://api.myprovider.com/v1/models",
+        headers={"Authorization": f"Bearer {api_key}"},
+    )
+    resp.raise_for_status()
+    return resp.json()["models"]
+
+
+def determine_service_type(model: dict) -> str:
+    if "embedding" in model["id"].lower():
+        return "embedding"
+    if "image" in model["id"].lower():
+        return "image_generation"
+    return "llm"
+
+
+def extract_pricing(model: dict) -> dict | None:
+    if "pricing" not in model:
+        return None
+    p = model["pricing"]
+    return {
+        "type": "one_million_tokens",
+        "input": str(p.get("input_per_million", 0)),
+        "output": str(p.get("output_per_million", 0)),
+    }
+
+
+def build_context(model: dict) -> dict:
+    """Flatten an upstream model record into template variables."""
+    return {
+        # Required — becomes the service directory name.
+        "name": model["id"],
+        # Offering fields.
+        "display_name": model.get("display_name"),
+        "description": model.get("description", ""),
+        "service_type": determine_service_type(model),
+        "status": "ready" if model.get("active") else "draft",
+        "model_name": model["full_name"],
+        "details": {
+            "contextLength": model.get("context_length"),
+            "supportsTools": model.get("supports_tools", False),
+        },
+        # Listing fields.
+        "listing_status": "ready",
+        "pricing": extract_pricing(model),
+        # Provider-specific constants.
+        "provider_display_name": "My Provider",
+        "api_key_secret": "MY_PROVIDER_API_KEY",
+        "api_base_url": "https://api.myprovider.com/v1",
+        "gateway_path": "myprovider",
+    }
+
+
+def render_and_write(env: jinja2.Environment, name: str, context: dict) -> None:
+    service_dir = SERVICES_DIR / name
+    service_dir.mkdir(parents=True, exist_ok=True)
+    for template_name, output_name in (
+        ("offering.json.j2", "offering.json"),
+        ("listing.json.j2", "listing.json"),
+    ):
+        template = env.get_template(template_name)
+        rendered = template.render(**context)
+        # Validate JSON before writing so a broken template fails
+        # loudly instead of producing a half-written file.
+        json.loads(rendered)
+        (service_dir / output_name).write_text(rendered)
+
+
+def main() -> None:
+    env = jinja2.Environment(
+        loader=jinja2.FileSystemLoader(str(TEMPLATES_DIR)),
+        keep_trailing_newline=True,
+    )
+
+    existing = {p.name for p in SERVICES_DIR.iterdir() if p.is_dir()} if SERVICES_DIR.exists() else set()
+    generated: set[str] = set()
+
+    for model in fetch_models():
+        if not model.get("is_available"):
+            continue
+        context = build_context(model)
+        render_and_write(env, context["name"], context)
+        generated.add(context["name"])
+
+    # Auto-deprecate services that disappeared upstream. The next
+    # `usvc_seller data upload` will propagate status=deprecated to
+    # the backend.
+    for stale_name in existing - generated:
+        listing = SERVICES_DIR / stale_name / "listing.json"
+        if listing.exists():
+            data = json.loads(listing.read_text())
+            if data.get("status") != "deprecated":
+                data["status"] = "deprecated"
+                listing.write_text(json.dumps(data, indent=2) + "\n")
+
+    print(f"Generated {len(generated)} services, deprecated {len(existing - generated)}")
+
+
+if __name__ == "__main__":
+    main()
+```
+
+#### 5. Configure Provider to Run the Script
+
+Create `data/my-provider/provider.toml`:
+
+```toml
+schema = "provider_v1"
+name = "my-provider"
+display_name = "My Service Provider"
+
+[services_populator]
+command = "scripts/update_services.py"
+requirements = ["requests"]
+
+[services_populator.envs]
+MY_PROVIDER_API_KEY = ""  # Set via environment variable
+```
+
+#### 6. Run Populate Command
+
+```bash
+# Generate all services
+usvc_seller data populate
+
+# Generate for specific provider only
+usvc_seller data populate --provider my-provider
+
+# Dry run to see what would execute
+usvc_seller data populate --dry-run
+```
+
+Output shows progress:
+```
+[1/50] llama-3-70b
+  OK: llm
+[2/50] gpt-4-turbo
+  OK: llm
+...
+  Deprecated: old-model-v1
+  Deprecated: legacy-service
+
+Done! Total: 50, Written: 45, Skipped: 3, Filtered: 2, Errors: 0, Deprecated: 2
+```
+
+**Note:** Services that exist locally but are no longer returned by the upstream API are automatically marked as deprecated (their `offering.json` status is set to `"deprecated"`). To sync this to the backend, run `usvc_seller data upload` - deprecated services with a `service_id` will update the server-side status to deprecated.
+
+#### 7. Validate, Format, and Upload
+
+```bash
+usvc_seller data validate
+usvc_seller data format
+
+# Review changes
+git diff
+git add data/
+git commit -m "Update service catalog from API"
+
+# Upload
+usvc_seller data upload
+```
+
+### Template Tips
+
+**Conditional Fields:**
+```jinja2
+{%- if display_name %}
+  "display_name": "{{ display_name }}",
+{%- endif %}
+```
+
+**Iterating Over Details:**
+```jinja2
+"details": {
+{%- for key, value in details.items() %}
+    "{{ key }}": {{ value | tojson }}{{ "," if not loop.last else "" }}
+{%- endfor %}
+}
+```
+
+**Service Type Variations:**
+```jinja2
+{%- if service_type == 'image_generation' %}
+    "file_path": "../../docs/image_example.py.j2"
+{%- else %}
+    "file_path": "../../docs/chat_example.py.j2"
+{%- endif %}
+```
+
+**Default Values:**
+```jinja2
+"status": "{{ status | default('ready') }}"
+"description": "{{ description | default('', true) }}"
+```
+
+### Filtering Models
+
+Filter in the script itself — just skip models before calling
+`render_and_write`:
+
+```python
+for model in fetch_models():
+    if model.get("status") != "ready":
+        continue
+    if determine_service_type(model) != "llm":
+        continue
+    render_and_write(env, context["name"], build_context(model))
+```
+
+### Automation with CI/CD
+
+Create `.github/workflows/update-services.yml`:
+
+```yaml
+name: Update Services
+
+on:
+    schedule:
+        - cron: "0 0 * * *" # Daily at midnight
+    workflow_dispatch:
+
+jobs:
+    update:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+
+            - name: Set up Python
+              uses: actions/setup-python@v4
+              with:
+                  python-version: "3.11"
+
+            - name: Install dependencies
+              run: pip install unitysvc-sellers requests jinja2
+
+            - name: Generate services from templates
+              env:
+                  MY_PROVIDER_API_KEY: ${{ secrets.MY_PROVIDER_API_KEY }}
+              run: usvc_seller data populate
+
+            - name: Validate
+              run: usvc_seller data validate
+
+            - name: Format
+              run: usvc_seller data format
+
+            - name: Commit changes
+              run: |
+                  git config user.name "GitHub Actions"
+                  git config user.email "actions@github.com"
+                  git add data/
+                  git diff --staged --quiet || git commit -m "Update services from API"
+                  git push
+
+            - name: Upload to UnitySVC
+              env:
+                  UNITYSVC_API_URL: ${{ secrets.UNITYSVC_API_URL }}
+                  UNITYSVC_SELLER_API_KEY: ${{ secrets.UNITYSVC_SELLER_API_KEY }}
+              run: |
+                  usvc_seller data upload --data-path ./data
+```
+
+### Summary: Template-Based Workflow
+
+| Step | Action | Output |
+|------|--------|--------|
+| 1 | Create working service on unitysvc.com | Verified offering.json, listing.json |
+| 2 | Export and save as .j2 templates | templates/offering.json.j2, listing.json.j2 |
+| 3 | Replace variables with `{{ placeholders }}` | Parameterized templates |
+| 4 | Write script that yields model dicts | scripts/update_services.py |
+| 5 | Run `usvc_seller data populate` (which invokes the script) | services/{name}/offering.json, listing.json |
+
+## Hybrid Workflow
+
+Combine web interface and automated approaches:
+
+1. Use automated populate for most services
+2. Use web interface or manual files for special/custom services
+3. Edit files directly to adjust individual services
+
+```bash
+# Generate bulk of services from provider API
+usvc_seller data populate
+
+# Create premium service via web interface and export, or create files manually
+# Place in: data/my-provider/services/premium-service/
+
+# Edit files directly to update status or other fields
+# Then validate and upload
+usvc_seller data validate
+usvc_seller data upload
+```
+
+## Service Upload Lifecycle
+
+Understanding how services are created and updated is essential for managing your catalog:
+
+### First Upload: New Service Creation
+
+When you upload a listing file for the **first time** (from a new repository or data directory):
+
+1. **A new Service is always created** - even if the content is identical to an existing service
+2. The Service ID is generated by the backend
+3. **The SDK saves the `service_id`** to an override file (e.g., `listing.override.json`)
+
+```bash
+# First upload - creates a new service
+$ usvc_seller data upload
+  + Created service: my-service (provider: my-provider)
+    Service ID: 550e8400-e29b-41d4-a716-446655440000
+    → Saved to listing.override.json
+```
+
+### Override File Persistence
+
+After the first successful publish, the override file contains the stable service identity and the backend-resolved service name:
+
+```json
+// listing.override.json (auto-generated)
+{
+    "service_id": "550e8400-e29b-41d4-a716-446655440000",
+    "name": "gpt-4-enterprise"
+}
+```
+
+The `name` field is the backend-resolved service name (`listing.name` if set, otherwise `offering.name`). It is saved as a valid `listing.name` field, so it feeds back into subsequent uploads. This provides an unambiguous reference when targeting services in promotion files.
+
+**Best practices for override files:**
+
+- **Commit to version control** - preserves service identity across team members
+- **Don't manually edit** - the SDK manages this file
+- **Keep per-environment** if deploying to staging/production separately
+
+### Subsequent Uploads: Service Updates
+
+On subsequent uploads, the SDK automatically loads the `service_id` from the override file:
+
+```bash
+# Subsequent upload - updates existing service
+$ usvc_seller data upload
+  ~ Updated service: my-service (provider: my-provider)
+    Service ID: 550e8400-e29b-41d4-a716-446655440000
+```
+
+The Service ID remains stable, ensuring:
+
+- Subscriptions continue to work
+- Usage history is preserved
+- Customers experience no disruption
+
+### Uploading as New Service
+
+To create a completely new service (ignoring existing `service_id`):
+
+```bash
+# Delete the override file
+rm listing.override.json
+
+# Upload creates a new service with a new ID
+usvc_seller data upload
+```
+
+## Upload Order
+
+**Recommended:** Use `usvc_seller data upload` to upload all types automatically in the correct order:
+
+```mermaid
+flowchart LR
+    subgraph Step1["Step 1"]
+        A[Sellers]
+        B[Providers]
+    end
+
+    subgraph Step2["Step 2"]
+        C[Service Offerings]
+    end
+
+    subgraph Step3["Step 3"]
+        D[Service Listings]
+    end
+
+    A --> D
+    B --> C
+    C --> D
+
+    style A fill:#e1f5fe
+    style B fill:#e1f5fe
+    style C fill:#fff3e0
+    style D fill:#e8f5e9
+```
+
+1. **Sellers** - Must exist before listings
+2. **Providers** - Must exist before offerings
+3. **Service Offerings** - Links providers to services
+4. **Service Listings** - Links sellers to offerings
+
+The CLI handles this order automatically. Incorrect order will result in foreign key errors.
+
+## Deleting Services
+
+Use `usvc_seller services delete` to remove services from the backend:
+
+```bash
+# Preview what would be deleted
+usvc_seller services delete <service-id> --dryrun
+
+# Delete a service
+usvc_seller services delete <service-id>
+
+# Delete multiple services
+usvc_seller services delete <service-id-1> <service-id-2>
+
+# Force delete with active subscriptions (use with caution!)
+usvc_seller services delete <service-id> --force --yes
+```
+
+### Integration with Version Control
+
+After deleting services, update your local repository:
+
+```bash
+# Delete local files after removing from backend
+rm -rf data/my-provider/deprecated-service/
+
+# Commit the change
+git add data/
+git commit -m "Remove deprecated service from catalog"
+git push
+```
+
+### Best Practices for Deleting Services
+
+**Safety:**
+
+- **Always dryrun first** - Preview impact before deleting
+- **Check subscriptions** - Avoid force-deleting services with active users
+- **Use version control** - Keep deleted files in git history
+
+**Communication:**
+
+- **Notify users** - Warn customers before removing services
+- **Deprecation period** - Use `usvc_seller services deprecate` before deleting
+- **Document reasons** - Log why services were removed
+
+## Best Practices
+
+### Version Control
+
+- Commit generated files to git
+- Review changes before uploading
+- Use meaningful commit messages
+- Tag releases
+
+### Validation
+
+- Always run `usvc_seller data validate` before `usvc_seller data upload`
+- Fix all validation errors
+- Use `usvc_seller data format --check` in CI to enforce formatting
+
+### Environment Management
+
+- Use different API keys for dev/staging/prod
+- Store secrets in environment variables, not files
+
+### Error Handling
+
+- Check exit codes in scripts
+- Log populate script output
+- Retry failed publishes with exponential backoff
+
+### Documentation
+
+- Document custom populate scripts
+- Keep README.md updated with service catalog
+- Explain any special services or pricing
+
+## Troubleshooting
+
+### Populate Script Fails
+
+- Check API credentials in `services_populator.envs`
+- Verify script has execute permissions
+- Test script manually: `python3 populate_services.py`
+
+### Validation Errors After Populate
+
+- Check generated file formats
+- Verify all required fields are populated
+- Ensure file paths are relative
+
+### Upload Failures
+
+- Verify credentials are set
+- Check network connectivity
+- Use `usvc_seller data upload` to handle upload order automatically
+- Look for foreign key constraint errors
+- Verify you're in the correct directory or using `--data-path`
+
+## Next Steps
+
+- [CLI Reference](cli-reference.md) - Detailed command documentation
+- [Data Structure](data-structure.md) - File organization rules
+- [File Schemas](file-schemas.md) - Schema specifications

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,87 @@
+site_name: UnitySVC Seller SDK
+site_description: Python SDK and CLI for the UnitySVC seller API
+site_author: UnitySVC Team
+site_url: https://unitysvc-sellers.readthedocs.io
+
+repo_name: unitysvc/unitysvc-sellers
+repo_url: https://github.com/unitysvc/unitysvc-sellers
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  palette:
+    - scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.tabs
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - content.code.annotate
+
+plugins:
+  - search
+
+markdown_extensions:
+  - admonition
+  - codehilite
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.details
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - toc:
+      permalink: true
+  - tables
+  - attr_list
+  - md_in_html
+
+nav:
+  - Home: index.md
+  - Getting Started:
+      - Usage Overview: usage.md
+      - Installation & Quick Start: getting-started.md
+      - Service Types: service-types.md
+      - Data Structure: data-structure.md
+      - Workflows: workflows.md
+      - Seller Lifecycle: seller-lifecycle.md
+  - Reference:
+      - CLI Commands: cli-reference.md
+      - Python SDK: sdk-reference.md
+      - File Schemas: file-schemas.md
+      - Pricing: pricing.md
+      - Code Examples: code-examples.md
+      - Documenting Services: documenting-services.md
+  - Advanced:
+      - User Access Interface Templates: tech-notes/user-access-interface-template.md
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/unitysvc/unitysvc-sellers
+    - icon: fontawesome/brands/python
+      link: https://pypi.org/project/unitysvc-sellers/
+
+copyright: Copyright &copy; 2026 UnitySVC

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,12 @@ dev = [
   "ty",
   "ipdb",
 ]
+docs = [
+  "mkdocs",
+  "mkdocs-material",
+  "mkdocs-autorefs",
+  "pymdown-extensions",
+]
 
 [project.urls]
 bugs = "https://github.com/unitysvc/unitysvc-sellers/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "unitysvc-sellers"
-version = "0.2.0"
+version = "0.1.1"
 description = "Seller-facing tools for UnitySVC: HTTP SDK + usvc_seller CLI"
 readme = "README.md"
 authors = [{ name = "Bo Peng", email = "bo.peng@unitysvc.com" }]


### PR DESCRIPTION
## Summary

- Ports the entire MkDocs Material / ReadTheDocs site from `unitysvc-services` so the new SDK has a real documentation home, not just the README.
- Adds a new ~520-line **`docs/sdk-reference.md`** chapter covering `Client` / `AsyncClient`, every resource namespace, the `upload_directory` helper, task polling, exception handling, a local-execution `run-tests` example, and an end-to-end CI script.
- Bulk-renames `usvc` → `usvc_seller`, `unitysvc-services` → `unitysvc-sellers`, `unitysvc_services` → `unitysvc_sellers` across every page.
- Drops `api-reference.md` (legacy `ServiceDataPublisher` API), `installation.md` (folded into Getting Started), and `development.md` / `contributing.md` (internal-contributor pages, not relevant to seller audience).
- Rewrites `usage.md` as a short "which front-end should I use" landing page that points sellers at either the CLI or the SDK.
- Rewrites the automated workflow in `workflows.md` to use the new `[services_populator]` provider.toml + standalone-script model instead of the removed `populate_from_iterator()` import.
- Fixes five pre-existing broken intra-doc anchors so `mkdocs build --strict` passes clean.
- Adds the `docs` extra to `pyproject.toml` (mkdocs, mkdocs-material, mkdocs-autorefs, pymdown-extensions) and the `.readthedocs.yaml` build hook.

## Test plan

- [x] `uv run --extra docs mkdocs build --strict` passes with zero warnings
- [x] No `usvc` (bare) or `unitysvc-services` references remain in `docs/`
- [x] No double-renamed `usvc_seller_seller` strings
- [x] All 14 markdown pages reachable from the nav
- [x] `tech-notes/user-access-interface-template.md` included in the Advanced section
- [ ] Once merged, the ReadTheDocs build picks up `.readthedocs.yaml` and publishes at https://unitysvc-sellers.readthedocs.io
- [ ] Smoke-check the rendered SDK reference page in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)