### PR TITLE
Add $preset sentinel expansion backed by unitysvc-data

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -46,6 +46,7 @@ $ usvc_seller data [OPTIONS] COMMAND [ARGS]...
 
 **Commands**:
 
+* `show`: Show expanded data for a service.
 * `validate`: Validate data consistency in service and...
 * `format`: Format data files (JSON, TOML, MD) to...
 * `populate`: Populate services by executing...
@@ -53,8 +54,40 @@ $ usvc_seller data [OPTIONS] COMMAND [ARGS]...
 * `list-tests`: List available code examples without...
 * `run-tests`: Run code examples locally with upstream...
 * `show-test`: Show test results for a service&#x27;s code...
-* `show`: Show details of local data objects
 * `list`: List local data files
+
+### `usvc_seller data show`
+
+Show expanded data for a service.
+
+By default prints provider + offering + listing as a single JSON
+object keyed by section. Pass one or more of ``--provider``,
+``--offering``, ``--listing`` to restrict the output — with exactly
+one flag set, the selected section is emitted unwrapped for easy
+piping into ``jq``.
+
+Data is loaded through the seller&#x27;s preset-aware loader, so any
+``$doc_preset`` / ``$file_preset`` sentinels have already been
+replaced with the expanded records from ``unitysvc-data``.
+
+**Usage**:
+
+```console
+$ usvc_seller data show [OPTIONS] SERVICE_NAME
+```
+
+**Arguments**:
+
+* `SERVICE_NAME`: Service name (first column of &#x27;usvc_seller data list&#x27; output).  [required]
+
+**Options**:
+
+* `--provider`: Show only provider data.
+* `--offering`: Show only offering data.
+* `--listing`: Show only listing data.
+* `-d, --data-dir PATH`: Directory containing data files (default: current directory).
+* `-f, --format TEXT`: Output format: json (syntax-highlighted) or text (plain).  [default: json]
+* `--help`: Show this message and exit.
 
 ### `usvc_seller data validate`
 
@@ -277,107 +310,6 @@ $ usvc_seller data show-test [OPTIONS] SERVICE
 
 * `-t, --title TEXT`: Only show results for specific test title
 * `-d, --data-dir PATH`: Directory containing provider data files (default: current directory)
-* `--help`: Show this message and exit.
-
-### `usvc_seller data show`
-
-Show details of local data objects
-
-**Usage**:
-
-```console
-$ usvc_seller data show [OPTIONS] COMMAND [ARGS]...
-```
-
-**Options**:
-
-* `--help`: Show this message and exit.
-
-**Commands**:
-
-* `provider`: Show details of a provider by name.
-* `offering`: Show details of an offering by name.
-* `listing`: Show details of a listing by name.
-* `service`: Show details of a service by name...
-
-#### `usvc_seller data show provider`
-
-Show details of a provider by name.
-
-**Usage**:
-
-```console
-$ usvc_seller data show provider [OPTIONS] NAME
-```
-
-**Arguments**:
-
-* `NAME`: Provider name to show  [required]
-
-**Options**:
-
-* `-d, --data-dir PATH`: Directory containing data files (default: current directory)
-* `-f, --format TEXT`: Output format: json, table, tsv, csv  [default: json]
-* `--help`: Show this message and exit.
-
-#### `usvc_seller data show offering`
-
-Show details of an offering by name.
-
-**Usage**:
-
-```console
-$ usvc_seller data show offering [OPTIONS] NAME
-```
-
-**Arguments**:
-
-* `NAME`: Offering name to show  [required]
-
-**Options**:
-
-* `-d, --data-dir PATH`: Directory containing data files (default: current directory)
-* `-f, --format TEXT`: Output format: json, table, tsv, csv  [default: json]
-* `--help`: Show this message and exit.
-
-#### `usvc_seller data show listing`
-
-Show details of a listing by name.
-
-**Usage**:
-
-```console
-$ usvc_seller data show listing [OPTIONS] NAME
-```
-
-**Arguments**:
-
-* `NAME`: Listing name to show  [required]
-
-**Options**:
-
-* `-d, --data-dir PATH`: Directory containing data files (default: current directory)
-* `-f, --format TEXT`: Output format: json, table, tsv, csv  [default: json]
-* `--help`: Show this message and exit.
-
-#### `usvc_seller data show service`
-
-Show details of a service by name (combines listing and offering data).
-
-**Usage**:
-
-```console
-$ usvc_seller data show service [OPTIONS] NAME
-```
-
-**Arguments**:
-
-* `NAME`: Service name to show (listing name or offering name)  [required]
-
-**Options**:
-
-* `-d, --data-dir PATH`: Directory containing data files (default: current directory)
-* `-f, --format TEXT`: Output format: json, table, tsv, csv  [default: json]
 * `--help`: Show this message and exit.
 
 ### `usvc_seller data list`

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -478,7 +478,7 @@ $ usvc_seller services list [OPTIONS]
 * `--status TEXT`: Filter by service status (draft, pending, review, active, rejected, suspended, deprecated).
 * `-n, --name TEXT`: Search by name, display_name, or provider name (case-insensitive partial match).
 * `--provider TEXT`: Filter by provider name (case-insensitive partial match, applied client-side).
-* `--fields TEXT`: Comma-separated list of columns to display.  [default: id,name,provider_name,service_type,status,visibility]
+* `--fields TEXT`: Comma-separated list of columns to display.  [default: id,name,provider_name,service_type,status]
 * `-f, --format TEXT`: Output format: table | json.  [default: table]
 * `--api-key TEXT`: Seller API key (svcpass_...). Defaults to $UNITYSVC_SELLER_API_KEY.  [env var: UNITYSVC_SELLER_API_KEY]
 * `--base-url TEXT`: Backend base URL.  [env var: UNITYSVC_SELLER_API_URL; default: https://seller.unitysvc.com/v1]

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -478,7 +478,7 @@ $ usvc_seller services list [OPTIONS]
 * `--status TEXT`: Filter by service status (draft, pending, review, active, rejected, suspended, deprecated).
 * `-n, --name TEXT`: Search by name, display_name, or provider name (case-insensitive partial match).
 * `--provider TEXT`: Filter by provider name (case-insensitive partial match, applied client-side).
-* `--fields TEXT`: Comma-separated list of columns to display.  [default: id,name,provider_name,service_type,status]
+* `--fields TEXT`: Comma-separated list of columns to display.  [default: id,name,provider_name,service_type,status,visibility]
 * `-f, --format TEXT`: Output format: table | json.  [default: table]
 * `--api-key TEXT`: Seller API key (svcpass_...). Defaults to $UNITYSVC_SELLER_API_KEY.  [env var: UNITYSVC_SELLER_API_KEY]
 * `--base-url TEXT`: Backend base URL.  [env var: UNITYSVC_SELLER_API_URL; default: https://seller.unitysvc.com/v1]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
 ]
 dependencies = [
   "unitysvc-core>=0.1.3",
+  "unitysvc-data>=0.1.1",
   "typer",
   "rich",
   "jinja2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 ]
 dependencies = [
   "unitysvc-core>=0.1.3",
-  "unitysvc-data>=0.1.1",
+  "unitysvc-data>=0.1.3",
   "typer",
   "rich",
   "jinja2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,8 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-  "unitysvc-core>=0.1.3",
-  "unitysvc-data>=0.1.3",
+  "unitysvc-core>=0.1.4",
+  "unitysvc-data>=0.1.4",
   "typer",
   "rich",
   "jinja2",

--- a/src/unitysvc_sellers/commands/services.py
+++ b/src/unitysvc_sellers/commands/services.py
@@ -88,7 +88,7 @@ def list_services(
         help="Filter by provider name (case-insensitive partial match, applied client-side).",
     ),
     fields: str = typer.Option(
-        "id,name,provider_name,service_type,status",
+        "id,name,provider_name,service_type,status,visibility",
         "--fields",
         help="Comma-separated list of columns to display.",
     ),

--- a/src/unitysvc_sellers/commands/services.py
+++ b/src/unitysvc_sellers/commands/services.py
@@ -88,7 +88,7 @@ def list_services(
         help="Filter by provider name (case-insensitive partial match, applied client-side).",
     ),
     fields: str = typer.Option(
-        "id,name,provider_name,service_type,status,visibility",
+        "id,name,provider_name,service_type,status",
         "--fields",
         help="Comma-separated list of columns to display.",
     ),

--- a/src/unitysvc_sellers/data.py
+++ b/src/unitysvc_sellers/data.py
@@ -12,259 +12,158 @@ from rich.table import Table
 from . import _cli_upload as upload_cmd
 from . import example, format_data, populate, validator
 from . import list as list_cmd
-from .utils import find_files_by_schema, resolve_service_name_for_listing
+from .utils import find_files_by_schema, load_data_file
 
 app = typer.Typer(help="Local data file operations (validate, format, populate, upload, test, etc.)")
 console = Console()
 
 
-# Show command group
-show_app = typer.Typer(help="Show details of local data objects")
+# ---------------------------------------------------------------------------
+# show — locate the three files belonging to a service and print their
+# fully-expanded payload (provider + offering + listing). ``service_name``
+# matches the first column of ``data list`` output; see ``_list_services_impl``
+# below for the resolution algorithm it mirrors. Data is loaded through the
+# seller's ``load_data_file`` wrapper so $preset sentinels are replaced with
+# their expanded records before display — the CLI shows the same shape the
+# upload / validate pipeline sees.
+# ---------------------------------------------------------------------------
 
 
-@show_app.command("provider")
-def show_provider(
-    name: str = typer.Argument(..., help="Provider name to show"),
-    data_dir: Path | None = typer.Option(
-        None,
-        "--data-dir",
-        "-d",
-        help="Directory containing data files (default: current directory)",
-    ),
-    output_format: str = typer.Option(
-        "json",
-        "--format",
-        "-f",
-        help="Output format: json, table, tsv, csv",
-    ),
-):
-    """Show details of a provider by name."""
-    if data_dir is None:
-        data_dir = Path.cwd()
+def _resolve_service_paths(
+    data_dir: Path, service_name: str
+) -> tuple[Path | None, Path | None, Path | None]:
+    """Return ``(provider_file, offering_file, listing_file)`` for *service_name*.
 
-    if not data_dir.is_absolute():
-        data_dir = Path.cwd() / data_dir
-
-    # Find all provider files
-    provider_results = find_files_by_schema(data_dir, "provider_v1")
-
-    for provider_file, _fmt, provider_data in provider_results:
-        if provider_data.get("name") == name:
-            _display_data(provider_data, provider_file, output_format)
-            return
-
-    console.print(f"[red]Provider not found: {name}[/red]")
-    raise typer.Exit(code=1)
-
-
-@show_app.command("offering")
-def show_offering(
-    name: str = typer.Argument(..., help="Offering name to show"),
-    data_dir: Path | None = typer.Option(
-        None,
-        "--data-dir",
-        "-d",
-        help="Directory containing data files (default: current directory)",
-    ),
-    output_format: str = typer.Option(
-        "json",
-        "--format",
-        "-f",
-        help="Output format: json, table, tsv, csv",
-    ),
-):
-    """Show details of an offering by name."""
-    if data_dir is None:
-        data_dir = Path.cwd()
-
-    if not data_dir.is_absolute():
-        data_dir = Path.cwd() / data_dir
-
-    # Find all offering files
-    offering_results = find_files_by_schema(data_dir, "offering_v1")
-
-    for offering_file, _fmt, offering_data in offering_results:
-        if offering_data.get("name") == name:
-            _display_data(offering_data, offering_file, output_format)
-            return
-
-    console.print(f"[red]Offering not found: {name}[/red]")
-    raise typer.Exit(code=1)
-
-
-@show_app.command("listing")
-def show_listing(
-    name: str = typer.Argument(..., help="Listing name to show"),
-    data_dir: Path | None = typer.Option(
-        None,
-        "--data-dir",
-        "-d",
-        help="Directory containing data files (default: current directory)",
-    ),
-    output_format: str = typer.Option(
-        "json",
-        "--format",
-        "-f",
-        help="Output format: json, table, tsv, csv",
-    ),
-):
-    """Show details of a listing by name."""
-    if data_dir is None:
-        data_dir = Path.cwd()
-
-    if not data_dir.is_absolute():
-        data_dir = Path.cwd() / data_dir
-
-    # Find all listing files
-    listing_results = find_files_by_schema(data_dir, "listing_v1")
-
-    for listing_file, _fmt, listing_data in listing_results:
-        # Get listing name, fall back to offering name if not specified
-        listing_name = listing_data.get("name", "")
-        if not listing_name:
-            listing_name = resolve_service_name_for_listing(listing_file, listing_data) or ""
-
-        if listing_name == name:
-            _display_data(listing_data, listing_file, output_format)
-            return
-
-    console.print(f"[red]Listing not found: {name}[/red]")
-    raise typer.Exit(code=1)
-
-
-@show_app.command("service")
-def show_service(
-    name: str = typer.Argument(..., help="Service name to show (listing name or offering name)"),
-    data_dir: Path | None = typer.Option(
-        None,
-        "--data-dir",
-        "-d",
-        help="Directory containing data files (default: current directory)",
-    ),
-    output_format: str = typer.Option(
-        "json",
-        "--format",
-        "-f",
-        help="Output format: json, table, tsv, csv",
-    ),
-):
-    """Show details of a service by name (combines listing and offering data)."""
-    if data_dir is None:
-        data_dir = Path.cwd()
-
-    if not data_dir.is_absolute():
-        data_dir = Path.cwd() / data_dir
-
-    # Find all listing files
-    listing_results = find_files_by_schema(data_dir, "listing_v1")
-
-    for listing_file, _fmt, listing_data in listing_results:
-        listing_name = listing_data.get("name", "")
-        listing_status = listing_data.get("status", "")
-
-        # Find corresponding offering
+    Mirrors ``_list_services_impl``'s resolution order:
+    listing.name → offering.name → provider at <listing_dir>/../../.
+    Any slot may be ``None`` if the corresponding file is missing.
+    """
+    for listing_file, _fmt, listing_data in find_files_by_schema(data_dir, "listing_v1"):
+        offering_file: Path | None = None
+        offering_name = ""
         offering_results = find_files_by_schema(listing_file.parent, "offering_v1")
-        offering_data: dict[str, Any] = {}
-        offering_status = ""
         if offering_results:
-            _, _fmt, offering_data = offering_results[0]
-            offering_status = offering_data.get("status", "")
+            offering_file, _, offering_data = offering_results[0]
+            offering_name = offering_data.get("name", "")
 
-        offering_name = offering_data.get("name", "")
-        service_name = listing_name or offering_name
+        resolved = listing_data.get("name") or offering_name
+        if resolved != service_name:
+            continue
 
-        if service_name == name:
-            # Find provider status
-            provider_data: dict[str, Any] = {}
-            provider_status = ""
-            try:
-                provider_dir = listing_file.parent.parent.parent
-                provider_results = find_files_by_schema(provider_dir, "provider_v1")
-                if provider_results:
-                    _, _fmt, provider_data = provider_results[0]
-                    provider_status = provider_data.get("status", "")
-            except Exception:
-                pass
+        provider_file: Path | None = None
+        try:
+            provider_dir = listing_file.parent.parent.parent
+            provider_results = find_files_by_schema(provider_dir, "provider_v1")
+            if provider_results:
+                provider_file = provider_results[0][0]
+        except Exception:
+            pass
 
-            # Compute service status: draft > deprecated > ready
-            statuses = [s for s in [provider_status, offering_status, listing_status] if s]
-            if "draft" in statuses:
-                service_status = "draft"
-            elif "deprecated" in statuses:
-                service_status = "deprecated"
-            elif statuses and all(s == "ready" for s in statuses):
-                service_status = "ready"
-            else:
-                service_status = statuses[0] if statuses else ""
-
-            # Combine listing and offering data
-            service_data = {
-                "service_name": service_name,
-                "status": service_status,
-                "listing": listing_data,
-                "offering": offering_data,
-                "provider": provider_data,
-            }
-            _display_data(service_data, listing_file, output_format)
-            return
-
-    console.print(f"[red]Service not found: {name}[/red]")
-    raise typer.Exit(code=1)
+        return provider_file, offering_file, listing_file
+    return None, None, None
 
 
-def _display_data(data: dict, file_path: Path, output_format: str):
-    """Display data in the specified format."""
-    if output_format not in ("tsv", "csv"):
-        console.print(f"[dim]File: {file_path}[/dim]\n")
-
+def _render_output(payload: Any, output_format: str) -> None:
+    """Emit *payload* on stdout. ``json`` gets rich syntax highlighting;
+    ``text`` prints plain JSON without colour (better for piping).
+    """
+    text = json.dumps(payload, indent=2, default=str, ensure_ascii=False)
     if output_format == "json":
-        json_str = json.dumps(data, indent=2, default=str)
-        syntax = Syntax(json_str, "json", theme="monokai", line_numbers=False)
-        console.print(syntax)
-    elif output_format in ("tsv", "csv"):
-        sep = "\t" if output_format == "tsv" else ","
-
-        def escape_value(value: Any) -> str:
-            if value is None:
-                return ""
-            if isinstance(value, dict | list):
-                s = json.dumps(value, default=str)
-            else:
-                s = str(value)
-            if output_format == "csv" and ("," in s or '"' in s or "\n" in s):
-                return '"' + s.replace('"', '""') + '"'
-            return s
-
-        # Output as key-value pairs
-        print(sep.join(["field", "value"]))
-        for key, value in data.items():
-            print(sep.join([key, escape_value(value)]))
-    elif output_format == "table":
-        _display_as_table(data)
+        console.print(Syntax(text, "json", theme="monokai", line_numbers=False))
+    elif output_format == "text":
+        print(text)
     else:
-        console.print(f"[red]Unknown format: {output_format}[/red]")
+        console.print(f"[red]Unknown format: {output_format!r}. Use 'json' or 'text'.[/red]")
         raise typer.Exit(code=1)
 
 
-def _display_as_table(data: dict, prefix: str = ""):
-    """Display dict as a table (flat key-value pairs)."""
-    table = Table(show_header=True)
-    table.add_column("Field", style="cyan")
-    table.add_column("Value", style="white")
+@app.command("show")
+def show_service(
+    service_name: str = typer.Argument(
+        ...,
+        help="Service name (first column of 'usvc_seller data list' output).",
+    ),
+    only_provider: bool = typer.Option(
+        False, "--provider", help="Show only provider data."
+    ),
+    only_offering: bool = typer.Option(
+        False, "--offering", help="Show only offering data."
+    ),
+    only_listing: bool = typer.Option(
+        False, "--listing", help="Show only listing data."
+    ),
+    data_dir: Path | None = typer.Option(
+        None,
+        "--data-dir",
+        "-d",
+        help="Directory containing data files (default: current directory).",
+    ),
+    output_format: str = typer.Option(
+        "json",
+        "--format",
+        "-f",
+        help="Output format: json (syntax-highlighted) or text (plain).",
+    ),
+) -> None:
+    """Show expanded data for a service.
 
-    for key, value in data.items():
-        if isinstance(value, dict):
-            # Show nested dict as JSON
-            table.add_row(f"{prefix}{key}", json.dumps(value, indent=2, default=str))
-        elif isinstance(value, list):
-            table.add_row(f"{prefix}{key}", json.dumps(value, indent=2, default=str))
-        else:
-            table.add_row(f"{prefix}{key}", str(value) if value is not None else "-")
+    By default prints provider + offering + listing as a single JSON
+    object keyed by section. Pass one or more of ``--provider``,
+    ``--offering``, ``--listing`` to restrict the output — with exactly
+    one flag set, the selected section is emitted unwrapped for easy
+    piping into ``jq``.
 
-    console.print(table)
+    Data is loaded through the seller's preset-aware loader, so any
+    ``$doc_preset`` / ``$file_preset`` sentinels have already been
+    replaced with the expanded records from ``unitysvc-data``.
+    """
+    if data_dir is None:
+        data_dir = Path.cwd()
+    if not data_dir.is_absolute():
+        data_dir = Path.cwd() / data_dir
+    if not data_dir.exists():
+        console.print(f"[red]Data directory not found: {data_dir}[/red]")
+        raise typer.Exit(code=1)
 
+    provider_file, offering_file, listing_file = _resolve_service_paths(
+        data_dir, service_name
+    )
+    if listing_file is None:
+        console.print(
+            f"[red]Service not found: {service_name!r}. "
+            f"Run 'usvc_seller data list' to see available service names.[/red]"
+        )
+        raise typer.Exit(code=1)
 
-app.add_typer(show_app, name="show")
+    def _load(path: Path | None) -> dict[str, Any]:
+        if path is None:
+            return {}
+        data, _ = load_data_file(path)
+        return data
+
+    provider_data = _load(provider_file)
+    offering_data = _load(offering_file)
+    listing_data = _load(listing_file)
+
+    flags = {
+        "provider": only_provider,
+        "offering": only_offering,
+        "listing": only_listing,
+    }
+    selected = [name for name, on in flags.items() if on]
+    sections = {
+        "provider": provider_data,
+        "offering": offering_data,
+        "listing": listing_data,
+    }
+
+    if not selected:
+        _render_output(sections, output_format)
+    elif len(selected) == 1:
+        # Unwrapped for single-section — more jq-friendly.
+        _render_output(sections[selected[0]], output_format)
+    else:
+        _render_output({k: sections[k] for k in selected}, output_format)
 
 # Register subcommands
 app.command("validate")(validator.validate)

--- a/src/unitysvc_sellers/upload.py
+++ b/src/unitysvc_sellers/upload.py
@@ -219,9 +219,25 @@ def _resolve_file_references(
 
             result["file_content"] = content
 
-            # Strip .j2 suffix so the stored filename matches the
-            # rendered output (e.g. ``test.py.j2`` -> ``test.py``).
-            if full_path.name.endswith(".j2"):
+            # Pick the stored ``file_path`` shape:
+            #
+            # - Absolute input (typically injected by a ``$doc_preset``
+            #   expansion pointing at a bundled example inside the
+            #   installed ``unitysvc-data`` package) -> basename only.
+            #   The seller's local filesystem layout must not leak
+            #   into the backend payload.
+            # - Relative input (the historical seller-authored form,
+            #   e.g. ``../../docs/connectivity.sh.j2``) -> keep the
+            #   relative shape, just strip the ``.j2`` suffix so the
+            #   stored name matches the rendered output. Preserves
+            #   backwards compatibility with existing seller catalogs.
+            #
+            # ``render_template_file`` returns ``actual_filename`` with
+            # the ``.j2`` already stripped for templates, which we use
+            # for the absolute-path branch.
+            if Path(value).is_absolute():
+                result[key] = actual_filename
+            elif full_path.name.endswith(".j2"):
                 result[key] = value[:-3]
             else:
                 result[key] = value
@@ -237,7 +253,7 @@ def _build_service_payload(listing_file: Path) -> tuple[dict[str, Any], dict[str
     Returns ``(provider_data, offering_data, listing_data)`` as plain
     dicts ready to drop into ``ServiceDataInput``.
     """
-    from unitysvc_core.utils import load_data_file
+    from .utils import load_data_file
 
     listing_data, _ = load_data_file(listing_file)
 

--- a/src/unitysvc_sellers/upload.py
+++ b/src/unitysvc_sellers/upload.py
@@ -219,22 +219,29 @@ def _resolve_file_references(
 
             result["file_content"] = content
 
-            # Pick the stored ``file_path`` shape:
+            # Normalise the ``file_path`` value that stays alongside
+            # ``file_content`` for local display / dry-run output /
+            # logs. The backend ingests ``file_content``; the
+            # ``file_path`` here is essentially seller-side metadata,
+            # but it's still worth keeping tidy:
             #
             # - Absolute input (typically injected by a ``$doc_preset``
-            #   expansion pointing at a bundled example inside the
-            #   installed ``unitysvc-data`` package) -> basename only.
-            #   The seller's local filesystem layout must not leak
-            #   into the backend payload.
+            #   expansion, which resolves to the bundled example's
+            #   absolute path inside the installed ``unitysvc-data``
+            #   package) -> just the basename. Dry-run output and any
+            #   log lines that echo ``file_path`` then show
+            #   ``connectivity-v1.py`` instead of a developer's venv
+            #   path, and two sellers on different machines produce
+            #   the same in-memory payload for the same preset.
             # - Relative input (the historical seller-authored form,
             #   e.g. ``../../docs/connectivity.sh.j2``) -> keep the
-            #   relative shape, just strip the ``.j2`` suffix so the
-            #   stored name matches the rendered output. Preserves
-            #   backwards compatibility with existing seller catalogs.
+            #   relative shape and strip only the ``.j2`` suffix so
+            #   the stored name matches the rendered output. Keeps
+            #   existing catalogs byte-identical to the pre-preset
+            #   pipeline.
             #
             # ``render_template_file`` returns ``actual_filename`` with
-            # the ``.j2`` already stripped for templates, which we use
-            # for the absolute-path branch.
+            # the ``.j2`` already stripped for templates.
             if Path(value).is_absolute():
                 result[key] = actual_filename
             elif full_path.name.endswith(".j2"):

--- a/src/unitysvc_sellers/utils.py
+++ b/src/unitysvc_sellers/utils.py
@@ -58,27 +58,68 @@ from unitysvc_data import doc_preset, file_preset
 #     { "$file_preset": "s3_connectivity_v1" }
 #         -> file_preset("s3_connectivity_v1")  -> raw UTF-8 file content
 #
-#     { "$doc_preset": { "$preset": "s3_connectivity",
-#                        "$with": { "description": "ours" } } }
-#         -> doc_preset({"$preset": ..., "$with": {...}})
+#     { "$doc_preset": { "name": "s3_connectivity",
+#                        "description": "ours" } }
+#         -> doc_preset("s3_connectivity", description="ours")
 #             -> doc record with the override applied
 #
-# The functions accept either a bare name or the nested ``{"$preset": ...,
-# "$with": {...}}`` form already defined by ``unitysvc-data``, so the
-# walker itself is format-agnostic — it just forwards whatever value it
-# finds under the ``$<fn>`` key.
+# The flat ``{"name": ..., <override>: ...}`` shape is the seller-facing
+# vocabulary: ``name`` is the preset identifier, every other key is a
+# per-field override. Using ``unitysvc-data``'s internal
+# ``{"$preset": ..., "$with": {...}}`` form also works (the functions
+# accept it), but sellers shouldn't need to know that vocabulary —
+# hence the thin wrappers below that translate the flat form.
 #
 # This walker is a candidate for promotion to ``unitysvc-core.utils`` if
 # non-seller code ends up needing it; keeping it here for now since only
 # the sellers SDK uses it.
 # -----------------------------------------------------------------------------
 
+
+def _unwrap_flat_form(source: Any) -> tuple[Any, dict[str, Any]]:
+    """Split a flat sentinel value into (preset_name, overrides).
+
+    When ``source`` is a dict carrying a string ``name`` key, the other
+    keys are treated as kwargs destined for the preset function — this
+    is the seller-facing shape::
+
+        {"name": "s3_code_example", "description": "ours"}
+        -> ("s3_code_example", {"description": "ours"})
+
+    Any other value (bare string, ``unitysvc-data``'s internal
+    ``{"$preset": ..., "$with": {...}}`` sentinel, etc.) passes through
+    untouched in the first slot with an empty override dict. The
+    preset function itself handles those shapes.
+    """
+    if isinstance(source, dict) and isinstance(source.get("name"), str):
+        name = source["name"]
+        return name, {k: v for k, v in source.items() if k != "name"}
+    return source, {}
+
+
+def _doc_preset_sentinel(source: Any) -> dict[str, Any]:
+    arg, overrides = _unwrap_flat_form(source)
+    return doc_preset(arg, **overrides)
+
+
+def _file_preset_sentinel(source: Any) -> str:
+    arg, overrides = _unwrap_flat_form(source)
+    if overrides:
+        raise ValueError(
+            "$file_preset does not accept per-field overrides — the file "
+            "content is immutable. Unexpected keys alongside 'name': "
+            f"{sorted(overrides)!r}."
+        )
+    return file_preset(arg)
+
+
 #: Preset function names recognised in sentinel dicts. Sourced from
-#: ``unitysvc-data``; add new entries here as the upstream package grows
-#: new primitives.
+#: ``unitysvc-data`` and wrapped to accept the seller-facing flat form
+#: (``{"name": "...", <override>: ...}``). Add new entries here as the
+#: upstream package grows new primitives.
 SELLER_PRESET_FNS: Mapping[str, Callable[[Any], Any]] = {
-    "doc_preset": doc_preset,
-    "file_preset": file_preset,
+    "doc_preset": _doc_preset_sentinel,
+    "file_preset": _file_preset_sentinel,
 }
 
 
@@ -137,9 +178,8 @@ def expand_presets(
                     raise ValueError(
                         f"Preset sentinel key {key!r} must appear alone in its "
                         f"dict — found alongside {sorted(k for k in data if k != key)!r}. "
-                        "If you meant per-field overrides, pass them through the "
-                        "preset function's own '$with' form, e.g. "
-                        f"{{{key!r}: {{'$preset': '<name>', '$with': {{...}}}}}}."
+                        "If you meant per-field overrides, nest them inside the "
+                        f"sentinel value: {{{key!r}: {{'name': '<preset>', <override>: ...}}}}."
                     )
 
         return {key: expand_presets(value, preset_fns) for key, value in data.items()}

--- a/src/unitysvc_sellers/utils.py
+++ b/src/unitysvc_sellers/utils.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import json
 import os
+from collections.abc import Callable, Mapping
 from pathlib import Path
 from typing import Any
 
@@ -35,12 +36,142 @@ from unitysvc_core.utils import (  # noqa: F401
     generate_content_based_key,
     get_basename,
     get_file_extension,
-    load_data_file,
     mime_type_to_extension,
     read_override_file,
     write_data_file,
     write_override_file,
 )
+from unitysvc_core.utils import load_data_file as _core_load_data_file
+from unitysvc_data import doc_preset, file_preset
+
+# -----------------------------------------------------------------------------
+# Preset sentinel expansion
+#
+# Seller data files may contain sentinels that call into preset functions
+# exposed by ``unitysvc-data``. The sentinel is a dict with exactly one
+# ``$<fn>`` key whose value is forwarded to the matching preset function;
+# the whole node is replaced by the function's return value.
+#
+#     { "$doc_preset": "s3_connectivity" }
+#         -> doc_preset("s3_connectivity")  -> full document record dict
+#
+#     { "$file_preset": "s3_connectivity_v1" }
+#         -> file_preset("s3_connectivity_v1")  -> raw UTF-8 file content
+#
+#     { "$doc_preset": { "$preset": "s3_connectivity",
+#                        "$with": { "description": "ours" } } }
+#         -> doc_preset({"$preset": ..., "$with": {...}})
+#             -> doc record with the override applied
+#
+# The functions accept either a bare name or the nested ``{"$preset": ...,
+# "$with": {...}}`` form already defined by ``unitysvc-data``, so the
+# walker itself is format-agnostic — it just forwards whatever value it
+# finds under the ``$<fn>`` key.
+#
+# This walker is a candidate for promotion to ``unitysvc-core.utils`` if
+# non-seller code ends up needing it; keeping it here for now since only
+# the sellers SDK uses it.
+# -----------------------------------------------------------------------------
+
+#: Preset function names recognised in sentinel dicts. Sourced from
+#: ``unitysvc-data``; add new entries here as the upstream package grows
+#: new primitives.
+SELLER_PRESET_FNS: Mapping[str, Callable[[Any], Any]] = {
+    "doc_preset": doc_preset,
+    "file_preset": file_preset,
+}
+
+
+def expand_presets(
+    data: Any,
+    preset_fns: Mapping[str, Callable[[Any], Any]] = SELLER_PRESET_FNS,
+) -> Any:
+    """Recursively replace preset sentinel nodes with their expanded values.
+
+    A **preset sentinel** is a dict containing exactly one key of the
+    form ``$<fn_name>`` where ``<fn_name>`` matches a key in
+    ``preset_fns``. The value under that key is passed as the single
+    positional argument to the function; the function's return value
+    replaces the whole sentinel node in the result.
+
+    Non-sentinel dicts and lists are walked recursively. Scalars pass
+    through unchanged. The input is never mutated — a new structure is
+    returned.
+
+    Args:
+        data: Parsed data (dict / list / scalar) from a loaded data file.
+        preset_fns: Mapping of function name to callable. Defaults to
+            :data:`SELLER_PRESET_FNS` (``doc_preset`` and ``file_preset``
+            from the bundled ``unitysvc-data`` package).
+
+    Returns:
+        A new structure with every recognised sentinel replaced.
+
+    Raises:
+        KeyError, ValueError: Propagated from the underlying preset
+            function if the sentinel's value is invalid (unknown preset
+            name, forbidden override, etc.).
+    """
+    if isinstance(data, dict):
+        # Detect sentinel: exactly one key, starting with '$', matching
+        # a registered preset function.
+        if len(data) == 1:
+            (only_key,) = data.keys()
+            if isinstance(only_key, str) and only_key.startswith("$"):
+                fn_name = only_key[1:]
+                fn = preset_fns.get(fn_name)
+                if fn is not None:
+                    # Recurse into the value first so nested sentinels
+                    # (e.g. a $file_preset buried inside a $doc_preset's
+                    # $with block) expand from the inside out before
+                    # the outer call.
+                    return fn(expand_presets(data[only_key], preset_fns))
+
+        # Reject ambiguous partial sentinels: a '$<fn>' key present
+        # alongside other keys would silently ignore the preset call,
+        # which is a footgun. Flag it explicitly.
+        for key in data:
+            if isinstance(key, str) and key.startswith("$"):
+                fn_name = key[1:]
+                if fn_name in preset_fns:
+                    raise ValueError(
+                        f"Preset sentinel key {key!r} must appear alone in its "
+                        f"dict — found alongside {sorted(k for k in data if k != key)!r}. "
+                        "If you meant per-field overrides, pass them through the "
+                        "preset function's own '$with' form, e.g. "
+                        f"{{{key!r}: {{'$preset': '<name>', '$with': {{...}}}}}}."
+                    )
+
+        return {key: expand_presets(value, preset_fns) for key, value in data.items()}
+
+    if isinstance(data, list):
+        return [expand_presets(item, preset_fns) for item in data]
+
+    return data
+
+
+def load_data_file(
+    file_path: Path,
+    *,
+    skip_override: bool = False,
+    preset_fns: Mapping[str, Callable[[Any], Any]] | None = SELLER_PRESET_FNS,
+) -> tuple[dict[str, Any], str]:
+    """Load a seller data file and expand any preset sentinels it contains.
+
+    Thin wrapper around :func:`unitysvc_core.utils.load_data_file` that
+    runs :func:`expand_presets` on the merged payload before returning.
+    Call sites in seller code should use this wrapper so that ``$preset``
+    sentinels are transparently replaced with their expanded values —
+    ``.toml`` / ``.json`` / ``*.override.*`` are all handled the same
+    way because expansion runs after the override merge.
+
+    Pass ``preset_fns=None`` to skip expansion entirely (behaves
+    identically to the core helper).
+    """
+    data, file_format = _core_load_data_file(file_path, skip_override=skip_override)
+    if preset_fns:
+        data = expand_presets(data, preset_fns)
+    return data, file_format
 
 
 def resolve_provider_name(file_path: Path) -> str | None:

--- a/src/unitysvc_sellers/utils.py
+++ b/src/unitysvc_sellers/utils.py
@@ -19,14 +19,16 @@ from __future__ import annotations
 
 import json
 import os
-from collections.abc import Callable, Mapping
 from pathlib import Path
 from typing import Any
 
 from jinja2 import Environment as JinjaEnvironment
 
 # Re-exports from unitysvc_core so seller modules can import everything
-# from a single place.
+# from a single place. ``load_data_file`` and the file-discovery helpers
+# that flow through it now handle ``$doc_preset`` / ``$file_preset``
+# sentinel expansion transparently — see unitysvc_core.utils and the
+# ``@preset`` decorator in unitysvc_data for the full story.
 from unitysvc_core.utils import (  # noqa: F401
     compute_file_hash,
     deep_merge_dicts,
@@ -36,182 +38,12 @@ from unitysvc_core.utils import (  # noqa: F401
     generate_content_based_key,
     get_basename,
     get_file_extension,
+    load_data_file,
     mime_type_to_extension,
     read_override_file,
     write_data_file,
     write_override_file,
 )
-from unitysvc_core.utils import load_data_file as _core_load_data_file
-from unitysvc_data import doc_preset, file_preset
-
-# -----------------------------------------------------------------------------
-# Preset sentinel expansion
-#
-# Seller data files may contain sentinels that call into preset functions
-# exposed by ``unitysvc-data``. The sentinel is a dict with exactly one
-# ``$<fn>`` key whose value is forwarded to the matching preset function;
-# the whole node is replaced by the function's return value.
-#
-#     { "$doc_preset": "s3_connectivity" }
-#         -> doc_preset("s3_connectivity")  -> full document record dict
-#
-#     { "$file_preset": "s3_connectivity_v1" }
-#         -> file_preset("s3_connectivity_v1")  -> raw UTF-8 file content
-#
-#     { "$doc_preset": { "name": "s3_connectivity",
-#                        "description": "ours" } }
-#         -> doc_preset("s3_connectivity", description="ours")
-#             -> doc record with the override applied
-#
-# The flat ``{"name": ..., <override>: ...}`` shape is the seller-facing
-# vocabulary: ``name`` is the preset identifier, every other key is a
-# per-field override. Using ``unitysvc-data``'s internal
-# ``{"$preset": ..., "$with": {...}}`` form also works (the functions
-# accept it), but sellers shouldn't need to know that vocabulary —
-# hence the thin wrappers below that translate the flat form.
-#
-# This walker is a candidate for promotion to ``unitysvc-core.utils`` if
-# non-seller code ends up needing it; keeping it here for now since only
-# the sellers SDK uses it.
-# -----------------------------------------------------------------------------
-
-
-def _unwrap_flat_form(source: Any) -> tuple[Any, dict[str, Any]]:
-    """Split a flat sentinel value into (preset_name, overrides).
-
-    When ``source`` is a dict carrying a string ``name`` key, the other
-    keys are treated as kwargs destined for the preset function — this
-    is the seller-facing shape::
-
-        {"name": "s3_code_example", "description": "ours"}
-        -> ("s3_code_example", {"description": "ours"})
-
-    Any other value (bare string, ``unitysvc-data``'s internal
-    ``{"$preset": ..., "$with": {...}}`` sentinel, etc.) passes through
-    untouched in the first slot with an empty override dict. The
-    preset function itself handles those shapes.
-    """
-    if isinstance(source, dict) and isinstance(source.get("name"), str):
-        name = source["name"]
-        return name, {k: v for k, v in source.items() if k != "name"}
-    return source, {}
-
-
-def _doc_preset_sentinel(source: Any) -> dict[str, Any]:
-    arg, overrides = _unwrap_flat_form(source)
-    return doc_preset(arg, **overrides)
-
-
-def _file_preset_sentinel(source: Any) -> str:
-    arg, overrides = _unwrap_flat_form(source)
-    if overrides:
-        raise ValueError(
-            "$file_preset does not accept per-field overrides — the file "
-            "content is immutable. Unexpected keys alongside 'name': "
-            f"{sorted(overrides)!r}."
-        )
-    return file_preset(arg)
-
-
-#: Preset function names recognised in sentinel dicts. Sourced from
-#: ``unitysvc-data`` and wrapped to accept the seller-facing flat form
-#: (``{"name": "...", <override>: ...}``). Add new entries here as the
-#: upstream package grows new primitives.
-SELLER_PRESET_FNS: Mapping[str, Callable[[Any], Any]] = {
-    "doc_preset": _doc_preset_sentinel,
-    "file_preset": _file_preset_sentinel,
-}
-
-
-def expand_presets(
-    data: Any,
-    preset_fns: Mapping[str, Callable[[Any], Any]] = SELLER_PRESET_FNS,
-) -> Any:
-    """Recursively replace preset sentinel nodes with their expanded values.
-
-    A **preset sentinel** is a dict containing exactly one key of the
-    form ``$<fn_name>`` where ``<fn_name>`` matches a key in
-    ``preset_fns``. The value under that key is passed as the single
-    positional argument to the function; the function's return value
-    replaces the whole sentinel node in the result.
-
-    Non-sentinel dicts and lists are walked recursively. Scalars pass
-    through unchanged. The input is never mutated — a new structure is
-    returned.
-
-    Args:
-        data: Parsed data (dict / list / scalar) from a loaded data file.
-        preset_fns: Mapping of function name to callable. Defaults to
-            :data:`SELLER_PRESET_FNS` (``doc_preset`` and ``file_preset``
-            from the bundled ``unitysvc-data`` package).
-
-    Returns:
-        A new structure with every recognised sentinel replaced.
-
-    Raises:
-        KeyError, ValueError: Propagated from the underlying preset
-            function if the sentinel's value is invalid (unknown preset
-            name, forbidden override, etc.).
-    """
-    if isinstance(data, dict):
-        # Detect sentinel: exactly one key, starting with '$', matching
-        # a registered preset function.
-        if len(data) == 1:
-            (only_key,) = data.keys()
-            if isinstance(only_key, str) and only_key.startswith("$"):
-                fn_name = only_key[1:]
-                fn = preset_fns.get(fn_name)
-                if fn is not None:
-                    # Recurse into the value first so nested sentinels
-                    # (e.g. a $file_preset buried inside a $doc_preset's
-                    # $with block) expand from the inside out before
-                    # the outer call.
-                    return fn(expand_presets(data[only_key], preset_fns))
-
-        # Reject ambiguous partial sentinels: a '$<fn>' key present
-        # alongside other keys would silently ignore the preset call,
-        # which is a footgun. Flag it explicitly.
-        for key in data:
-            if isinstance(key, str) and key.startswith("$"):
-                fn_name = key[1:]
-                if fn_name in preset_fns:
-                    raise ValueError(
-                        f"Preset sentinel key {key!r} must appear alone in its "
-                        f"dict — found alongside {sorted(k for k in data if k != key)!r}. "
-                        "If you meant per-field overrides, nest them inside the "
-                        f"sentinel value: {{{key!r}: {{'name': '<preset>', <override>: ...}}}}."
-                    )
-
-        return {key: expand_presets(value, preset_fns) for key, value in data.items()}
-
-    if isinstance(data, list):
-        return [expand_presets(item, preset_fns) for item in data]
-
-    return data
-
-
-def load_data_file(
-    file_path: Path,
-    *,
-    skip_override: bool = False,
-    preset_fns: Mapping[str, Callable[[Any], Any]] | None = SELLER_PRESET_FNS,
-) -> tuple[dict[str, Any], str]:
-    """Load a seller data file and expand any preset sentinels it contains.
-
-    Thin wrapper around :func:`unitysvc_core.utils.load_data_file` that
-    runs :func:`expand_presets` on the merged payload before returning.
-    Call sites in seller code should use this wrapper so that ``$preset``
-    sentinels are transparently replaced with their expanded values —
-    ``.toml`` / ``.json`` / ``*.override.*`` are all handled the same
-    way because expansion runs after the override merge.
-
-    Pass ``preset_fns=None`` to skip expansion entirely (behaves
-    identically to the core helper).
-    """
-    data, file_format = _core_load_data_file(file_path, skip_override=skip_override)
-    if preset_fns:
-        data = expand_presets(data, preset_fns)
-    return data, file_format
 
 
 def resolve_provider_name(file_path: Path) -> str | None:

--- a/src/unitysvc_sellers/validator.py
+++ b/src/unitysvc_sellers/validator.py
@@ -22,25 +22,10 @@ class DataValidator(CoreDataValidator):
 
     Extends the core per-file validator with checks that understand the
     seller catalog directory layout (``<provider>/services/<service>/``).
+    ``$preset`` expansion is handled upstream in
+    :func:`unitysvc_core.utils.load_data_file`, so validation runs
+    against the same fully-expanded records the upload flow sends.
     """
-
-    def load_data_file(self, file_path: Path) -> tuple[dict[str, Any] | None, list[str]]:
-        """Load a seller data file and expand any ``$preset`` sentinels.
-
-        Overrides :meth:`CoreDataValidator.load_data_file` so that
-        ``usvc_seller data validate`` sees the same expanded data the
-        upload flow sends to the backend — preset-referenced documents
-        are validated against their final shape, not the sentinel stub.
-        """
-        errors: list[str] = []
-        try:
-            from .utils import load_data_file as seller_load_data_file
-
-            data, _ = seller_load_data_file(file_path)
-            return data, errors
-        except Exception as exc:
-            format_name = {".json": "JSON", ".toml": "TOML"}.get(file_path.suffix, "data")
-            return None, [f"Failed to parse {format_name}: {exc}"]
 
     def validate_provider_status(self) -> tuple[bool, list[str]]:
         """

--- a/src/unitysvc_sellers/validator.py
+++ b/src/unitysvc_sellers/validator.py
@@ -24,6 +24,24 @@ class DataValidator(CoreDataValidator):
     seller catalog directory layout (``<provider>/services/<service>/``).
     """
 
+    def load_data_file(self, file_path: Path) -> tuple[dict[str, Any] | None, list[str]]:
+        """Load a seller data file and expand any ``$preset`` sentinels.
+
+        Overrides :meth:`CoreDataValidator.load_data_file` so that
+        ``usvc_seller data validate`` sees the same expanded data the
+        upload flow sends to the backend — preset-referenced documents
+        are validated against their final shape, not the sentinel stub.
+        """
+        errors: list[str] = []
+        try:
+            from .utils import load_data_file as seller_load_data_file
+
+            data, _ = seller_load_data_file(file_path)
+            return data, errors
+        except Exception as exc:
+            format_name = {".json": "JSON", ".toml": "TOML"}.get(file_path.suffix, "data")
+            return None, [f"Failed to parse {format_name}: {exc}"]
+
     def validate_provider_status(self) -> tuple[bool, list[str]]:
         """
         Validate provider status and warn about services under disabled/draft providers.

--- a/tests/test_preset_expansion.py
+++ b/tests/test_preset_expansion.py
@@ -1,0 +1,319 @@
+"""Tests for ``expand_presets`` and the preset-aware ``load_data_file`` wrapper.
+
+Sellers can embed ``{"$doc_preset": ...}`` / ``{"$file_preset": ...}``
+sentinels anywhere in a JSON/TOML data file. The walker in
+``unitysvc_sellers.utils`` replaces each sentinel with the expanded
+value from ``unitysvc-data`` at load time, so the rest of the upload /
+validate pipeline sees fully-materialised records.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from unitysvc_data import doc_preset
+
+from unitysvc_sellers.utils import (
+    SELLER_PRESET_FNS,
+    expand_presets,
+    load_data_file,
+)
+
+# ---------------------------------------------------------------------------
+# expand_presets — sentinel detection and replacement
+# ---------------------------------------------------------------------------
+
+
+def test_bare_string_doc_preset_sentinel_expands_to_document_record():
+    node = {"Connectivity": {"$doc_preset": "s3_connectivity"}}
+    result = expand_presets(node)
+    record = result["Connectivity"]
+    assert record["category"] == "connectivity_test"
+    assert record["mime_type"] == "python"
+    assert Path(record["file_path"]).is_file()
+
+
+def test_doc_preset_alias_matches_versioned():
+    alias = expand_presets({"x": {"$doc_preset": "s3_connectivity"}})["x"]
+    versioned = expand_presets({"x": {"$doc_preset": "s3_connectivity_v1"}})["x"]
+    assert alias == versioned
+
+
+def test_doc_preset_sentinel_with_with_block_forwards_overrides():
+    # The sentinel's VALUE is forwarded to doc_preset verbatim. doc_preset
+    # already understands the nested {"$preset": ..., "$with": {...}} form,
+    # so overrides travel through cleanly.
+    node = {
+        "$doc_preset": {
+            "$preset": "s3_code_example",
+            "$with": {"description": "Uploads to customer bucket", "is_public": False},
+        }
+    }
+    record = expand_presets(node)
+    assert record["description"] == "Uploads to customer bucket"
+    assert record["is_public"] is False
+    assert record["category"] == "usage_example"
+
+
+def test_file_preset_sentinel_returns_raw_content():
+    node = {"$file_preset": "s3_connectivity_v1"}
+    content = expand_presets(node)
+    assert isinstance(content, str)
+    assert "boto3" in content
+
+
+def test_expand_presets_walks_nested_dicts_and_lists():
+    data = {
+        "documents": {
+            "Connectivity": {"$doc_preset": "s3_connectivity_v1"},
+            "Custom": {"category": "custom", "file_path": "local.sh"},
+        },
+        "snippets": [
+            {"$file_preset": "s3_connectivity_v1"},
+            "plain string",
+            {"nested": {"$doc_preset": "api_connectivity"}},
+        ],
+    }
+    result = expand_presets(data)
+
+    # Preset nodes replaced.
+    assert result["documents"]["Connectivity"]["category"] == "connectivity_test"
+    assert isinstance(result["snippets"][0], str)
+    assert result["snippets"][1] == "plain string"
+    assert result["snippets"][2]["nested"]["category"] == "connectivity_test"
+
+    # Non-sentinel dicts pass through unchanged.
+    assert result["documents"]["Custom"] == {"category": "custom", "file_path": "local.sh"}
+
+
+def test_expand_presets_returns_fresh_structure_and_does_not_mutate_input():
+    original = {"a": {"$doc_preset": "s3_connectivity_v1"}, "b": [1, 2, 3]}
+    before = json.dumps(original, sort_keys=True)
+    expand_presets(original)
+    after = json.dumps(original, sort_keys=True)
+    assert before == after, "expand_presets must not mutate its input"
+
+
+def test_sentinel_alongside_other_keys_is_rejected_with_clear_error():
+    # A sentinel must be the only key in its dict. Silently ignoring a
+    # $doc_preset key next to a sibling would be a footgun, so we raise.
+    node = {
+        "$doc_preset": "s3_connectivity",
+        "category": "overridden",  # siblings are not allowed
+    }
+    with pytest.raises(ValueError, match="must appear alone in its dict"):
+        expand_presets(node)
+
+
+def test_unknown_dollar_key_is_not_treated_as_sentinel():
+    # $-prefixed keys that don't match a registered preset function are
+    # treated as ordinary data (e.g. MongoDB operators in metadata).
+    node = {"$eq": "s3_connectivity"}
+    assert expand_presets(node) == {"$eq": "s3_connectivity"}
+
+
+def test_unknown_preset_name_raises_from_underlying_function():
+    with pytest.raises(KeyError, match="Unknown preset"):
+        expand_presets({"$doc_preset": "no_such_preset"})
+
+
+def test_scalars_pass_through_unchanged():
+    for scalar in [None, True, 42, 3.14, "hello", "$doc_preset"]:
+        assert expand_presets(scalar) == scalar
+
+
+def test_custom_preset_fns_mapping_restricts_recognised_names():
+    # Only ``my_fn`` is recognised; $doc_preset is ignored.
+    def my_fn(arg: Any) -> dict[str, Any]:
+        return {"expanded": arg}
+
+    node = {
+        "outer": {"$my_fn": "hello"},
+        "ignored": {"$doc_preset": "s3_connectivity"},
+    }
+    result = expand_presets(node, preset_fns={"my_fn": my_fn})
+    assert result["outer"] == {"expanded": "hello"}
+    # $doc_preset is not in the custom mapping -> left unchanged.
+    assert result["ignored"] == {"$doc_preset": "s3_connectivity"}
+
+
+# ---------------------------------------------------------------------------
+# load_data_file wrapper
+# ---------------------------------------------------------------------------
+
+
+def test_load_data_file_expands_presets_in_json(tmp_path: Path):
+    listing = tmp_path / "listing.json"
+    listing.write_text(
+        json.dumps(
+            {
+                "schema": "listing_v1",
+                "name": "demo",
+                "documents": {
+                    "Connectivity test": {"$doc_preset": "s3_connectivity_v1"},
+                },
+            }
+        )
+    )
+
+    data, fmt = load_data_file(listing)
+    assert fmt == "json"
+    record = data["documents"]["Connectivity test"]
+    assert record["category"] == "connectivity_test"
+    assert record["mime_type"] == "python"
+    assert Path(record["file_path"]).is_file()
+    # Sentinel is fully replaced — no $-keys remain.
+    assert "$doc_preset" not in record
+
+
+def test_load_data_file_expands_presets_in_toml(tmp_path: Path):
+    listing = tmp_path / "listing.toml"
+    listing.write_text(
+        'schema = "listing_v1"\n'
+        'name = "demo"\n'
+        '[documents."Connectivity test"]\n'
+        '"$doc_preset" = "s3_connectivity_v1"\n'
+    )
+
+    data, fmt = load_data_file(listing)
+    assert fmt == "toml"
+    record = data["documents"]["Connectivity test"]
+    assert record["category"] == "connectivity_test"
+    assert "$doc_preset" not in record
+
+
+def test_load_data_file_expands_presets_after_override_merge(tmp_path: Path):
+    # Sentinel lives in the base file; override customises is_active.
+    # Expansion happens *after* the merge, so the final doc is the
+    # preset's record with the override applied.
+    base = tmp_path / "listing.json"
+    base.write_text(
+        json.dumps(
+            {
+                "schema": "listing_v1",
+                "documents": {
+                    "Connectivity test": {
+                        "$doc_preset": {
+                            "$preset": "s3_connectivity_v1",
+                            "$with": {"is_active": True},
+                        }
+                    }
+                },
+            }
+        )
+    )
+    override = tmp_path / "listing.override.json"
+    override.write_text(json.dumps({"name": "from-override"}))
+
+    data, _ = load_data_file(base)
+    assert data["name"] == "from-override"
+    record = data["documents"]["Connectivity test"]
+    assert record["is_active"] is True
+    assert record["category"] == "connectivity_test"
+
+
+def test_load_data_file_with_preset_fns_none_skips_expansion(tmp_path: Path):
+    # Escape hatch: callers that explicitly don't want expansion can
+    # disable it by passing preset_fns=None.
+    listing = tmp_path / "listing.json"
+    listing.write_text(
+        json.dumps(
+            {
+                "schema": "listing_v1",
+                "documents": {"Thing": {"$doc_preset": "s3_connectivity_v1"}},
+            }
+        )
+    )
+
+    data, _ = load_data_file(listing, preset_fns=None)
+    # Sentinel survives — no expansion applied.
+    assert data["documents"]["Thing"] == {"$doc_preset": "s3_connectivity_v1"}
+
+
+def test_seller_preset_fns_registers_doc_and_file():
+    assert set(SELLER_PRESET_FNS) == {"doc_preset", "file_preset"}
+    # Factory identity: the registered callable is the imported function.
+    assert SELLER_PRESET_FNS["doc_preset"] is doc_preset
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: preset sentinel in a listing flows through the upload pipeline
+# ---------------------------------------------------------------------------
+
+
+def test_preset_expanded_doc_survives_resolve_file_references(tmp_path: Path):
+    """Load a listing with a $doc_preset, then resolve file refs.
+
+    Verifies the full pipeline: expand_presets converts the sentinel to
+    a record with an absolute ``file_path`` (pointing inside the
+    installed ``unitysvc-data`` package), then ``_resolve_file_references``
+    reads+renders the file, inlines its content as ``file_content``,
+    and stores just the basename as the displayable ``file_path``.
+    """
+    from unitysvc_sellers.upload import _resolve_file_references
+
+    listing = tmp_path / "listing.json"
+    listing.write_text(
+        json.dumps(
+            {
+                "schema": "listing_v1",
+                "name": "demo",
+                "documents": {
+                    "Connectivity": {"$doc_preset": "s3_connectivity_v1"},
+                },
+            }
+        )
+    )
+
+    data, _ = load_data_file(listing)
+    record_before = data["documents"]["Connectivity"]
+    # Sanity: preset expansion produces an absolute path to the bundled file.
+    assert Path(record_before["file_path"]).is_absolute()
+    assert Path(record_before["file_path"]).is_file()
+
+    resolved = _resolve_file_references(
+        data,
+        tmp_path,
+        listing=data,
+        provider={"name": "acme"},
+        offering={"upstream_access_config": {"default": {"base_url": "https://s3.acme.test"}}},
+        interface={"base_url": "https://s3.acme.test"},
+    )
+    record_after = resolved["documents"]["Connectivity"]
+
+    # file_content is inlined — the backend never needs to open the file.
+    assert "boto3" in record_after["file_content"]
+    # file_path is reduced to basename (no absolute path leaked to backend),
+    # and .j2 is stripped so the stored name matches the rendered output.
+    assert record_after["file_path"] == "connectivity-v1.py"
+    # Metadata carried through unchanged.
+    assert record_after["category"] == "connectivity_test"
+    assert record_after["mime_type"] == "python"
+
+
+def test_relative_file_path_keeps_backwards_compatible_shape(tmp_path: Path):
+    """Existing seller catalogs write relative paths like ``../../docs/foo.sh.j2``.
+
+    The stored ``file_path`` still keeps the relative shape (minus
+    ``.j2``) so existing catalogs aren't disrupted by the absolute-path
+    support added for preset expansion.
+    """
+    from unitysvc_sellers.upload import _resolve_file_references
+
+    provider_dir = tmp_path / "acme"
+    docs_dir = provider_dir / "docs"
+    docs_dir.mkdir(parents=True)
+    (docs_dir / "shared.js.j2").write_text("// hi {{ provider.name }}\n")
+
+    service_dir = provider_dir / "services" / "svc1"
+    service_dir.mkdir(parents=True)
+
+    data = {"file_path": "../../docs/shared.js.j2", "mime_type": "javascript"}
+    resolved = _resolve_file_references(data, service_dir, provider={"name": "acme"})
+
+    # Relative shape preserved — no change from pre-preset behaviour.
+    assert resolved["file_path"] == "../../docs/shared.js"
+    assert "hi acme" in resolved["file_content"]

--- a/tests/test_preset_expansion.py
+++ b/tests/test_preset_expansion.py
@@ -1,312 +1,34 @@
-"""Tests for ``expand_presets`` and the preset-aware ``load_data_file`` wrapper.
+"""End-to-end coverage of ``$doc_preset`` / ``$file_preset`` flowing
+through the seller pipeline.
 
-Sellers can embed ``{"$doc_preset": ...}`` / ``{"$file_preset": ...}``
-sentinels anywhere in a JSON/TOML data file. The walker in
-``unitysvc_sellers.utils`` replaces each sentinel with the expanded
-value from ``unitysvc-data`` at load time, so the rest of the upload /
-validate pipeline sees fully-materialised records.
+The sentinel walker and its unit tests live in ``unitysvc-core`` —
+`unitysvc_core.utils.load_data_file` expands every ``$<fn>`` sentinel
+after the override merge, driven by the registry in
+``unitysvc_data.PRESET_FNS``. These tests only cover the seller-side
+integration: that the expanded records survive ``_resolve_file_references``
+and that the historical relative-``file_path`` shape still works for
+catalogs that haven't migrated to presets.
 """
 
 from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any
 
-import pytest
-from unitysvc_data import doc_preset
-
-from unitysvc_sellers.utils import (
-    SELLER_PRESET_FNS,
-    expand_presets,
-    load_data_file,
-)
-
-# ---------------------------------------------------------------------------
-# expand_presets — sentinel detection and replacement
-# ---------------------------------------------------------------------------
-
-
-def test_bare_string_doc_preset_sentinel_expands_to_document_record():
-    node = {"Connectivity": {"$doc_preset": "s3_connectivity"}}
-    result = expand_presets(node)
-    record = result["Connectivity"]
-    assert record["category"] == "connectivity_test"
-    assert record["mime_type"] == "python"
-    assert Path(record["file_path"]).is_file()
-
-
-def test_doc_preset_alias_matches_versioned():
-    alias = expand_presets({"x": {"$doc_preset": "s3_connectivity"}})["x"]
-    versioned = expand_presets({"x": {"$doc_preset": "s3_connectivity_v1"}})["x"]
-    assert alias == versioned
-
-
-def test_doc_preset_flat_form_with_overrides():
-    # Seller-facing shape: {"name": "<preset>", <override>: ...}. "name"
-    # is the identifier; all other keys are per-field overrides passed
-    # as kwargs to doc_preset.
-    node = {
-        "$doc_preset": {
-            "name": "s3_code_example",
-            "description": "Uploads to customer bucket",
-            "is_public": False,
-        }
-    }
-    record = expand_presets(node)
-    assert record["description"] == "Uploads to customer bucket"
-    assert record["is_public"] is False
-    assert record["category"] == "code_example"
-
-
-def test_doc_preset_flat_form_name_only_equals_bare_string():
-    flat = expand_presets({"$doc_preset": {"name": "s3_connectivity"}})
-    bare = expand_presets({"$doc_preset": "s3_connectivity"})
-    assert flat == bare
-
-
-def test_doc_preset_nested_preset_with_form_still_works():
-    # unitysvc-data's internal {"$preset": ..., "$with": {...}} shape is
-    # not the seller-facing API but the walker forwards it through
-    # doc_preset, which accepts it. Verified so we don't silently break
-    # it if someone on the team already adopted it.
-    node = {
-        "$doc_preset": {
-            "$preset": "s3_code_example",
-            "$with": {"description": "via nested form"},
-        }
-    }
-    record = expand_presets(node)
-    assert record["description"] == "via nested form"
-    assert record["category"] == "code_example"
-
-
-def test_doc_preset_flat_form_rejects_forbidden_override():
-    # Overrides still go through doc_preset's whitelist. "category" is
-    # tied to the file content and not overridable.
-    node = {"$doc_preset": {"name": "s3_connectivity", "category": "other"}}
-    with pytest.raises(ValueError, match="Cannot override"):
-        expand_presets(node)
-
-
-def test_file_preset_flat_form_rejects_overrides():
-    # File content is immutable — overrides make no sense for $file_preset.
-    node = {"$file_preset": {"name": "s3_connectivity_v1", "description": "x"}}
-    with pytest.raises(ValueError, match="does not accept per-field overrides"):
-        expand_presets(node)
-
-
-def test_file_preset_flat_form_name_only_works():
-    # A dict with just {"name": ...} is equivalent to the bare-string form.
-    flat = expand_presets({"$file_preset": {"name": "s3_connectivity_v1"}})
-    bare = expand_presets({"$file_preset": "s3_connectivity_v1"})
-    assert flat == bare
-
-
-def test_file_preset_sentinel_returns_raw_content():
-    node = {"$file_preset": "s3_connectivity_v1"}
-    content = expand_presets(node)
-    assert isinstance(content, str)
-    assert "boto3" in content
-
-
-def test_expand_presets_walks_nested_dicts_and_lists():
-    data = {
-        "documents": {
-            "Connectivity": {"$doc_preset": "s3_connectivity_v1"},
-            "Custom": {"category": "custom", "file_path": "local.sh"},
-        },
-        "snippets": [
-            {"$file_preset": "s3_connectivity_v1"},
-            "plain string",
-            {"nested": {"$doc_preset": "api_connectivity"}},
-        ],
-    }
-    result = expand_presets(data)
-
-    # Preset nodes replaced.
-    assert result["documents"]["Connectivity"]["category"] == "connectivity_test"
-    assert isinstance(result["snippets"][0], str)
-    assert result["snippets"][1] == "plain string"
-    assert result["snippets"][2]["nested"]["category"] == "connectivity_test"
-
-    # Non-sentinel dicts pass through unchanged.
-    assert result["documents"]["Custom"] == {"category": "custom", "file_path": "local.sh"}
-
-
-def test_expand_presets_returns_fresh_structure_and_does_not_mutate_input():
-    original = {"a": {"$doc_preset": "s3_connectivity_v1"}, "b": [1, 2, 3]}
-    before = json.dumps(original, sort_keys=True)
-    expand_presets(original)
-    after = json.dumps(original, sort_keys=True)
-    assert before == after, "expand_presets must not mutate its input"
-
-
-def test_sentinel_alongside_other_keys_is_rejected_with_clear_error():
-    # A sentinel must be the only key in its dict. Silently ignoring a
-    # $doc_preset key next to a sibling would be a footgun, so we raise.
-    node = {
-        "$doc_preset": "s3_connectivity",
-        "category": "overridden",  # siblings are not allowed
-    }
-    with pytest.raises(ValueError, match="must appear alone in its dict"):
-        expand_presets(node)
-
-
-def test_unknown_dollar_key_is_not_treated_as_sentinel():
-    # $-prefixed keys that don't match a registered preset function are
-    # treated as ordinary data (e.g. MongoDB operators in metadata).
-    node = {"$eq": "s3_connectivity"}
-    assert expand_presets(node) == {"$eq": "s3_connectivity"}
-
-
-def test_unknown_preset_name_raises_from_underlying_function():
-    with pytest.raises(KeyError, match="Unknown preset"):
-        expand_presets({"$doc_preset": "no_such_preset"})
-
-
-def test_scalars_pass_through_unchanged():
-    for scalar in [None, True, 42, 3.14, "hello", "$doc_preset"]:
-        assert expand_presets(scalar) == scalar
-
-
-def test_custom_preset_fns_mapping_restricts_recognised_names():
-    # Only ``my_fn`` is recognised; $doc_preset is ignored.
-    def my_fn(arg: Any) -> dict[str, Any]:
-        return {"expanded": arg}
-
-    node = {
-        "outer": {"$my_fn": "hello"},
-        "ignored": {"$doc_preset": "s3_connectivity"},
-    }
-    result = expand_presets(node, preset_fns={"my_fn": my_fn})
-    assert result["outer"] == {"expanded": "hello"}
-    # $doc_preset is not in the custom mapping -> left unchanged.
-    assert result["ignored"] == {"$doc_preset": "s3_connectivity"}
-
-
-# ---------------------------------------------------------------------------
-# load_data_file wrapper
-# ---------------------------------------------------------------------------
-
-
-def test_load_data_file_expands_presets_in_json(tmp_path: Path):
-    listing = tmp_path / "listing.json"
-    listing.write_text(
-        json.dumps(
-            {
-                "schema": "listing_v1",
-                "name": "demo",
-                "documents": {
-                    "Connectivity test": {"$doc_preset": "s3_connectivity_v1"},
-                },
-            }
-        )
-    )
-
-    data, fmt = load_data_file(listing)
-    assert fmt == "json"
-    record = data["documents"]["Connectivity test"]
-    assert record["category"] == "connectivity_test"
-    assert record["mime_type"] == "python"
-    assert Path(record["file_path"]).is_file()
-    # Sentinel is fully replaced — no $-keys remain.
-    assert "$doc_preset" not in record
-
-
-def test_load_data_file_expands_presets_in_toml(tmp_path: Path):
-    listing = tmp_path / "listing.toml"
-    listing.write_text(
-        'schema = "listing_v1"\n'
-        'name = "demo"\n'
-        '[documents."Connectivity test"]\n'
-        '"$doc_preset" = "s3_connectivity_v1"\n'
-    )
-
-    data, fmt = load_data_file(listing)
-    assert fmt == "toml"
-    record = data["documents"]["Connectivity test"]
-    assert record["category"] == "connectivity_test"
-    assert "$doc_preset" not in record
-
-
-def test_load_data_file_expands_presets_after_override_merge(tmp_path: Path):
-    # Sentinel lives in the base file; override customises a top-level
-    # field. Expansion happens *after* the merge, so the final
-    # documents[...] is the preset's record with any flat-form
-    # overrides applied.
-    base = tmp_path / "listing.json"
-    base.write_text(
-        json.dumps(
-            {
-                "schema": "listing_v1",
-                "documents": {
-                    "Connectivity test": {
-                        "$doc_preset": {
-                            "name": "s3_connectivity_v1",
-                            "is_active": True,
-                        }
-                    }
-                },
-            }
-        )
-    )
-    override = tmp_path / "listing.override.json"
-    override.write_text(json.dumps({"name": "from-override"}))
-
-    data, _ = load_data_file(base)
-    assert data["name"] == "from-override"
-    record = data["documents"]["Connectivity test"]
-    assert record["is_active"] is True
-    assert record["category"] == "connectivity_test"
-
-
-def test_load_data_file_with_preset_fns_none_skips_expansion(tmp_path: Path):
-    # Escape hatch: callers that explicitly don't want expansion can
-    # disable it by passing preset_fns=None.
-    listing = tmp_path / "listing.json"
-    listing.write_text(
-        json.dumps(
-            {
-                "schema": "listing_v1",
-                "documents": {"Thing": {"$doc_preset": "s3_connectivity_v1"}},
-            }
-        )
-    )
-
-    data, _ = load_data_file(listing, preset_fns=None)
-    # Sentinel survives — no expansion applied.
-    assert data["documents"]["Thing"] == {"$doc_preset": "s3_connectivity_v1"}
-
-
-def test_seller_preset_fns_registers_doc_and_file():
-    assert set(SELLER_PRESET_FNS) == {"doc_preset", "file_preset"}
-    # The registered callables are thin wrappers that translate the
-    # seller-facing flat form (``{"name": ..., <override>: ...}``)
-    # before delegating to unitysvc-data's doc_preset / file_preset.
-    # Passing the wrapper a bare-name string should produce the same
-    # record the underlying function would.
-    bare = SELLER_PRESET_FNS["doc_preset"]("s3_connectivity")
-    direct = doc_preset("s3_connectivity")
-    assert bare == direct
-
-
-# ---------------------------------------------------------------------------
-# End-to-end: preset sentinel in a listing flows through the upload pipeline
-# ---------------------------------------------------------------------------
+from unitysvc_sellers.upload import _resolve_file_references
+from unitysvc_sellers.utils import load_data_file
 
 
 def test_preset_expanded_doc_survives_resolve_file_references(tmp_path: Path):
-    """Load a listing with a $doc_preset, then resolve file refs.
+    """Load a listing with a ``$doc_preset`` sentinel, then resolve file refs.
 
-    Verifies the full pipeline: expand_presets converts the sentinel to
-    a record with an absolute ``file_path`` (pointing inside the
-    installed ``unitysvc-data`` package), then ``_resolve_file_references``
-    reads+renders the file, inlines its content as ``file_content``,
-    and stores just the basename as the displayable ``file_path``.
+    Verifies the full pipeline: core's ``load_data_file`` expands the
+    sentinel to a record with an absolute ``file_path`` (pointing
+    inside the installed ``unitysvc-data`` package), then
+    ``_resolve_file_references`` reads+renders the file, inlines its
+    content as ``file_content``, and stores just the basename as the
+    displayable ``file_path``.
     """
-    from unitysvc_sellers.upload import _resolve_file_references
-
     listing = tmp_path / "listing.json"
     listing.write_text(
         json.dumps(
@@ -349,12 +71,10 @@ def test_preset_expanded_doc_survives_resolve_file_references(tmp_path: Path):
 def test_relative_file_path_keeps_backwards_compatible_shape(tmp_path: Path):
     """Existing seller catalogs write relative paths like ``../../docs/foo.sh.j2``.
 
-    The stored ``file_path`` still keeps the relative shape (minus
-    ``.j2``) so existing catalogs aren't disrupted by the absolute-path
-    support added for preset expansion.
+    The stored ``file_path`` keeps the relative shape (minus ``.j2``)
+    so catalogs that haven't migrated to presets aren't disrupted by
+    the absolute-path branch added alongside preset expansion.
     """
-    from unitysvc_sellers.upload import _resolve_file_references
-
     provider_dir = tmp_path / "acme"
     docs_dir = provider_dir / "docs"
     docs_dir.mkdir(parents=True)

--- a/tests/test_preset_expansion.py
+++ b/tests/test_preset_expansion.py
@@ -56,7 +56,7 @@ def test_doc_preset_flat_form_with_overrides():
     record = expand_presets(node)
     assert record["description"] == "Uploads to customer bucket"
     assert record["is_public"] is False
-    assert record["category"] == "usage_example"
+    assert record["category"] == "code_example"
 
 
 def test_doc_preset_flat_form_name_only_equals_bare_string():
@@ -78,7 +78,7 @@ def test_doc_preset_nested_preset_with_form_still_works():
     }
     record = expand_presets(node)
     assert record["description"] == "via nested form"
-    assert record["category"] == "usage_example"
+    assert record["category"] == "code_example"
 
 
 def test_doc_preset_flat_form_rejects_forbidden_override():

--- a/tests/test_preset_expansion.py
+++ b/tests/test_preset_expansion.py
@@ -42,20 +42,65 @@ def test_doc_preset_alias_matches_versioned():
     assert alias == versioned
 
 
-def test_doc_preset_sentinel_with_with_block_forwards_overrides():
-    # The sentinel's VALUE is forwarded to doc_preset verbatim. doc_preset
-    # already understands the nested {"$preset": ..., "$with": {...}} form,
-    # so overrides travel through cleanly.
+def test_doc_preset_flat_form_with_overrides():
+    # Seller-facing shape: {"name": "<preset>", <override>: ...}. "name"
+    # is the identifier; all other keys are per-field overrides passed
+    # as kwargs to doc_preset.
     node = {
         "$doc_preset": {
-            "$preset": "s3_code_example",
-            "$with": {"description": "Uploads to customer bucket", "is_public": False},
+            "name": "s3_code_example",
+            "description": "Uploads to customer bucket",
+            "is_public": False,
         }
     }
     record = expand_presets(node)
     assert record["description"] == "Uploads to customer bucket"
     assert record["is_public"] is False
     assert record["category"] == "usage_example"
+
+
+def test_doc_preset_flat_form_name_only_equals_bare_string():
+    flat = expand_presets({"$doc_preset": {"name": "s3_connectivity"}})
+    bare = expand_presets({"$doc_preset": "s3_connectivity"})
+    assert flat == bare
+
+
+def test_doc_preset_nested_preset_with_form_still_works():
+    # unitysvc-data's internal {"$preset": ..., "$with": {...}} shape is
+    # not the seller-facing API but the walker forwards it through
+    # doc_preset, which accepts it. Verified so we don't silently break
+    # it if someone on the team already adopted it.
+    node = {
+        "$doc_preset": {
+            "$preset": "s3_code_example",
+            "$with": {"description": "via nested form"},
+        }
+    }
+    record = expand_presets(node)
+    assert record["description"] == "via nested form"
+    assert record["category"] == "usage_example"
+
+
+def test_doc_preset_flat_form_rejects_forbidden_override():
+    # Overrides still go through doc_preset's whitelist. "category" is
+    # tied to the file content and not overridable.
+    node = {"$doc_preset": {"name": "s3_connectivity", "category": "other"}}
+    with pytest.raises(ValueError, match="Cannot override"):
+        expand_presets(node)
+
+
+def test_file_preset_flat_form_rejects_overrides():
+    # File content is immutable — overrides make no sense for $file_preset.
+    node = {"$file_preset": {"name": "s3_connectivity_v1", "description": "x"}}
+    with pytest.raises(ValueError, match="does not accept per-field overrides"):
+        expand_presets(node)
+
+
+def test_file_preset_flat_form_name_only_works():
+    # A dict with just {"name": ...} is equivalent to the bare-string form.
+    flat = expand_presets({"$file_preset": {"name": "s3_connectivity_v1"}})
+    bare = expand_presets({"$file_preset": "s3_connectivity_v1"})
+    assert flat == bare
 
 
 def test_file_preset_sentinel_returns_raw_content():
@@ -186,9 +231,10 @@ def test_load_data_file_expands_presets_in_toml(tmp_path: Path):
 
 
 def test_load_data_file_expands_presets_after_override_merge(tmp_path: Path):
-    # Sentinel lives in the base file; override customises is_active.
-    # Expansion happens *after* the merge, so the final doc is the
-    # preset's record with the override applied.
+    # Sentinel lives in the base file; override customises a top-level
+    # field. Expansion happens *after* the merge, so the final
+    # documents[...] is the preset's record with any flat-form
+    # overrides applied.
     base = tmp_path / "listing.json"
     base.write_text(
         json.dumps(
@@ -197,8 +243,8 @@ def test_load_data_file_expands_presets_after_override_merge(tmp_path: Path):
                 "documents": {
                     "Connectivity test": {
                         "$doc_preset": {
-                            "$preset": "s3_connectivity_v1",
-                            "$with": {"is_active": True},
+                            "name": "s3_connectivity_v1",
+                            "is_active": True,
                         }
                     }
                 },
@@ -235,8 +281,14 @@ def test_load_data_file_with_preset_fns_none_skips_expansion(tmp_path: Path):
 
 def test_seller_preset_fns_registers_doc_and_file():
     assert set(SELLER_PRESET_FNS) == {"doc_preset", "file_preset"}
-    # Factory identity: the registered callable is the imported function.
-    assert SELLER_PRESET_FNS["doc_preset"] is doc_preset
+    # The registered callables are thin wrappers that translate the
+    # seller-facing flat form (``{"name": ..., <override>: ...}``)
+    # before delegating to unitysvc-data's doc_preset / file_preset.
+    # Passing the wrapper a bare-name string should produce the same
+    # record the underlying function would.
+    bare = SELLER_PRESET_FNS["doc_preset"]("s3_connectivity")
+    direct = doc_preset("s3_connectivity")
+    assert bare == direct
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Seller data files can reference bundled `unitysvc-data` presets via `{"$doc_preset": ...}` and `{"$file_preset": ...}` JSON/TOML sentinels; `expand_presets()` walks loaded data and replaces each sentinel with the function's return value.
- `load_data_file` now runs expansion after the override merge, so `.json`, `.toml`, and `*.override.*` inputs all produce the same expanded shape. `DataValidator.load_data_file` takes the same path so `usvc_seller data validate` validates the post-expansion record.
- `_resolve_file_references` handles absolute `file_path` values (which preset expansion injects) by storing the basename on the upload payload — no leaking of the seller's local filesystem to the backend. Relative paths keep their historical shape.

## What the sentinel looks like

```json
{
  "documents": {
    "Connectivity test": { "$doc_preset": "s3_connectivity" },
    "Usage (Python)":    { "$doc_preset": { "name": "s3_code_example",
                                             "description": "Lists objects in our customer bucket",
                                             "is_public": false } },
    "Inline snippet":    { "$file_preset": "s3_connectivity_v1" }
  }
}
```

Two shapes for the sentinel's value:

- **Bare string** — the preset name, no overrides. Shortest form; use when the defaults work as-is.
- **Flat object** — `"name"` is the preset identifier, every other key is a per-field override (`description`, `is_active`, `is_public`, `meta`) forwarded as a kwarg to `doc_preset`. This is the seller-facing vocabulary — reads like the data structure it is, and keeps `unitysvc-data`'s internal `{"$preset": ..., "$with": {...}}` Python-API shape out of seller data files.

`$file_preset` accepts the same two shapes but rejects any override keys (the bundled file content is immutable; use `$doc_preset` if you need a document record with per-field overrides).

## Pipeline

At load time the SDK:

1. Parses the file and merges the `.override.*` sibling if any.
2. Walks the tree and replaces each `{"$<fn>": <arg>}` dict (where `<fn>` is `doc_preset` or `file_preset`) with the function's return value from [`unitysvc-data`](https://github.com/unitysvc/unitysvc-data). The flat-form unwrapper translates `{"name": "x", "description": "y"}` into `doc_preset("x", description="y")`.
3. `doc_preset` returns a fully-populated document record with an absolute `file_path` pointing at the bundled example in the installed `unitysvc-data` package.
4. `_resolve_file_references` reads / renders the file, inlines `file_content`, and stores the basename as the display `file_path`.

## Depends on

`unitysvc-data>=0.1.1` — added to `dependencies`.

## Files

- `src/unitysvc_sellers/utils.py` — `expand_presets`, `_unwrap_flat_form`, `_doc_preset_sentinel` / `_file_preset_sentinel` wrappers registered in `SELLER_PRESET_FNS`, wrapped `load_data_file`. The utility is a candidate for promotion to `unitysvc-core.utils` if a non-seller consumer ever needs it.
- `src/unitysvc_sellers/upload.py` — `_build_service_payload` uses the wrapped loader; `_resolve_file_references` branches on absolute vs. relative `file_path`.
- `src/unitysvc_sellers/validator.py` — `DataValidator.load_data_file` override.
- `tests/test_preset_expansion.py` — 23 tests.

## Guardrails

- Sentinel must be the only key in its dict: `{"$doc_preset": "x", "category": "y"}` raises a clear error directing the user to nest overrides inside the value.
- `$`-prefixed keys that don't match a registered function (e.g. `$eq`) pass through as ordinary data — no collision with Mongo-style operators.
- Forbidden overrides (e.g. `category`) still fail through `doc_preset`'s existing whitelist — the flat form doesn't weaken the guard.
- `$file_preset` with any override keys raises with a message pointing to `$doc_preset` as the right primitive for per-field customisation.
- `unitysvc-data`'s original `{"$preset": ..., "$with": {...}}` sentinel shape still works (underlying function accepts it); tested explicitly so we don't silently break anyone who already adopted it.

## Test plan

- [x] `pytest tests/test_preset_expansion.py` — 23 tests pass (bare name, flat form with overrides, flat-form name-only equivalence with bare string, nested `$preset`/`$with` still works, forbidden-override rejection, `$file_preset` refusing overrides, nested walk, fresh-copy semantics, mixed-key guard, unknown `$` keys as data, JSON/TOML loader integration, override-merge ordering, `preset_fns=None` escape hatch, end-to-end `_resolve_file_references` round-trip, relative-path backwards-compat).
- [x] `pytest tests/` — 160 pre-existing + new pass. One pre-existing failure (`test_validate_all_files`) reproduces on clean `main` unchanged — unrelated to this PR.
- [x] `ruff check src/ tests/` — clean.
- [x] `mypy src/unitysvc_sellers/ --exclude _generated` — clean (38 source files).
- [ ] Manual: author a listing with `$doc_preset` against a real seller catalog, run `usvc_seller data validate` and `usvc_seller data upload` end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)