### PR TITLE
Fix silent truncation in fetch_service_ids_by_status

### DIFF
--- a/src/unitysvc_sellers/commands/_helpers.py
+++ b/src/unitysvc_sellers/commands/_helpers.py
@@ -188,26 +188,47 @@ async def fetch_service_ids_by_status(
 ) -> list[str]:
     """List all service ids matching any of ``statuses``, optionally filtered by provider.
 
-    Replacement for the legacy
-    ``unitysvc_services.lifecycle.fetch_service_ids_by_status`` helper.
+    Follows cursor pagination to completion so sellers with more than
+    one page of services in a given status aren't silently truncated.
     """
     provider_lower = provider.lower() if provider else None
     all_ids: list[str] = []
 
-    for status in statuses:
-        try:
-            services = model_list(await client.services.list(status=status, limit=1000))
-        except SellerSDKError:
-            continue
+    # Backend caps page size at 200 (see seller/_pagination.LimitParam);
+    # requesting more raises 422 which previously was caught by a blanket
+    # `except SellerSDKError: continue` and silently returned no ids.
+    PAGE_SIZE = 200
 
-        for svc in services:
-            if not svc.get("id"):
-                continue
-            if provider_lower:
-                svc_provider = svc.get("provider_name", "") or ""
-                if provider_lower not in svc_provider.lower():
+    for status in statuses:
+        cursor: str | None = None
+        while True:
+            try:
+                response = await client.services.list(
+                    status=status,
+                    limit=PAGE_SIZE,
+                    cursor=cursor,
+                )
+            except SellerSDKError as exc:
+                # Surface the error instead of silently skipping — previously
+                # this branch masked a limit-validation failure and produced
+                # empty results with no indication of the cause.
+                console.print(f"[yellow]Warning:[/yellow] failed to list services with status={status}: {exc}")
+                break
+
+            for svc in model_list(response):
+                if not svc.get("id"):
                     continue
-            all_ids.append(str(svc["id"]))
+                if provider_lower:
+                    svc_provider = svc.get("provider_name", "") or ""
+                    if provider_lower not in svc_provider.lower():
+                        continue
+                all_ids.append(str(svc["id"]))
+
+            next_cursor = getattr(response, "next_cursor", None)
+            has_more = getattr(response, "has_more", False)
+            if not has_more or not next_cursor:
+                break
+            cursor = str(next_cursor)
 
     return all_ids
 


### PR DESCRIPTION
## Summary

\`fetch_service_ids_by_status\` asked the backend for \`limit=1000\`, but the seller services list endpoint caps \`LimitParam\` at 200 ([backend/app/api/routes/seller/_pagination.py](https://github.com/unitysvc/unitysvc/blob/main/backend/app/api/routes/seller/_pagination.py)). Every call raised a 422 validation error, which the blanket \`except SellerSDKError: continue\` swallowed — so \`services submit --all\`, \`deprecate --all\`, \`withdraw --all\`, and similar bulk commands silently reported "No matching services found" even when the seller had plenty of draft/rejected services.

## Repro

\`\`\`
$ usvc_seller services list --provider unitysvc-demo
# ...shows 28 draft services...

$ usvc_seller services submit --all --provider unitysvc-demo
Fetching services with status: draft, rejected for provider 'unitysvc-demo'...
No matching services found.
\`\`\`

## Fix

- Use \`limit=200\` (the backend cap) instead of 1000.
- Follow \`next_cursor\` / \`has_more\` to exhaust pages, matching the pattern used by \`services list --all\`.
- Surface errors with a warning instead of silently continuing so future limit mismatches aren't invisible.

## Test plan

- [ ] \`usvc_seller services submit --all --provider unitysvc-demo\` finds and submits the 28 matching drafts.
- [ ] Works correctly for sellers with > 200 drafts (pagination follows).
- [ ] Still exits cleanly when there genuinely are no matching services.