### PR TITLE
Bump version to 0.1.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "unitysvc-sellers"
-version = "0.1.4"
+version = "0.1.5"
 description = "Seller-facing tools for UnitySVC: HTTP SDK + usvc_seller CLI"
 readme = "README.md"
 authors = [{ name = "Bo Peng", email = "bo.peng@unitysvc.com" }]


### PR DESCRIPTION
## Summary
- Bump package version from 0.1.4 to 0.1.5 in preparation for PyPI release

## Test plan
- [ ] CI passes
- [ ] After merge, tag `v0.1.5` and publish GitHub release to trigger PyPI upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)