### PR TITLE
Add model_data and template_populate from unitysvc-services

### DIFF
--- a/src/unitysvc_sellers/model_data.py
+++ b/src/unitysvc_sellers/model_data.py
@@ -1,0 +1,496 @@
+"""Model data fetching utilities for LLM service providers.
+
+This module provides utilities for fetching model pricing, context window,
+and evaluation data from external sources like LiteLLM, Hugging Face,
+and OpenRouter. These are useful for any-llm providers that need to
+enrich their service data with information from these sources.
+
+Example usage:
+    from unitysvc_services.model_data import ModelDataFetcher, ModelDataLookup
+
+    fetcher = ModelDataFetcher()
+    litellm_data = fetcher.fetch_litellm_model_data()
+    hf_data = fetcher.fetch_huggingface_leaderboard_data()
+
+    lookup = ModelDataLookup()
+    details = lookup.lookup_model_details("gpt-4", litellm_data)
+"""
+
+import json
+from typing import Any
+
+import httpx
+
+
+class ModelDataFetcher:
+    """Handles fetching model data from external sources.
+
+    This class provides methods to fetch model information from various
+    public APIs and data sources:
+    - LiteLLM: Model pricing and context window data
+    - Hugging Face Leaderboard: Model evaluation benchmarks
+    - OpenRouter: Model details, pricing, and context lengths
+    - Hugging Face Model Hub: Individual model details
+
+    All fetch methods use caching to avoid redundant network requests.
+    """
+
+    def __init__(self, user_agent: str = "unitysvc-services/1.0"):
+        """Initialize the fetcher with an httpx client.
+
+        Args:
+            user_agent: User agent string for HTTP requests
+        """
+        self._client: httpx.Client | None = None
+        self._user_agent = user_agent
+        self._litellm_data: dict[str, Any] | None = None
+        self._hf_leaderboard_data: dict[str, Any] | None = None
+        self._openrouter_data: dict[str, Any] | None = None
+
+    @property
+    def client(self) -> httpx.Client:
+        """Lazily create and return the HTTP client."""
+        if self._client is None:
+            self._client = httpx.Client(
+                headers={"User-Agent": self._user_agent},
+                timeout=30.0,
+            )
+        return self._client
+
+    def fetch_litellm_model_data(self, quiet: bool = False) -> dict[str, Any]:
+        """Fetch model pricing and context window data from LiteLLM.
+
+        LiteLLM maintains a comprehensive JSON file with pricing and context
+        window information for models from various providers.
+
+        Args:
+            quiet: If True, suppress progress messages
+
+        Returns:
+            Dictionary mapping model identifiers to their pricing/context data.
+            Returns empty dict if fetch fails.
+
+        Example:
+            >>> fetcher = ModelDataFetcher()
+            >>> data = fetcher.fetch_litellm_model_data()
+            >>> data.get("gpt-4")
+            {'input_cost_per_token': 0.00003, 'output_cost_per_token': 0.00006, ...}
+        """
+        if self._litellm_data is not None:
+            return self._litellm_data
+
+        url = "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json"
+
+        try:
+            if not quiet:
+                print("Fetching LiteLLM model data...")
+            response = self.client.get(url)
+            response.raise_for_status()
+            self._litellm_data = response.json()
+            return self._litellm_data
+        except httpx.HTTPError as e:
+            if not quiet:
+                print(f"Warning: Failed to fetch LiteLLM model data: {e}")
+            self._litellm_data = {}
+            return self._litellm_data
+        except json.JSONDecodeError as e:
+            if not quiet:
+                print(f"Warning: Failed to parse LiteLLM model data: {e}")
+            self._litellm_data = {}
+            return self._litellm_data
+
+    def fetch_huggingface_leaderboard_data(self, quiet: bool = False) -> dict[str, Any]:
+        """Fetch model evaluation data from Hugging Face Open LLM Leaderboard.
+
+        The leaderboard contains benchmark scores for various LLMs on tasks
+        like ARC, HellaSwag, MMLU, TruthfulQA, WinoGrande, and GSM8K.
+
+        Args:
+            quiet: If True, suppress progress messages
+
+        Returns:
+            Dictionary mapping model names to their leaderboard data.
+            Returns empty dict if fetch fails.
+
+        Example:
+            >>> fetcher = ModelDataFetcher()
+            >>> data = fetcher.fetch_huggingface_leaderboard_data()
+            >>> data.get("meta-llama/Llama-2-70b-chat-hf")
+            {'average': 67.87, 'arc': 64.59, 'mmlu': 63.91, ...}
+        """
+        if self._hf_leaderboard_data is not None:
+            return self._hf_leaderboard_data
+
+        url = "https://huggingface.co/api/datasets/open-llm-leaderboard/results"
+
+        try:
+            if not quiet:
+                print("Fetching Hugging Face leaderboard data...")
+            response = self.client.get(url)
+            response.raise_for_status()
+            data = response.json()
+
+            # Convert to a dict keyed by model name for easier lookup
+            leaderboard_dict: dict[str, Any] = {}
+            if "rows" in data:
+                for row in data["rows"]:
+                    if "row" in row and "fullname" in row["row"]:
+                        model_name = row["row"]["fullname"]
+                        leaderboard_dict[model_name] = row["row"]
+
+            self._hf_leaderboard_data = leaderboard_dict
+            return self._hf_leaderboard_data
+        except httpx.HTTPError as e:
+            if not quiet:
+                print(f"Warning: Failed to fetch Hugging Face leaderboard data: {e}")
+            self._hf_leaderboard_data = {}
+            return self._hf_leaderboard_data
+        except (json.JSONDecodeError, KeyError) as e:
+            if not quiet:
+                print(f"Warning: Failed to parse Hugging Face leaderboard data: {e}")
+            self._hf_leaderboard_data = {}
+            return self._hf_leaderboard_data
+
+    def fetch_openrouter_models_data(self, quiet: bool = False) -> dict[str, Any]:
+        """Fetch model data from OpenRouter API.
+
+        OpenRouter provides information about available models including
+        context lengths, pricing, and capabilities.
+
+        Args:
+            quiet: If True, suppress progress messages
+
+        Returns:
+            Dictionary mapping model IDs to their OpenRouter data.
+            Returns empty dict if fetch fails.
+
+        Example:
+            >>> fetcher = ModelDataFetcher()
+            >>> data = fetcher.fetch_openrouter_models_data()
+            >>> data.get("anthropic/claude-3-opus")
+            {'id': 'anthropic/claude-3-opus', 'context_length': 200000, ...}
+        """
+        if self._openrouter_data is not None:
+            return self._openrouter_data
+
+        url = "https://openrouter.ai/api/v1/models"
+
+        try:
+            if not quiet:
+                print("Fetching OpenRouter model data...")
+            response = self.client.get(url)
+            response.raise_for_status()
+            data = response.json()
+
+            # Convert to a dict keyed by model ID for easier lookup
+            models_dict: dict[str, Any] = {}
+            if "data" in data:
+                for model in data["data"]:
+                    if "id" in model:
+                        models_dict[model["id"]] = model
+
+            self._openrouter_data = models_dict
+            return self._openrouter_data
+        except httpx.HTTPError as e:
+            if not quiet:
+                print(f"Warning: Failed to fetch OpenRouter model data: {e}")
+            self._openrouter_data = {}
+            return self._openrouter_data
+        except (json.JSONDecodeError, KeyError) as e:
+            if not quiet:
+                print(f"Warning: Failed to parse OpenRouter model data: {e}")
+            self._openrouter_data = {}
+            return self._openrouter_data
+
+    def fetch_huggingface_model_details(self, model_id: str, quiet: bool = False) -> dict[str, Any] | None:
+        """Fetch detailed model information from Hugging Face Model Hub API.
+
+        Attempts to fetch model details using various ID format variations
+        to handle different naming conventions.
+
+        Args:
+            model_id: Model identifier (e.g., "llama-2-70b", "meta-llama/Llama-2-70b")
+            quiet: If True, suppress progress messages
+
+        Returns:
+            Model details dict if found, None otherwise.
+
+        Example:
+            >>> fetcher = ModelDataFetcher()
+            >>> details = fetcher.fetch_huggingface_model_details("meta-llama/Llama-2-70b-chat-hf")
+            >>> details.get("pipeline_tag")
+            'text-generation'
+        """
+        # Try various model ID formats for HF
+        model_variations = [
+            model_id,
+            model_id.replace(":", "/"),
+            f"huggingface/{model_id}",
+            f"microsoft/{model_id}",
+            f"meta-llama/{model_id}",
+            f"google/{model_id}",
+            f"mistralai/{model_id}",
+            f"anthropic/{model_id}",
+        ]
+
+        # Use shorter timeout for individual model lookups
+        for model_name in model_variations:
+            url = f"https://huggingface.co/api/models/{model_name}"
+            try:
+                response = self.client.get(url, timeout=15.0)
+                if response.status_code == 200:
+                    return response.json()
+            except httpx.HTTPError:
+                continue
+
+        return None
+
+    def clear_cache(self) -> None:
+        """Clear all cached data to force fresh fetches."""
+        self._litellm_data = None
+        self._hf_leaderboard_data = None
+        self._openrouter_data = None
+
+    def close(self) -> None:
+        """Close the HTTP client."""
+        if self._client is not None:
+            self._client.close()
+            self._client = None
+
+    def __enter__(self) -> "ModelDataFetcher":
+        """Context manager entry."""
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        """Context manager exit."""
+        self.close()
+
+
+class ModelDataLookup:
+    """Handles looking up model details from fetched data.
+
+    This class provides static methods for fuzzy matching model IDs
+    against the data fetched by ModelDataFetcher.
+    """
+
+    @staticmethod
+    def lookup_model_details(model_id: str, litellm_data: dict[str, Any]) -> dict[str, Any] | None:
+        """Look up additional model details from LiteLLM data.
+
+        Performs fuzzy matching to find model data, trying:
+        1. Exact match
+        2. Match with provider prefix (e.g., "openai/gpt-4")
+        3. Partial match (model_id in key or key in model_id)
+
+        Args:
+            model_id: Model identifier to look up
+            litellm_data: Dictionary from fetch_litellm_model_data()
+
+        Returns:
+            Model details dict if found, None otherwise.
+        """
+        if not litellm_data:
+            return None
+
+        # Try exact match first
+        if model_id in litellm_data:
+            return litellm_data[model_id]
+
+        # Try with provider prefix
+        for key in litellm_data:
+            if key.endswith(f"/{model_id}") or key.endswith(model_id):
+                return litellm_data[key]
+
+        # Try partial match
+        for key in litellm_data:
+            if model_id in key or key in model_id:
+                return litellm_data[key]
+
+        return None
+
+    @staticmethod
+    def lookup_hf_leaderboard_details(model_id: str, hf_data: dict[str, Any]) -> dict[str, Any] | None:
+        """Look up model evaluation details from Hugging Face leaderboard data.
+
+        Performs fuzzy matching with various transformations including
+        case variations and underscore/hyphen substitutions.
+
+        Args:
+            model_id: Model identifier to look up
+            hf_data: Dictionary from fetch_huggingface_leaderboard_data()
+
+        Returns:
+            Leaderboard details dict if found, None otherwise.
+        """
+        if not hf_data:
+            return None
+
+        # Try exact match first
+        if model_id in hf_data:
+            return hf_data[model_id]
+
+        # Try different variations
+        variations = [
+            model_id.lower(),
+            model_id.upper(),
+            model_id.replace("-", "_"),
+            model_id.replace("_", "-"),
+        ]
+
+        for variation in variations:
+            if variation in hf_data:
+                return hf_data[variation]
+
+        # Try partial matching
+        for key in hf_data:
+            key_lower = key.lower()
+            model_lower = model_id.lower()
+
+            if model_lower in key_lower or key_lower in model_lower:
+                return hf_data[key]
+
+            # Try matching without common prefixes
+            key_clean = key_lower.replace("huggingface/", "").replace("microsoft/", "").replace("meta-llama/", "")
+            if model_lower in key_clean or key_clean in model_lower:
+                return hf_data[key]
+
+        return None
+
+    @staticmethod
+    def lookup_openrouter_details(model_id: str, openrouter_data: dict[str, Any]) -> dict[str, Any] | None:
+        """Look up model details from OpenRouter data.
+
+        Performs fuzzy matching with case-insensitive comparison
+        and partial matching.
+
+        Args:
+            model_id: Model identifier to look up
+            openrouter_data: Dictionary from fetch_openrouter_models_data()
+
+        Returns:
+            OpenRouter details dict if found, None otherwise.
+        """
+        if not openrouter_data:
+            return None
+
+        # Try exact match first
+        if model_id in openrouter_data:
+            return openrouter_data[model_id]
+
+        # Try different variations and partial matching
+        model_lower = model_id.lower()
+
+        for key in openrouter_data:
+            key_lower = key.lower()
+
+            if (
+                key_lower == model_lower
+                or key_lower.endswith(f"/{model_lower}")
+                or key_lower.endswith(model_lower)
+                or model_lower in key_lower
+                or key_lower in model_lower
+            ):
+                return openrouter_data[key]
+
+        return None
+
+    # =========================================================================
+    # HuggingFace pipeline_tag utilities
+    # =========================================================================
+
+    # Map HuggingFace pipeline_tag to code example template suffix.
+    # pipeline_tag is HuggingFace's standardized task taxonomy:
+    # https://huggingface.co/docs/hub/en/models-tasks
+    PIPELINE_EXAMPLE_SUFFIX: dict[str, str] = {
+        # NLP / text tasks → chat completion template
+        "text-generation": "",
+        "text2text-generation": "",
+        "conversational": "",
+        "fill-mask": "",
+        "text-classification": "",
+        "token-classification": "",
+        "question-answering": "",
+        "summarization": "",
+        "translation": "",
+        "zero-shot-classification": "",
+        "document-question-answering": "",
+        # Embedding / similarity → sentence transformers template
+        "feature-extraction": "-sentencetransformers",
+        "sentence-similarity": "-sentencetransformers",
+        # Image generation → image template
+        "text-to-image": "-image",
+        "unconditional-image-generation": "-image",
+        # Image-to-image → imagetoimage template
+        "image-to-image": "-imagetoimage",
+        # Vision → chat template (no dedicated vision template yet)
+        "image-to-text": "",
+        "image-text-to-text": "",
+        "visual-question-answering": "",
+        "image-classification": "",
+        "zero-shot-image-classification": "",
+        # Audio → speech templates
+        "automatic-speech-recognition": "-prerecordedtranscription",
+        "text-to-speech": "-tts",
+        "text-to-audio": "-tts",
+        # Video → text-to-video template
+        "text-to-video": "-ttv",
+        "image-to-video": "-ttv",
+    }
+
+    @staticmethod
+    def get_capabilities_from_hf(
+        model_id: str, fetcher: "ModelDataFetcher"
+    ) -> tuple[list[str], str]:
+        """Get capabilities and example suffix from HuggingFace model metadata.
+
+        Fetches pipeline_tag from the HuggingFace Model Hub API and uses it
+        as the model's capability. Also determines the appropriate code
+        example template suffix.
+
+        Args:
+            model_id: Model identifier (e.g., "meta-llama/Llama-3.1-8B")
+            fetcher: ModelDataFetcher instance for API calls
+
+        Returns:
+            Tuple of (capabilities list, example_suffix string).
+            capabilities uses HF pipeline_tag values directly (e.g., "text-generation",
+            "image-to-image", "automatic-speech-recognition").
+            example_suffix is the template suffix (e.g., "", "-image", "-tts").
+            Falls back to (["llm"], "") if HF metadata is unavailable.
+        """
+        hf_details = fetcher.fetch_huggingface_model_details(model_id, quiet=True)
+        if not hf_details:
+            return ["llm"], ""
+
+        pipeline_tag = hf_details.get("pipeline_tag")
+        if not pipeline_tag:
+            return ["llm"], ""
+
+        capabilities = [pipeline_tag]
+        example_suffix = ModelDataLookup.PIPELINE_EXAMPLE_SUFFIX.get(pipeline_tag, "")
+        return capabilities, example_suffix
+
+    @staticmethod
+    def get_hf_tags(model_id: str, fetcher: "ModelDataFetcher") -> list[str]:
+        """Get cleaned tags from HuggingFace model metadata.
+
+        Fetches tags from the HuggingFace Model Hub API, filtering out
+        metadata-only tags (base_model, region, license).
+
+        Args:
+            model_id: Model identifier
+            fetcher: ModelDataFetcher instance for API calls
+
+        Returns:
+            List of cleaned tag strings, or empty list if unavailable.
+        """
+        hf_details = fetcher.fetch_huggingface_model_details(model_id, quiet=True)
+        if not hf_details:
+            return []
+
+        return [
+            t for t in hf_details.get("tags", [])
+            if not t.startswith("base_model:")
+            and not t.startswith("region:")
+            and not t.startswith("license:")
+        ]

