### PR TITLE
Drop "Found" column from upload summary table

### DIFF
--- a/src/unitysvc_sellers/_cli_upload.py
+++ b/src/unitysvc_sellers/_cli_upload.py
@@ -118,7 +118,6 @@ def upload(
     console.print()
     table = Table(title="Upload Summary", show_header=True, header_style="bold cyan", border_style="cyan")
     table.add_column("Type", style="cyan", no_wrap=True)
-    table.add_column("Found", justify="right")
     table.add_column("Success", justify="right", style="green")
     table.add_column("Failed", justify="right", style="red")
 
@@ -129,7 +128,6 @@ def upload(
     ):
         table.add_row(
             kind,
-            str(counts.total),
             str(counts.success),
             str(counts.failed) if counts.failed else "",
         )


### PR DESCRIPTION
## Summary
- Remove the `Found` column from the `usvc_seller data upload` summary table — the backend no longer returns unmodified/compared items, so `Found` was redundant with `Success + Failed` and misleading.
- `UploadCounts.total` (the count of local files discovered) is kept as-is; it's still asserted in `tests/test_tasks.py` and is useful programmatically, it just no longer surfaces in the CLI summary.

## Test plan
- [ ] Run `usvc_seller data upload` against a sample catalog and confirm the summary shows only `Type / Success / Failed`.
- [ ] `uv run --extra test pytest tests/` passes (no test relied on the CLI column count).

🤖 Generated with [Claude Code](https://claude.com/claude-code)