### PR TITLE
secrets set: drop --value-file/--value-stdin, add stdin/TTY auto-detect

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -28,7 +28,7 @@ $ usvc_seller [OPTIONS] COMMAND [ARGS]...
 * `services`: Remote service operations (list, show,...
 * `promotions`: Remote promotion operations (list, show,...
 * `groups`: Remote service group operations (list,...
-* `secrets`: Remote secret operations (list, show,...
+* `secrets`: Remote secret operations (list, show, set,...
 
 ## `usvc_seller data`
 
@@ -1050,7 +1050,7 @@ $ usvc_seller groups delete [OPTIONS] NAME_OR_ID
 
 ## `usvc_seller secrets`
 
-Remote secret operations (list, show, create, rotate, delete).
+Remote secret operations (list, show, set, delete).
 
 **Usage**:
 
@@ -1111,8 +1111,15 @@ $ usvc_seller secrets show [OPTIONS] NAME
 
 Set a secret to ``value`` (idempotent — creates or rotates).
 
-Maps to ``PUT /v1/seller/secrets/{name}``. The value cannot be
-retrieved after this call — store it securely if you need a copy.
+Maps to ``PUT /v1/seller/secrets/{name}``. The value is encrypted
+server-side and cannot be retrieved later. Resolution order:
+
+  1. ``--value VALUE``  — explicit literal (or ``--value &quot;$ENV&quot;``
+                          via shell expansion)
+  2. piped stdin        — ``echo v | usvc secrets set X``
+  3. interactive prompt — TTY only; hidden input
+
+Mirrors ``gh secret set`` and ``vault kv put``.
 
 **Usage**:
 
@@ -1126,9 +1133,7 @@ $ usvc_seller secrets set [OPTIONS] NAME
 
 **Options**:
 
-* `-v, --value TEXT`: Secret value. Omit to prompt securely.
-* `--value-file PATH`: Read value from file.
-* `--value-stdin`: Read value from stdin.
+* `-v, --value TEXT`: Secret value. If omitted: reads from stdin when piped, prompts with hidden input when run interactively.
 * `-f, --format TEXT`: Output format: table | json.  [default: table]
 * `--api-key TEXT`: Seller API key (svcpass_...). Defaults to $UNITYSVC_SELLER_API_KEY.  [env var: UNITYSVC_SELLER_API_KEY]
 * `--base-url TEXT`: Backend base URL.  [env var: UNITYSVC_SELLER_API_URL; default: https://seller.unitysvc.com/v1]

--- a/src/unitysvc_sellers/commands/secrets.py
+++ b/src/unitysvc_sellers/commands/secrets.py
@@ -1,11 +1,10 @@
-"""``usvc_seller secrets`` — remote seller secret operations.
+"""``usvc secrets`` — remote seller secret operations.
 
 Commands:
 
 - ``list``   — list the seller's secrets (metadata only)
 - ``show``   — show one secret's metadata by name
-- ``create`` — create a new secret
-- ``rotate`` — rotate (update) an existing secret's value
+- ``set``    — set a secret (idempotent — creates or rotates)
 - ``delete`` — permanently delete a secret
 """
 
@@ -14,7 +13,6 @@ from __future__ import annotations
 import json
 import sys
 from getpass import getpass
-from pathlib import Path
 
 import typer
 from rich.console import Console
@@ -32,41 +30,33 @@ from ._helpers import (
 console = Console()
 
 app = typer.Typer(
-    help="Remote secret operations (list, show, create, rotate, delete).",
+    help="Remote secret operations (list, show, set, delete).",
 )
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-def _read_value(
-    value: str | None,
-    value_file: Path | None,
-    value_stdin: bool,
-) -> str:
-    """Resolve a secret value from flags or interactive prompt.
+def _resolve_value(value: str | None, *, name: str) -> str:
+    """Resolve a secret value with mainstream-CLI semantics.
 
-    Priority: --value-stdin > --value-file > --value > interactive prompt.
+    Resolution order:
+      1. ``--value VALUE``  — explicit literal (also covers shell expansion
+                              like ``--value "$ENV_NAME"``)
+      2. piped stdin        — ``echo v | usvc secret set X``
+                              (trailing newline stripped)
+      3. interactive prompt — TTY only; hidden input
+
+    Mirrors ``gh secret set`` and ``vault kv put``.
     """
-    if value_stdin:
-        v = sys.stdin.read().strip()
-        if not v:
-            console.print("[red]Error:[/red] No value received on stdin")
-            raise typer.Exit(code=1)
-        return v
-    if value_file is not None:
-        if not value_file.exists():
-            console.print(f"[red]Error:[/red] File not found: {value_file}")
-            raise typer.Exit(code=1)
-        return value_file.read_text().strip()
     if value is not None:
         return value
-    # Interactive secure prompt
-    v = getpass("Secret value: ")
-    if not v:
-        console.print("[red]Error:[/red] No value provided")
-        raise typer.Exit(code=1)
-    return v
+    if not sys.stdin.isatty():
+        # Piped (or closed) stdin: read it. Strip a single trailing
+        # newline so ``echo "$X" | ...`` works as expected.
+        return sys.stdin.read().rstrip("\n")
+    # Terminal: prompt with hidden input.
+    return getpass(f"Value for secret '{name}': ")
 
 
 # ---------------------------------------------------------------------------
@@ -151,19 +141,31 @@ def show_secret(
 @app.command("set")
 def set_secret(
     name: str = typer.Argument(..., help="Secret name (uppercase + underscores, e.g. OPENAI_API_KEY)."),
-    value: str | None = typer.Option(None, "--value", "-v", help="Secret value. Omit to prompt securely."),
-    value_file: Path | None = typer.Option(None, "--value-file", help="Read value from file."),
-    value_stdin: bool = typer.Option(False, "--value-stdin", help="Read value from stdin."),
+    value: str | None = typer.Option(
+        None,
+        "--value",
+        "-v",
+        help=(
+            "Secret value. If omitted: reads from stdin when piped, prompts with hidden input when run interactively."
+        ),
+    ),
     output_format: str = typer.Option("table", "--format", "-f", help="Output format: table | json."),
     api_key: str | None = api_key_option(),
     base_url: str = base_url_option(),
 ) -> None:
     """Set a secret to ``value`` (idempotent — creates or rotates).
 
-    Maps to ``PUT /v1/seller/secrets/{name}``. The value cannot be
-    retrieved after this call — store it securely if you need a copy.
+    Maps to ``PUT /v1/seller/secrets/{name}``. The value is encrypted
+    server-side and cannot be retrieved later. Resolution order:
+
+      1. ``--value VALUE``  — explicit literal (or ``--value "$ENV"``
+                              via shell expansion)
+      2. piped stdin        — ``echo v | usvc secrets set X``
+      3. interactive prompt — TTY only; hidden input
+
+    Mirrors ``gh secret set`` and ``vault kv put``.
     """
-    resolved_value = _read_value(value, value_file, value_stdin)
+    resolved_value = _resolve_value(value, name=name)
 
     async def _impl():
         async with async_client(api_key, base_url) as client:


### PR DESCRIPTION
## Summary

Aligns the value-resolution scheme of ``usvc secrets set`` with ``gh secret set`` and other mainstream CLIs:

| Resolution order | When |
|---|---|
| 1. ``--value VALUE`` | explicit literal (or ``--value \"\$ENV\"`` via shell expansion) |
| 2. piped stdin | ``echo v \| usvc secrets set X`` (trailing newline stripped) |
| 3. interactive prompt | TTY only; hidden input |

Drops the ``--value-file PATH`` and ``--value-stdin`` flags — pipes cover both cases without a separate flag, and compose with anything that produces a value (``cat``, ``gpg -d``, ``op read``, ``aws ssm get-parameter``…).

## Why this shape

- **Matches ``gh secret set``** exactly — least surprise for anyone who's used GitHub's CLI.
- **Two fewer flags to remember** — the `_resolve_value` helper has 3 branches instead of 4, and the call signature drops two parameters.
- **Composable** — pipe handles every "value comes from elsewhere" case.
- **Interactive case stays secure** — TTY detection + hidden input via ``getpass``.

Also fixes a stale module docstring + Typer ``help`` that still listed ``create``/``rotate`` (the post-#798 surface is ``set``).

## Call patterns

```bash
usvc secrets set MY_KEY --value sk-foo            # literal
usvc secrets set MY_KEY --value "$MY_KEY"         # shell expansion (CLI sees literal)
echo "$MY_KEY" | usvc secrets set MY_KEY          # piped stdin
cat secret.txt | usvc secrets set MY_KEY          # file via cat
gpg -d secret.gpg | usvc secrets set MY_KEY       # any pipe source
usvc secrets set MY_KEY                           # interactive (TTY) → hidden prompt
```

## No version bump

Purely a CLI surface refinement — no SDK or API changes. Removing ``--value-file`` and ``--value-stdin`` is technically breaking for any callers that relied on them, but the replacements (``cat file | ...`` / piping) work in all the same places.

## Test plan

- [x] Secret-related tests: 15 passed
- [x] ``ruff check`` + ``ruff format`` clean
- [x] ``docs/cli-reference.md`` regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)