--- a/src/unitysvc_sellers/template_populate.py
+++ b/src/unitysvc_sellers/template_populate.py
@@ -1,0 +1,247 @@
+"""
+Template-based service population utilities.
+
+This module provides utilities for populating services using Jinja2 templates
+instead of the DataBuilder APIs. This approach separates data from structure.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Iterator
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from jinja2 import Environment, FileSystemLoader
+
+if TYPE_CHECKING:
+    pass
+
+
+def populate_from_iterator(
+    iterator: Iterator[dict],
+    templates_dir: str | Path,
+    output_dir: str | Path,
+    offering_template: str = "offering.json.j2",
+    listing_template: str = "listing.json.j2",
+    name_field: str = "name",
+    filter_func: Callable[[dict], bool] | None = None,
+    dry_run: bool = False,
+    deprecate_missing: bool = True,
+) -> dict:
+    """
+    Populate services from an iterator of model dictionaries.
+
+    This function renders Jinja2 templates with each dictionary from the iterator
+    and writes the resulting offering.json and listing.json files.
+
+    Args:
+        iterator: Yields dicts with template variables. Must include `name_field`.
+        templates_dir: Directory containing .j2 templates.
+        output_dir: Directory to write services (creates {name}/ subdirs).
+        offering_template: Filename of offering template (default: offering.json.j2).
+        listing_template: Filename of listing template (default: listing.json.j2).
+        name_field: Dict key to use for directory name (default: "name").
+        filter_func: Optional function that takes a model dict and returns True to
+            include it, False to skip. Useful for filtering without modifying iterator.
+        dry_run: If True, don't write files, just report what would happen.
+        deprecate_missing: If True (default), mark services that exist locally but
+            are no longer in the iterator as deprecated (sets status="deprecated").
+
+    Returns:
+        Stats dict: {"total": N, "written": N, "skipped": N, "filtered": N, "errors": N, "deprecated": N}
+
+    Example:
+        >>> def iter_models():
+        ...     yield {"name": "model-1", "service_type": "llm", ...}
+        ...     yield {"name": "model-2", "service_type": "llm", ...}
+        >>> populate_from_iterator(iter_models(), "templates", "services")
+
+        # With filter - only include LLM models
+        >>> populate_from_iterator(
+        ...     iter_models(),
+        ...     "templates",
+        ...     "services",
+        ...     filter_func=lambda m: m.get("service_type") == "llm"
+        ... )
+    """
+    templates_dir = Path(templates_dir)
+    output_dir = Path(output_dir)
+
+    # Track existing services before iteration (for deprecation)
+    existing_services: set[str] = set()
+    if deprecate_missing and output_dir.exists():
+        existing_services = {d.name for d in output_dir.iterdir() if d.is_dir() and (d / "offering.json").exists()}
+
+    updated_services: set[str] = set()
+
+    # Set up Jinja2 environment
+    env = Environment(
+        loader=FileSystemLoader(templates_dir),
+        trim_blocks=True,
+        lstrip_blocks=True,
+        keep_trailing_newline=True,
+    )
+
+    # Load templates
+    offering_tpl = env.get_template(offering_template)
+    listing_tpl = env.get_template(listing_template)
+
+    stats = {"total": 0, "written": 0, "skipped": 0, "filtered": 0, "errors": 0, "deprecated": 0}
+
+    for model_data in iterator:
+        stats["total"] += 1
+
+        # Get service name for directory
+        service_name = model_data.get(name_field)
+        if not service_name:
+            print(f"  Warning: Missing '{name_field}' field, skipping")
+            stats["errors"] += 1
+            continue
+
+        # Apply filter if provided
+        if filter_func is not None and not filter_func(model_data):
+            stats["filtered"] += 1
+            continue
+
+        # Sanitize directory name
+        dir_name = _sanitize_dirname(service_name)
+        service_dir = output_dir / dir_name
+
+        # Track this service as updated (for deprecation logic)
+        updated_services.add(dir_name)
+
+        try:
+            # Render templates
+            offering_json = offering_tpl.render(**model_data)
+            listing_json = listing_tpl.render(**model_data)
+
+            # Parse to validate JSON and normalize formatting
+            offering_data = json.loads(offering_json)
+            listing_data = json.loads(listing_json)
+
+            if dry_run:
+                print(f"  Would write: {dir_name}/")
+                stats["written"] += 1
+                continue
+
+            # Create directory
+            service_dir.mkdir(parents=True, exist_ok=True)
+
+            # Smart write (skip if unchanged, preserve time_created)
+            offering_written = _smart_write_json(
+                service_dir / "offering.json",
+                offering_data,
+            )
+            listing_written = _smart_write_json(
+                service_dir / "listing.json",
+                listing_data,
+            )
+
+            if offering_written or listing_written:
+                stats["written"] += 1
+            else:
+                stats["skipped"] += 1
+
+        except json.JSONDecodeError as e:
+            print(f"  Error: Invalid JSON for {service_name}: {e}")
+            stats["errors"] += 1
+        except Exception as e:
+            print(f"  Error processing {service_name}: {e}")
+            stats["errors"] += 1
+
+    # Deprecate services no longer in upstream
+    if deprecate_missing and not dry_run:
+        missing_services = existing_services - updated_services
+        for service_name in sorted(missing_services):
+            service_dir = output_dir / service_name
+            if _deprecate_service(service_dir):
+                stats["deprecated"] += 1
+                print(f"  Deprecated: {service_name}")
+
+    print(
+        f"\nDone! Total: {stats['total']}, Written: {stats['written']}, "
+        f"Skipped: {stats['skipped']}, Filtered: {stats['filtered']}, "
+        f"Errors: {stats['errors']}, Deprecated: {stats['deprecated']}"
+    )
+
+    return stats
+
+
+def _sanitize_dirname(name: str) -> str:
+    """Convert model name to valid directory name."""
+    return name.replace(":", "_").replace("/", "_")
+
+
+def _smart_write_json(path: Path, data: dict) -> bool:
+    """
+    Write JSON file only if content changed (ignoring time_created).
+
+    Preserves original time_created if file exists and content is different.
+    Adds time_created if not present.
+
+    Returns:
+        True if file was written, False if skipped (unchanged).
+    """
+    path = Path(path)
+
+    # Check existing file
+    if path.exists():
+        try:
+            existing = json.loads(path.read_text())
+
+            # Compare without time_created
+            existing_cmp = {k: v for k, v in existing.items() if k != "time_created"}
+            new_cmp = {k: v for k, v in data.items() if k != "time_created"}
+
+            if existing_cmp == new_cmp:
+                return False  # No changes
+
+            # Preserve original time_created
+            if "time_created" in existing:
+                data["time_created"] = existing["time_created"]
+
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    # Add time_created if not present
+    if "time_created" not in data:
+        data["time_created"] = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+    # Write file with consistent formatting (sorted keys for deterministic output)
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n")
+    return True
+
+
+def _deprecate_service(service_dir: Path) -> bool:
+    """
+    Mark a service as deprecated by updating its offering.json.
+
+    Sets status="deprecated" if not already deprecated.
+
+    Args:
+        service_dir: Path to the service directory.
+
+    Returns:
+        True if the service was newly deprecated, False if already deprecated or error.
+    """
+    offering_path = service_dir / "offering.json"
+    if not offering_path.exists():
+        return False
+
+    try:
+        data = json.loads(offering_path.read_text())
+
+        # Skip if already deprecated
+        if data.get("status") == "deprecated":
+            return False
+
+        # Mark as deprecated
+        data["status"] = "deprecated"
+
+        offering_path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n")
+        return True
+
+    except (json.JSONDecodeError, OSError):
+        return False


### PR DESCRIPTION
## Summary

- Moves `ModelDataFetcher`, `ModelDataLookup` (`model_data.py`) and `populate_from_iterator` (`template_populate.py`) from the deprecated `unitysvc-services` package into `unitysvc-sellers`.
- These are seller catalog build tools used by 12+ `unitysvc-services-*` repos in their `update_services.py` populate scripts.
- Import path: `from unitysvc_sellers.model_data import ModelDataFetcher, ModelDataLookup` and `from unitysvc_sellers.template_populate import populate_from_iterator`

Closes #9

## Test plan

- [ ] Verify `from unitysvc_sellers.model_data import ModelDataFetcher, ModelDataLookup` works
- [ ] Verify `from unitysvc_sellers.template_populate import populate_from_iterator` works
- [ ] Run `usvc_seller data populate` in a service data repo to confirm end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)