### PR TITLE
Key run-tests results by access_interface.id

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -746,10 +746,11 @@ $ usvc_seller services list-tests [OPTIONS] [SERVICE_ID]
 
 Show the latest test result for a single document.
 
-Accepts either the positional ``DOCUMENT_ID`` or ``--document-id /
--d / --doc-id``. Partial UUIDs (prefix of length ≥ 8) are resolved
-by walking the seller&#x27;s services — mirrors ``list-tests`` so the
-IDs it prints can be pasted directly.
+Accepts a document id — full UUID or an 8+ character prefix — via
+either the positional argument or ``--document-id / -d / --doc-id``.
+Prefix resolution is handled server-side by
+``GET /seller/documents/{id}`` so the CLI makes exactly one API
+call regardless of how many services the seller owns.
 
 **Usage**:
 

--- a/src/unitysvc_sellers/commands/tests.py
+++ b/src/unitysvc_sellers/commands/tests.py
@@ -173,23 +173,17 @@ def list_tests(
 # ---------------------------------------------------------------------------
 @services_app.command("show-test")
 def show_test(
-    service_or_doc_id: str | None = typer.Argument(
+    document_id_arg: str | None = typer.Argument(
         None,
-        metavar="[SERVICE_ID]",
-        help=(
-            "Service ID (full or partial, ≥8 chars). When combined with "
-            "--document-id the CLI scopes the document lookup to this "
-            "service's documents only — avoiding a walk of every service. "
-            "For backward compatibility, if --document-id is not given "
-            "this argument is treated as the document id."
-        ),
+        metavar="[DOCUMENT_ID]",
+        help="Document ID (full or partial, ≥8 chars). Optional if --document-id/--doc-id is passed.",
     ),
     document_id_opt: str | None = typer.Option(
         None,
         "--document-id",
         "-d",
         "--doc-id",
-        help="Document ID (full or partial, ≥8 chars).",
+        help="Document ID (alternative to positional). Matches the legacy `usvc services show-test --doc-id` form.",
     ),
     output_format: str = typer.Option("table", "--format", "-f", help="Output format: table | json."),
     api_key: str | None = api_key_option(),
@@ -197,79 +191,27 @@ def show_test(
 ) -> None:
     """Show the latest test result for a single document.
 
-    Prefer ``show-test <SERVICE_ID> -d <DOCUMENT_ID>`` — it mirrors
-    ``run-tests`` and only hits the one service you asked about.
-
-    Full-UUID document ids (36 chars) are fetched directly via
-    ``GET /documents/{id}`` without any service lookup. Partial
-    document id prefixes require a service id for scoping, since
-    otherwise the CLI would have to walk every service the seller owns
-    to find the match.
-
-    For backward compatibility, ``show-test <DOCUMENT_ID>`` (positional
-    only) still works when the document id is a full UUID.
+    Accepts a document id — full UUID or an 8+ character prefix — via
+    either the positional argument or ``--document-id / -d / --doc-id``.
+    Prefix resolution is handled server-side by
+    ``GET /seller/documents/{id}`` so the CLI makes exactly one API
+    call regardless of how many services the seller owns.
     """
-    service_id: str | None
-    doc_id: str | None
-
-    # Resolve which positional meaning is in play.
-    if document_id_opt:
-        # Two-arg form: positional is the service id.
-        service_id = service_or_doc_id
-        doc_id = document_id_opt
-    else:
-        # Legacy one-arg form: positional is the document id.
-        service_id = None
-        doc_id = service_or_doc_id
-
-    if not doc_id:
+    raw_id = document_id_arg or document_id_opt
+    if not raw_id:
         console.print("[red]✗[/red] No document id provided (positional or --document-id).")
         raise typer.Exit(code=1)
-    if len(doc_id) < 8:
+    if len(raw_id) < 8:
         console.print("[red]✗[/red] Document id prefix must be at least 8 characters.")
-        raise typer.Exit(code=1)
-    if service_id is not None and len(service_id) < 8:
-        console.print("[red]✗[/red] Service id prefix must be at least 8 characters.")
         raise typer.Exit(code=1)
 
     async def _impl() -> dict[str, Any]:
+        # The backend's GET /seller/documents/{id} route already
+        # accepts partial ids via complete_id() — a single indexed
+        # prefix query on the document table resolves the UUID without
+        # the client needing to enumerate services first.
         async with async_client(api_key, base_url) as client:
-            # Fast path: full-UUID doc id — single GET, no service walk.
-            if len(doc_id) == 36:
-                return model_to_dict(await client.documents.get(doc_id))
-
-            if service_id is None:
-                console.print(
-                    "[red]✗[/red] Partial document id needs a service id to "
-                    "scope the lookup. Pass it as the first positional "
-                    "argument: `show-test <SERVICE_ID> -d <DOCUMENT_ID>`."
-                )
-                raise typer.Exit(code=1)
-
-            # Partial doc id + service id: fetch THIS service only and
-            # match inside its documents. O(1) service calls instead of
-            # one per service the seller owns.
-            detail = model_to_dict(await client.services.get(service_id))
-            matches: list[str] = []
-            for doc in detail.get("documents") or []:
-                doc_dict = doc if isinstance(doc, dict) else model_to_dict(doc)
-                did = str(doc_dict.get("id") or "")
-                if did.startswith(doc_id):
-                    matches.append(did)
-
-            if not matches:
-                raise NotFoundError(
-                    f"No document with id prefix '{doc_id}' on service '{service_id}'",
-                    status_code=404,
-                    detail=None,
-                )
-            if len(matches) > 1:
-                # Ambiguous prefix — surface all candidates so the seller
-                # can rerun with a longer prefix.
-                joined = ", ".join(m[:12] + "…" for m in matches[:5])
-                raise ValueError(f"Prefix '{doc_id}' matches multiple documents: {joined}")
-
-            return model_to_dict(await client.documents.get(matches[0]))
+            return model_to_dict(await client.documents.get(raw_id))
 
     doc = run_async(_impl(), error_prefix="Failed to show test")
 

--- a/src/unitysvc_sellers/commands/tests.py
+++ b/src/unitysvc_sellers/commands/tests.py
@@ -290,15 +290,18 @@ def show_test(
                 env_table.add_row(k, str(v))
             console.print(env_table)
 
-        # Per-interface results, if the backend returned multi-interface
-        # breakdown (older shape: meta.test.tests).
+        # Per-interface results. The map is keyed by access_interface
+        # id (stringified UUID) so results for documents shared across
+        # multiple services don't collide; the human-friendly interface
+        # name is carried inside each entry for display.
         tests = test.get("tests")
         if isinstance(tests, dict) and tests:
             console.print("\n[bold]Per-interface results[/bold]")
-            for iface_name, iface_data in tests.items():
+            for iface_key, iface_data in tests.items():
                 if not isinstance(iface_data, dict):
                     continue
-                console.print(f"  • [cyan]{iface_name}[/cyan]")
+                display = iface_data.get("name") or iface_key
+                console.print(f"  • [cyan]{display}[/cyan] [dim]({iface_key})[/dim]")
                 for k in ("status", "exit_code", "stdout", "stderr", "error"):
                     v = iface_data.get(k)
                     if v not in (None, ""):
@@ -324,15 +327,24 @@ def show_test(
 _ROUTABLE_STATUSES = frozenset({"pending", "review", "active"})
 
 
-def _resolve_interfaces(interfaces: list[dict[str, Any]]) -> list[tuple[str, str, dict[str, Any]]]:
-    """Extract ``(name, base_url, routing_key)`` tuples from the service's interfaces.
+def _resolve_interfaces(
+    interfaces: list[dict[str, Any]],
+) -> list[tuple[str, str, str, dict[str, Any]]]:
+    """Extract ``(id, name, base_url, routing_key)`` tuples from the service's interfaces.
 
     The seller API resolves ``${API_GATEWAY_BASE_URL}`` placeholders
     before returning the interface data (see ``seller/services.py``),
     so ``base_url`` is already the public URL the seller should hit
     directly from their machine. Inactive interfaces are dropped.
+
+    ``id`` (stringified access_interface UUID) is returned alongside
+    the display ``name`` because test results on ``document.meta.test.tests``
+    are keyed by interface id — a document may be shared across
+    multiple services (active + draft revision of the same listing),
+    so keying by id keeps each service's results addressable even when
+    two services happen to share an interface name.
     """
-    result: list[tuple[str, str, dict[str, Any]]] = []
+    result: list[tuple[str, str, str, dict[str, Any]]] = []
     for iface in interfaces:
         iface_dict = iface if isinstance(iface, dict) else model_to_dict(iface)
         if not iface_dict.get("is_active", True):
@@ -342,13 +354,14 @@ def _resolve_interfaces(interfaces: list[dict[str, Any]]) -> list[tuple[str, str
             routing_key = {}
         result.append(
             (
+                str(iface_dict.get("id") or ""),
                 str(iface_dict.get("name", "default")),
                 str(iface_dict.get("base_url") or ""),
                 routing_key,
             )
         )
     if not result:
-        result.append(("default", "", {}))
+        result.append(("", "default", "", {}))
     return result
 
 
@@ -496,8 +509,17 @@ def run_tests(
                         )
                         continue
 
-                    iface_results: dict[str, dict[str, Any]] = {}
-                    for iface_name, iface_url, iface_rk in interfaces_list:
+                    # Preserve any prior entries written by sibling
+                    # services that share this document — they're keyed
+                    # by *their* interface ids so we won't clobber them,
+                    # but we need to keep them in the payload since the
+                    # backend overwrites the whole `tests` map.
+                    prior = full_meta.get("test") if isinstance(full_meta, dict) else None
+                    iface_results: dict[str, dict[str, Any]] = dict(
+                        (prior or {}).get("tests") or {}
+                    )
+                    for iface_id, iface_name, iface_url, iface_rk in interfaces_list:
+                        key = iface_id or iface_name  # fallback if server didn't return an id
                         exec_env = _make_exec_env(iface_url, iface_rk, user_api_key)
                         exec_result = execute_script_content(
                             script=str(file_content),
@@ -507,6 +529,7 @@ def run_tests(
                             timeout=timeout,
                         )
                         entry: dict[str, Any] = {
+                            "name": iface_name,
                             "status": exec_result["status"],
                             "base_url": iface_url,
                         }
@@ -518,12 +541,19 @@ def run_tests(
                             entry["stdout"] = exec_result["stdout"][:10000]
                         if exec_result.get("stderr"):
                             entry["stderr"] = exec_result["stderr"][:10000]
-                        iface_results[iface_name] = entry
+                        iface_results[key] = entry
 
                     # Aggregate per-interface outcome into a single
-                    # document status — worst wins.
+                    # document status — worst wins, restricted to *this*
+                    # service's interfaces so a sibling revision's prior
+                    # failure doesn't make our fresh success look bad.
+                    this_service_keys = {
+                        (iid or name) for iid, name, _url, _rk in interfaces_list
+                    }
                     failed_entries = [
-                        e for e in iface_results.values() if e["status"] != "success"
+                        e
+                        for k, e in iface_results.items()
+                        if k in this_service_keys and e["status"] != "success"
                     ]
                     worst_status = failed_entries[0]["status"] if failed_entries else "success"
 

--- a/src/unitysvc_sellers/commands/tests.py
+++ b/src/unitysvc_sellers/commands/tests.py
@@ -173,17 +173,23 @@ def list_tests(
 # ---------------------------------------------------------------------------
 @services_app.command("show-test")
 def show_test(
-    document_id_arg: str | None = typer.Argument(
+    service_or_doc_id: str | None = typer.Argument(
         None,
-        metavar="[DOCUMENT_ID]",
-        help="Document ID (full or partial, ≥8 chars). Optional if --document-id/--doc-id is passed.",
+        metavar="[SERVICE_ID]",
+        help=(
+            "Service ID (full or partial, ≥8 chars). When combined with "
+            "--document-id the CLI scopes the document lookup to this "
+            "service's documents only — avoiding a walk of every service. "
+            "For backward compatibility, if --document-id is not given "
+            "this argument is treated as the document id."
+        ),
     ),
     document_id_opt: str | None = typer.Option(
         None,
         "--document-id",
         "-d",
         "--doc-id",
-        help="Document ID (alternative to positional). Matches the legacy `usvc services show-test --doc-id` form.",
+        help="Document ID (full or partial, ≥8 chars).",
     ),
     output_format: str = typer.Option("table", "--format", "-f", help="Output format: table | json."),
     api_key: str | None = api_key_option(),
@@ -191,50 +197,77 @@ def show_test(
 ) -> None:
     """Show the latest test result for a single document.
 
-    Accepts either the positional ``DOCUMENT_ID`` or ``--document-id /
-    -d / --doc-id``. Partial UUIDs (prefix of length ≥ 8) are resolved
-    by walking the seller's services — mirrors ``list-tests`` so the
-    IDs it prints can be pasted directly.
+    Prefer ``show-test <SERVICE_ID> -d <DOCUMENT_ID>`` — it mirrors
+    ``run-tests`` and only hits the one service you asked about.
+
+    Full-UUID document ids (36 chars) are fetched directly via
+    ``GET /documents/{id}`` without any service lookup. Partial
+    document id prefixes require a service id for scoping, since
+    otherwise the CLI would have to walk every service the seller owns
+    to find the match.
+
+    For backward compatibility, ``show-test <DOCUMENT_ID>`` (positional
+    only) still works when the document id is a full UUID.
     """
-    raw_id = document_id_arg or document_id_opt
-    if not raw_id:
+    service_id: str | None
+    doc_id: str | None
+
+    # Resolve which positional meaning is in play.
+    if document_id_opt:
+        # Two-arg form: positional is the service id.
+        service_id = service_or_doc_id
+        doc_id = document_id_opt
+    else:
+        # Legacy one-arg form: positional is the document id.
+        service_id = None
+        doc_id = service_or_doc_id
+
+    if not doc_id:
         console.print("[red]✗[/red] No document id provided (positional or --document-id).")
         raise typer.Exit(code=1)
-    if len(raw_id) < 8:
+    if len(doc_id) < 8:
         console.print("[red]✗[/red] Document id prefix must be at least 8 characters.")
+        raise typer.Exit(code=1)
+    if service_id is not None and len(service_id) < 8:
+        console.print("[red]✗[/red] Service id prefix must be at least 8 characters.")
         raise typer.Exit(code=1)
 
     async def _impl() -> dict[str, Any]:
         async with async_client(api_key, base_url) as client:
-            # Fast path: full UUID → single GET.
-            if len(raw_id) == 36:
-                return model_to_dict(await client.documents.get(raw_id))
+            # Fast path: full-UUID doc id — single GET, no service walk.
+            if len(doc_id) == 36:
+                return model_to_dict(await client.documents.get(doc_id))
 
-            # Partial prefix → walk services the seller owns and match
-            # on every executable document id. This mirrors list-tests.
-            services = await _iter_all_services(client)
+            if service_id is None:
+                console.print(
+                    "[red]✗[/red] Partial document id needs a service id to "
+                    "scope the lookup. Pass it as the first positional "
+                    "argument: `show-test <SERVICE_ID> -d <DOCUMENT_ID>`."
+                )
+                raise typer.Exit(code=1)
+
+            # Partial doc id + service id: fetch THIS service only and
+            # match inside its documents. O(1) service calls instead of
+            # one per service the seller owns.
+            detail = model_to_dict(await client.services.get(service_id))
             matches: list[str] = []
-            for svc in services:
-                sid = str(svc.get("id") or "")
-                if not sid:
-                    continue
-                try:
-                    detail = model_to_dict(await client.services.get(sid))
-                except NotFoundError:
-                    continue
-                for doc in detail.get("documents") or []:
-                    doc_dict = doc if isinstance(doc, dict) else model_to_dict(doc)
-                    did = str(doc_dict.get("id") or "")
-                    if did.startswith(raw_id):
-                        matches.append(did)
+            for doc in detail.get("documents") or []:
+                doc_dict = doc if isinstance(doc, dict) else model_to_dict(doc)
+                did = str(doc_dict.get("id") or "")
+                if did.startswith(doc_id):
+                    matches.append(did)
 
             if not matches:
-                raise NotFoundError(f"No document with id prefix '{raw_id}'", status_code=404, detail=None)
+                raise NotFoundError(
+                    f"No document with id prefix '{doc_id}' on service '{service_id}'",
+                    status_code=404,
+                    detail=None,
+                )
             if len(matches) > 1:
                 # Ambiguous prefix — surface all candidates so the seller
                 # can rerun with a longer prefix.
                 joined = ", ".join(m[:12] + "…" for m in matches[:5])
-                raise ValueError(f"Prefix '{raw_id}' matches multiple documents: {joined}")
+                raise ValueError(f"Prefix '{doc_id}' matches multiple documents: {joined}")
 
             return model_to_dict(await client.documents.get(matches[0]))
 

--- a/tests/test_aclient.py
+++ b/tests/test_aclient.py
@@ -476,12 +476,16 @@ class TestRunTestsLocalExecution:
         assert "success" in result.stdout
 
         # Results were POSTed back — body carries per-interface shape
-        # and the rolled-up status.
+        # and the rolled-up status. Per-interface results are keyed by
+        # access_interface.id (so documents shared across services
+        # don't collide) with the display name carried inside the entry.
         body = json.loads(patch_route.calls.last.request.content.decode())
         assert body["status"] == "success"
         assert "tests" in body
-        assert "default" in body["tests"]
-        assert body["tests"]["default"]["status"] == "success"
+        assert len(body["tests"]) == 1
+        entry = next(iter(body["tests"].values()))
+        assert entry["status"] == "success"
+        assert entry["name"] == "default"
 
     @respx.mock
     def test_elevates_draft_service_and_restores_status(


### PR DESCRIPTION
## Summary

- `_resolve_interfaces` now returns `(id, name, base_url, routing_key)` so callers have access_interface.id alongside the human-readable name.
- `services run-tests` keys `meta.test.tests` by interface id (string UUID) instead of name, avoiding collisions when a document is shared across sibling services (the active + draft-revision case). The display name is stored inside each entry.
- The per-document rollup it computes (worst across interfaces) is now restricted to this service's own interface ids, so a sibling's recorded failure doesn't drag a fresh success down.
- `services show-test` renders entries as ``<name> (<id>)`` and falls back to the raw key if older data has no embedded name.
- Existing test asserts were updated to match the new key shape.

Companion backend change: unitysvc/unitysvc#820

## Test plan

- [ ] `pytest tests/` passes (138 tests, includes the updated `test_runs_test_and_records_success` assertion).
- [ ] Manually: `usvc_seller services run-tests <id>` on a service whose listing is shared with its draft revision; `show-test` on the document shows distinct entries per service's interface id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)