### PR TITLE
services list: show `visibility` alongside `status` by default

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -546,7 +546,7 @@ $ usvc_seller services list [OPTIONS]
 * `--status TEXT`: Filter by service status (draft, pending, review, active, rejected, suspended, deprecated).
 * `-n, --name TEXT`: Search by name, display_name, or provider name (case-insensitive partial match).
 * `--provider TEXT`: Filter by provider name (case-insensitive partial match, applied client-side).
-* `--fields TEXT`: Comma-separated list of columns to display.  [default: id,name,provider_name,service_type,status]
+* `--fields TEXT`: Comma-separated list of columns to display.  [default: id,name,provider_name,service_type,status,visibility]
 * `-f, --format TEXT`: Output format: table | json.  [default: table]
 * `--api-key TEXT`: Seller API key (svcpass_...). Defaults to $UNITYSVC_SELLER_API_KEY.  [env var: UNITYSVC_SELLER_API_KEY]
 * `--base-url TEXT`: Backend base URL.  [env var: UNITYSVC_SELLER_API_URL; default: https://seller.unitysvc.com/v1]

--- a/src/unitysvc_sellers/commands/services.py
+++ b/src/unitysvc_sellers/commands/services.py
@@ -88,7 +88,7 @@ def list_services(
         help="Filter by provider name (case-insensitive partial match, applied client-side).",
     ),
     fields: str = typer.Option(
-        "id,name,provider_name,service_type,status",
+        "id,name,provider_name,service_type,status,visibility",
         "--fields",
         help="Comma-separated list of columns to display.",
     ),


### PR DESCRIPTION
## Summary

\`status\` and \`visibility\` are orthogonal axes — a service can be \`active + unlisted\` (live but hidden from the public catalog), \`active + public\`, \`draft + private\`, etc. The list view was showing only \`status\`, which leaves the catalog state ambiguous and forces \`usvc_seller services show <id>\` for every spot-check.

Adds \`visibility\` to the default \`--fields\` so one \`usvc_seller services list\` call tells the full story.

Before:

\`\`\`
id,name,provider_name,service_type,status
\`\`\`

After:

\`\`\`
id,name,provider_name,service_type,status,visibility
\`\`\`

Users who want the old columns can pass the old string as \`--fields\`.

## SDK note

\`ServicePublic\` in the generated SDK already types \`visibility: ServiceVisibilityEnum\` (\`private\` / \`public\` / \`unlisted\`), so the value is first-class — no \`additional_properties\` dance needed.

## Test plan

- [x] \`ruff check src/ tests/\` — clean
- [x] \`mypy src/unitysvc_sellers/ --exclude _generated\` — clean
- [x] \`pytest tests/\` — 139 pass (no regressions)
- [x] \`./scripts/generate_cli_reference.sh\` — regenerated; diff is a one-line \`[default: ...]\` update

## Companion PR

Mirror change in the admin CLI: [unitysvc-admin#7](https://github.com/unitysvc/unitysvc-admin/pull/7) — adds \`visibility\` to \`usvc_admin services list\`'s default fields so the two CLIs stay visually aligned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)