### PR TITLE
Default to production URL, add /docs endpoints, remove legacy surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ Seller-facing tools for [UnitySVC](https://unitysvc.com/). Provides:
 - A typed Python **HTTP SDK** with sync ([`Client`](#programmatic-usage))
   and async ([`AsyncClient`](#async-client)) facades for the seller
   API surface — services, promotions, service groups, documents, and
-  end-to-end catalog upload. Defaults to the dedicated
-  `seller.staging.unitysvc.com/v1` subdomain; overridable via
-  `UNITYSVC_SELLER_API_URL` for production or local development.
+  end-to-end catalog upload. Defaults to the production
+  `seller.unitysvc.com/v1` subdomain; overridable via
+  `UNITYSVC_SELLER_API_URL` for staging or local development.
 - The **`usvc_seller` CLI** for organizing local seller catalogs and
   for managing remote services / promotions / service groups against
   the UnitySVC backend.
@@ -61,7 +61,7 @@ print(f"services: {result.services.success}/{result.services.total}")
 | Source     | Default                                   | Override                                                    |
 |------------|-------------------------------------------|-------------------------------------------------------------|
 | API key    | (required)                                | `Client(api_key=...)` / `UNITYSVC_SELLER_API_KEY`           |
-| Base URL   | `https://seller.staging.unitysvc.com/v1`  | `Client(base_url=...)` / `UNITYSVC_SELLER_API_URL`          |
+| Base URL   | `https://seller.unitysvc.com/v1`          | `Client(base_url=...)` / `UNITYSVC_SELLER_API_URL`          |
 | Timeout    | 30 s                                      | `Client(timeout=...)`                                       |
 
 The seller context is encoded entirely in the API key (`svcpass_...`),
@@ -79,15 +79,12 @@ subdomain + API key. The same generated SDK works against any
 deployment layout without regeneration:
 
 ```python
-# Default: seller-scoped staging subdomain
+# Default: production seller subdomain
 Client()  # reads UNITYSVC_SELLER_API_URL or defaults to
-          # https://seller.staging.unitysvc.com/v1
+          # https://seller.unitysvc.com/v1
 
-# Production (seller-scoped subdomain)
-Client(base_url="https://seller.unitysvc.com/v1")
-
-# Legacy combined surface where /seller is a path component
-Client(base_url="https://api.unitysvc.com/v1/seller")
+# Staging
+Client(base_url="https://seller.staging.unitysvc.com/v1")
 
 # Local development against a running backend
 Client(base_url="http://localhost:8000/v1/seller")
@@ -129,6 +126,18 @@ client.secrets.delete("OPENAI_API_KEY")
 
 Secret names must be uppercase with underscores (e.g. `OPENAI_API_KEY`,
 `STRIPE_SECRET`). Names starting with `__` are reserved for platform use.
+
+### API documentation
+
+The seller API serves interactive docs directly from the backend:
+
+| Endpoint   | Description                                      |
+|------------|--------------------------------------------------|
+| `/docs`    | Swagger UI — interactive API explorer            |
+| `/redoc`   | ReDoc — detailed reference documentation         |
+
+For production: <https://seller.unitysvc.com/docs> and
+<https://seller.unitysvc.com/redoc>.
 
 ### Pagination
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,20 @@
 # unitysvc-sellers
 
-Seller-facing tools for [UnitySVC](https://unitysvc.com/). Provides:
+Python SDK and CLI for the [UnitySVC](https://unitysvc.com/) seller
+API (`https://seller.unitysvc.com/v1`). This package provides:
 
-- A typed Python **HTTP SDK** with sync ([`Client`](#programmatic-usage))
-  and async ([`AsyncClient`](#async-client)) facades for the seller
-  API surface — services, promotions, service groups, documents, and
-  end-to-end catalog upload. Defaults to the production
-  `seller.unitysvc.com/v1` subdomain; overridable via
-  `UNITYSVC_SELLER_API_URL` for staging or local development.
-- The **`usvc_seller` CLI** for organizing local seller catalogs and
-  for managing remote services / promotions / service groups against
-  the UnitySVC backend.
+1. **`unitysvc_sellers`** — a typed Python package (sync `Client` +
+   async `AsyncClient`) that wraps the upstream REST API into
+   importable, type-checked method calls.
+2. **`usvc_seller`** — a CLI built on top of the SDK for day-to-day
+   seller operations (catalog management, secret rotation, service
+   lifecycle) without writing code.
+
+| | Documentation |
+|-|---------------|
+| **Upstream API** | [Swagger UI](https://seller.unitysvc.com/docs) · [ReDoc](https://seller.unitysvc.com/redoc) |
+| **Python SDK** | [SDK Reference](https://unitysvc-sellers.readthedocs.io/en/latest/sdk-reference/) · [API Reference (auto-generated)](https://unitysvc-sellers.readthedocs.io/en/latest/api-reference/) |
+| **CLI** | [CLI Reference](https://unitysvc-sellers.readthedocs.io/en/latest/cli-reference/) |
 
 ## Install
 
@@ -126,18 +130,6 @@ client.secrets.delete("OPENAI_API_KEY")
 
 Secret names must be uppercase with underscores (e.g. `OPENAI_API_KEY`,
 `STRIPE_SECRET`). Names starting with `__` are reserved for platform use.
-
-### API documentation
-
-The seller API serves interactive docs directly from the backend:
-
-| Endpoint   | Description                                      |
-|------------|--------------------------------------------------|
-| `/docs`    | Swagger UI — interactive API explorer            |
-| `/redoc`   | ReDoc — detailed reference documentation         |
-
-For production: <https://seller.unitysvc.com/docs> and
-<https://seller.unitysvc.com/redoc>.
 
 ### Pagination
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,84 @@
+# API Reference (auto-generated)
+
+This page is auto-generated from source docstrings via
+[mkdocstrings](https://mkdocstrings.github.io/). For narrative
+documentation with examples, see [Python SDK](sdk-reference.md).
+
+## Client
+
+::: unitysvc_sellers.Client
+    options:
+      members:
+        - from_env
+        - services
+        - promotions
+        - groups
+        - documents
+        - secrets
+        - tasks
+        - upload
+
+## AsyncClient
+
+::: unitysvc_sellers.AsyncClient
+    options:
+      members:
+        - from_env
+        - services
+        - promotions
+        - groups
+        - documents
+        - secrets
+        - tasks
+
+## Resources
+
+### SecretsResource
+
+::: unitysvc_sellers.resources.secrets.SecretsResource
+    options:
+      members:
+        - list
+        - get
+        - create
+        - rotate
+        - delete
+
+### ServicesResource
+
+::: unitysvc_sellers.resources.services.ServicesResource
+    options:
+      show_root_heading: true
+
+### PromotionsResource
+
+::: unitysvc_sellers.resources.promotions.PromotionsResource
+    options:
+      show_root_heading: true
+
+### GroupsResource
+
+::: unitysvc_sellers.resources.groups.GroupsResource
+    options:
+      show_root_heading: true
+
+### DocumentsResource
+
+::: unitysvc_sellers.resources.documents.DocumentsResource
+    options:
+      show_root_heading: true
+
+## Exceptions
+
+::: unitysvc_sellers.exceptions
+    options:
+      members:
+        - SellerSDKError
+        - APIError
+        - AuthenticationError
+        - PermissionError
+        - NotFoundError
+        - ValidationError
+        - ConflictError
+        - RateLimitError
+        - ServerError

--- a/docs/sdk-reference.md
+++ b/docs/sdk-reference.md
@@ -25,7 +25,7 @@ environment by default:
 | Variable                  | Purpose                                                                        |
 | ------------------------- | ------------------------------------------------------------------------------ |
 | `UNITYSVC_SELLER_API_KEY` | Seller API key (`svcpass_…`). Get one from the UnitySVC dashboard.             |
-| `UNITYSVC_SELLER_API_URL` | Base URL for the seller API. Defaults to `https://seller.staging.unitysvc.com/v1`. |
+| `UNITYSVC_SELLER_API_URL` | Base URL for the seller API. Defaults to `https://seller.unitysvc.com/v1`. |
 
 ```python
 from unitysvc_sellers import Client

--- a/docs/sdk-reference.md
+++ b/docs/sdk-reference.md
@@ -97,6 +97,7 @@ properties:
 | `client.promotions`  | `/seller/promotions/*`                                        | CRUD on seller-funded promotion codes                                   |
 | `client.groups`      | `/seller/service-groups/*`                                    | CRUD on service groups                                                  |
 | `client.documents`   | `/seller/documents/*`                                         | Fetch document file content, execute (gateway dispatch), update test    |
+| `client.secrets`     | `/seller/secrets/*`                                           | Create, rotate, list, and delete encrypted seller secrets               |
 | `client.tasks`       | `/seller/tasks/*`                                             | Poll Celery task state for async operations (notably service upload)   |
 
 The async client exposes the same namespaces with `Async` prefixes
@@ -236,6 +237,49 @@ gateway. The CLI's `usvc_seller services run-tests` command, in
 contrast, runs the scripts **locally** on the seller's machine —
 see [Running connectivity tests locally](#running-connectivity-tests-locally)
 below for the recommended pattern.
+
+## `client.secrets`
+
+Manage encrypted seller secrets (API keys, tokens, credentials).
+Values are **write-only** — only metadata is ever returned by the API.
+
+| Method                       | Parameters              | Returns         | Description                          |
+| ---------------------------- | ----------------------- | --------------- | ------------------------------------ |
+| `list(skip=0, limit=100)`    | `skip: int`, `limit: int` | `SecretsPublic` | List secrets (metadata only)         |
+| `get(name)`                  | `name: str`             | `SecretPublic`  | Get one secret's metadata by name    |
+| `create(name, value)`        | `name: str`, `value: str` | `SecretPublic`  | Create a new secret                  |
+| `rotate(name, value)`        | `name: str`, `value: str` | `SecretPublic`  | Rotate (update) an existing secret   |
+| `delete(name)`               | `name: str`             | `None`          | Permanently delete a secret          |
+
+Secret names must be uppercase with underscores (e.g.
+`OPENAI_API_KEY`, `STRIPE_SECRET`). Names starting with `__` are
+reserved for platform use.
+
+```python
+from unitysvc_sellers import Client
+
+with Client() as client:
+    # Create a secret (value is write-only, cannot be retrieved)
+    client.secrets.create("OPENAI_API_KEY", "sk-proj-abc123...")
+
+    # List all secrets (metadata only)
+    for s in client.secrets.list().data:
+        print(s.name, s.created_at, s.last_used_at)
+
+    # Get one secret's metadata
+    meta = client.secrets.get("OPENAI_API_KEY")
+    print(meta.name, meta.updated_at)
+
+    # Rotate the value (e.g. after a key leak)
+    client.secrets.rotate("OPENAI_API_KEY", "sk-proj-new456...")
+
+    # Delete (immediate effect — services referencing it will break)
+    client.secrets.delete("OPENAI_API_KEY")
+```
+
+!!! warning "Write-only values"
+    The API never returns secret values. If you lose the value,
+    rotate it with a new one. There is no "get value" endpoint.
 
 ## `client.tasks`
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -34,7 +34,7 @@ from the UnitySVC dashboard → **Settings → API Keys**, then export it:
 
 ```bash
 export UNITYSVC_SELLER_API_KEY="svcpass_..."
-export UNITYSVC_SELLER_API_URL="https://seller.staging.unitysvc.com/v1"
+export UNITYSVC_SELLER_API_URL="https://seller.unitysvc.com/v1"
 ```
 
 The seller context is encoded entirely in the key — there is no

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,20 @@ theme:
 
 plugins:
   - search
+  - mkdocstrings:
+      default_handler: python
+      handlers:
+        python:
+          paths: [src]
+          options:
+            show_source: false
+            show_root_heading: true
+            show_category_heading: true
+            members_order: source
+            docstring_style: google
+            merge_init_into_class: true
+            show_signature_annotations: true
+            separate_signature: true
 
 markdown_extensions:
   - admonition
@@ -70,6 +84,7 @@ nav:
   - Reference:
       - CLI Commands: cli-reference.md
       - Python SDK: sdk-reference.md
+      - API Reference: api-reference.md
       - File Schemas: file-schemas.md
       - Pricing: pricing.md
       - Code Examples: code-examples.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ docs = [
   "mkdocs",
   "mkdocs-material",
   "mkdocs-autorefs",
+  "mkdocstrings[python]",
   "pymdown-extensions",
 ]
 

--- a/src/unitysvc_sellers/__init__.py
+++ b/src/unitysvc_sellers/__init__.py
@@ -26,8 +26,6 @@ constructor argument or the ``UNITYSVC_SELLER_API_URL`` env var.
 
 from ._spec_version import SPEC_SHA256, SPEC_VERSION
 from .aclient import AsyncClient
-from .model_data import ModelDataFetcher, ModelDataLookup
-from .template_populate import populate_from_iterator
 from .client import DEFAULT_SELLER_API_URL, ENV_SELLER_API_KEY, ENV_SELLER_API_URL, Client
 from .exceptions import (
     APIError,
@@ -64,8 +62,4 @@ __all__ = [
     "ConflictError",
     "RateLimitError",
     "ServerError",
-    # Catalog population utilities
-    "ModelDataFetcher",
-    "ModelDataLookup",
-    "populate_from_iterator",
 ]

--- a/src/unitysvc_sellers/__init__.py
+++ b/src/unitysvc_sellers/__init__.py
@@ -19,13 +19,15 @@ Quick start::
         print(s.name)
 
 The seller context is encoded entirely in the API key, so no separate
-``seller_id`` is required. The default base URL points at the staging
-environment (``https://seller.staging.unitysvc.com``); override with the
-``base_url`` constructor argument or the ``UNITYSVC_SELLER_API_URL`` env var.
+``seller_id`` is required. The default base URL points at production
+(``https://seller.unitysvc.com``); override with the ``base_url``
+constructor argument or the ``UNITYSVC_SELLER_API_URL`` env var.
 """
 
 from ._spec_version import SPEC_SHA256, SPEC_VERSION
 from .aclient import AsyncClient
+from .model_data import ModelDataFetcher, ModelDataLookup
+from .template_populate import populate_from_iterator
 from .client import DEFAULT_SELLER_API_URL, ENV_SELLER_API_KEY, ENV_SELLER_API_URL, Client
 from .exceptions import (
     APIError,
@@ -62,4 +64,8 @@ __all__ = [
     "ConflictError",
     "RateLimitError",
     "ServerError",
+    # Catalog population utilities
+    "ModelDataFetcher",
+    "ModelDataLookup",
+    "populate_from_iterator",
 ]

--- a/src/unitysvc_sellers/_cli_upload.py
+++ b/src/unitysvc_sellers/_cli_upload.py
@@ -4,7 +4,7 @@ Thin Typer wrapper over :meth:`unitysvc_sellers.Client.upload`. Reads
 credentials from the environment::
 
     UNITYSVC_SELLER_API_KEY    seller API key (svcpass_...)
-    UNITYSVC_SELLER_API_URL   override the default https://seller.staging.unitysvc.com
+    UNITYSVC_SELLER_API_URL   override the default https://seller.unitysvc.com
 
 Or pass them as flags.
 """

--- a/src/unitysvc_sellers/client.py
+++ b/src/unitysvc_sellers/client.py
@@ -20,9 +20,9 @@ Example::
 
 The seller context is encoded entirely in the API key, so no explicit
 ``seller_id`` is required. The default base URL points at the
-seller-scoped staging subdomain::
+production seller subdomain::
 
-    https://seller.staging.unitysvc.com/v1
+    https://seller.unitysvc.com/v1
 
 The SDK's generated paths are semantic resource paths
 (``/services/{id}``, ``/documents/{id}``, …) without any ``/seller``
@@ -31,14 +31,11 @@ key. A single SDK release therefore works against any deployment
 layout without regeneration; point ``base_url`` at whatever prefix the
 deployment uses::
 
-    # Staging (seller-scoped subdomain)
-    Client(base_url="https://seller.staging.unitysvc.com/v1")
-
-    # Production (seller-scoped subdomain)
+    # Production (default)
     Client(base_url="https://seller.unitysvc.com/v1")
 
-    # Legacy combined surface where /seller is a path component
-    Client(base_url="https://api.unitysvc.com/v1/seller")
+    # Staging (seller-scoped subdomain)
+    Client(base_url="https://seller.staging.unitysvc.com/v1")
 
     # Local development against a running backend
     Client(base_url="http://localhost:8000/v1/seller")
@@ -68,7 +65,7 @@ if TYPE_CHECKING:
     from .resources.tasks import TasksResource
     from .resources.upload import UploadResult
 
-DEFAULT_SELLER_API_URL = "https://seller.staging.unitysvc.com/v1"
+DEFAULT_SELLER_API_URL = "https://seller.unitysvc.com/v1"
 ENV_SELLER_API_KEY = "UNITYSVC_SELLER_API_KEY"
 ENV_SELLER_API_URL = "UNITYSVC_SELLER_API_URL"
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -42,7 +42,7 @@ class TestClientConstruction:
 
     def test_default_base_url(self) -> None:
         c = Client(api_key="svcpass_test")
-        assert c._base_url == "https://seller.staging.unitysvc.com/v1"
+        assert c._base_url == "https://seller.unitysvc.com/v1"
 
     def test_explicit_base_url_wins(self) -> None:
         c = Client(api_key="svcpass_test", base_url="https://other.example")


### PR DESCRIPTION
## Summary
- Change `DEFAULT_SELLER_API_URL` from `seller.staging.unitysvc.com` to `seller.unitysvc.com` across source, docs, and tests.
- Add API documentation section to README with `/docs` (Swagger UI) and `/redoc` endpoints.
- Remove legacy combined surface (`api.unitysvc.com/v1/seller`) references from README and client docstring.

## Test plan
- [ ] Verify `test_default_base_url` passes with the new production URL
- [ ] Confirm `/docs` and `/redoc` are accessible at `https://seller.unitysvc.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)