### PR TITLE
Skip tests cleanly when service has no active interfaces

### DIFF
--- a/src/unitysvc_sellers/commands/tests.py
+++ b/src/unitysvc_sellers/commands/tests.py
@@ -335,8 +335,11 @@ def _resolve_interfaces(
                 routing_key,
             )
         )
-    if not result:
-        result.append(("", "default", "", {}))
+    # No silent fallback for an empty list. Appending a stub
+    # ("", "default", "", {}) used to force the test to execute with
+    # no SERVICE_BASE_URL set, recording a "SERVICE_BASE_URL is not
+    # set" failure keyed by the literal string "default" — confusing
+    # garbage. Callers skip the document cleanly instead.
     return result
 
 
@@ -479,6 +482,22 @@ def run_tests(
                                 "title": title,
                                 "status": "skipped",
                                 "reason": "no file content",
+                                "iface_results": {},
+                            }
+                        )
+                        continue
+
+                    if not interfaces_list:
+                        # No active interfaces to test against. Running
+                        # with an empty SERVICE_BASE_URL would fail with
+                        # a confusing "SERVICE_BASE_URL is not set"
+                        # message; skip cleanly instead.
+                        doc_results.append(
+                            {
+                                "doc_id": did,
+                                "title": title,
+                                "status": "skipped",
+                                "reason": "service has no active interfaces",
                                 "iface_results": {},
                             }
                         )


### PR DESCRIPTION
## Summary

The empty-interfaces fallback in \`_resolve_interfaces\` returned a stub \`("", "default", "", {})\` whenever a service had no active interfaces, so \`run-tests\` then executed the script with no \`SERVICE_BASE_URL\` set and recorded a confusing \`"SERVICE_BASE_URL is not set"\` failure keyed by the literal string \`"default"\`. Replaced with an explicit skip (\`service has no active interfaces\`).

## Test plan

- [x] \`pytest tests/\` passes (138 tests).
- [ ] On a service with no active interfaces, \`services run-tests\` prints a clear skip reason instead of executing with an empty env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)