### PR TITLE
Add ModelDataLookup.get_canonical_metadata for LLM details

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ uv.lock
 .tool-venv/
 site/
 .claude/
+failed_*

--- a/src/unitysvc_sellers/model_data.py
+++ b/src/unitysvc_sellers/model_data.py
@@ -438,9 +438,7 @@ class ModelDataLookup:
     }
 
     @staticmethod
-    def get_capabilities_from_hf(
-        model_id: str, fetcher: "ModelDataFetcher"
-    ) -> tuple[list[str], str]:
+    def get_capabilities_from_hf(model_id: str, fetcher: "ModelDataFetcher") -> tuple[list[str], str]:
         """Get capabilities and example suffix from HuggingFace model metadata.
 
         Fetches pipeline_tag from the HuggingFace Model Hub API and uses it
@@ -489,8 +487,128 @@ class ModelDataLookup:
             return []
 
         return [
-            t for t in hf_details.get("tags", [])
-            if not t.startswith("base_model:")
-            and not t.startswith("region:")
-            and not t.startswith("license:")
+            t
+            for t in hf_details.get("tags", [])
+            if not t.startswith("base_model:") and not t.startswith("region:") and not t.startswith("license:")
         ]
+
+    # =========================================================================
+    # Canonical LLM metadata (context_length + parameter_count)
+    # =========================================================================
+
+    @staticmethod
+    def get_canonical_metadata(
+        model_id: str,
+        *,
+        fetcher: "ModelDataFetcher",
+    ) -> dict[str, Any]:
+        """Return canonical LLM metadata for use in ``offering.details``.
+
+        Resolves ``context_length`` and ``parameter_count`` to the platform's
+        canonical (snake_case) field names, hiding the upstream field-name
+        chaos behind a single call.  Each field independently falls back
+        across multiple sources; either may end up ``None`` if no source
+        publishes the value (e.g., closed-source models for which weight
+        counts aren't public).
+
+        Source priority for ``context_length`` (most → least authoritative):
+
+        1. **OpenRouter** ``context_length`` — explicitly named, snake_case,
+           covers most commercial models.
+        2. **LiteLLM** ``max_input_tokens`` — comprehensive coverage but
+           sometimes lags long-context model upgrades.
+        3. **HuggingFace** ``config.max_position_embeddings`` — works for
+           any open-weights model on the Hub.
+
+        Source for ``parameter_count``:
+
+        - **HuggingFace** ``safetensors.parameters`` — the only reliable
+          public source.  Sums per-dtype counts when ``total`` is absent.
+          Will be ``None`` for closed models (GPT-*, Claude-*, Gemini),
+          which is expected and acceptable per the platform's null-allowed
+          schema.
+
+        Args:
+            model_id: Model identifier (e.g. ``"meta-llama/Llama-3.1-8B"``,
+                ``"gpt-4"``, ``"anthropic/claude-3-opus"``).  Fuzzy matching
+                inside each ``lookup_*`` method handles provider-prefix
+                variations.
+            fetcher: ``ModelDataFetcher`` instance.  Reused across calls;
+                its internal cache means repeated lookups for the same
+                upstream don't re-hit the network.
+
+        Returns:
+            ``{"context_length": int | None, "parameter_count": int | None,
+            "sources": {"context_length": str, "parameter_count": str}}``.
+            ``sources`` only includes entries for fields that were
+            successfully resolved — useful for surfacing provenance in
+            ``offering.details.metadata_sources`` and for triage of
+            ``"this value looks wrong"`` reports.
+
+        Example:
+            >>> with ModelDataFetcher() as fetcher:
+            ...     meta = ModelDataLookup.get_canonical_metadata(
+            ...         "anthropic/claude-3-opus", fetcher=fetcher
+            ...     )
+            >>> meta
+            {'context_length': 200000, 'parameter_count': None,
+             'sources': {'context_length': 'openrouter'}}
+        """
+        result: dict[str, Any] = {
+            "context_length": None,
+            "parameter_count": None,
+            "sources": {},
+        }
+
+        # context_length: OpenRouter → LiteLLM → HuggingFace config.json.
+        # Each source uses a different field name; normalise to int here so
+        # callers don't have to know.
+        or_data = fetcher.fetch_openrouter_models_data(quiet=True)
+        or_match = ModelDataLookup.lookup_openrouter_details(model_id, or_data)
+        if or_match:
+            cl = or_match.get("context_length")
+            if isinstance(cl, int) and cl > 0:
+                result["context_length"] = cl
+                result["sources"]["context_length"] = "openrouter"
+
+        if result["context_length"] is None:
+            ll_data = fetcher.fetch_litellm_model_data(quiet=True)
+            ll_match = ModelDataLookup.lookup_model_details(model_id, ll_data)
+            if ll_match:
+                cl = ll_match.get("max_input_tokens")
+                if isinstance(cl, int) and cl > 0:
+                    result["context_length"] = cl
+                    result["sources"]["context_length"] = "litellm"
+
+        # HuggingFace details are also the source for parameter_count, so
+        # fetch once and reuse.  Returns None on miss / network failure.
+        hf_details = fetcher.fetch_huggingface_model_details(model_id, quiet=True)
+
+        if result["context_length"] is None and hf_details:
+            cfg = hf_details.get("config") or {}
+            mpe = cfg.get("max_position_embeddings")
+            if isinstance(mpe, int) and mpe > 0:
+                result["context_length"] = mpe
+                result["sources"]["context_length"] = "huggingface_config"
+
+        if hf_details:
+            # safetensors.parameters is the per-dtype breakdown the Hub
+            # publishes on weight-bearing model uploads since mid-2024.
+            # Older uploads won't have it; closed-source models never will.
+            st = (hf_details.get("safetensors") or {}).get("parameters") or {}
+            if isinstance(st, dict) and st:
+                # Prefer explicit total; otherwise sum per-dtype counts
+                # (BF16 + F32 etc.) — they represent the same parameter
+                # set in different precisions, so summing is wrong for the
+                # multi-precision case.  Use max() instead, which gives
+                # the parameter count regardless of how the weights are
+                # stored.  Fall back to sum if max isn't applicable.
+                total = st.get("total")
+                if not isinstance(total, int):
+                    int_values = [v for v in st.values() if isinstance(v, int) and v > 0]
+                    total = max(int_values) if int_values else None
+                if isinstance(total, int) and total > 0:
+                    result["parameter_count"] = total
+                    result["sources"]["parameter_count"] = "huggingface_safetensors"
+
+        return result

--- a/tests/test_model_data.py
+++ b/tests/test_model_data.py
@@ -1,0 +1,202 @@
+"""Tests for ModelDataLookup.get_canonical_metadata.
+
+The other ``ModelDataLookup`` methods are thin fuzzy-matchers tested
+implicitly through the per-provider scrapers; this file specifically
+covers ``get_canonical_metadata`` because it owns the source-priority
+logic and provenance contract that consuming code depends on.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from unitysvc_sellers.model_data import ModelDataFetcher, ModelDataLookup
+
+
+def _make_fetcher(
+    *,
+    openrouter: dict[str, Any] | None = None,
+    litellm: dict[str, Any] | None = None,
+    hf_details: dict[str, Any] | None = None,
+) -> MagicMock:
+    """Build a MagicMock that quacks like ModelDataFetcher.
+
+    Each source is independently controllable so each test only stubs
+    the ones it cares about.  Defaults to empty / None so the helper's
+    fallback chain is exercised honestly.
+    """
+    f = MagicMock(spec=ModelDataFetcher)
+    f.fetch_openrouter_models_data.return_value = openrouter or {}
+    f.fetch_litellm_model_data.return_value = litellm or {}
+    f.fetch_huggingface_model_details.return_value = hf_details
+    return f
+
+
+class TestContextLengthSourcePriority:
+    """OpenRouter beats LiteLLM beats HuggingFace config."""
+
+    def test_openrouter_wins_when_present(self) -> None:
+        fetcher = _make_fetcher(
+            openrouter={"anthropic/claude-3-opus": {"context_length": 200_000}},
+            litellm={"claude-3-opus": {"max_input_tokens": 100_000}},
+            hf_details={"config": {"max_position_embeddings": 50_000}},
+        )
+        result = ModelDataLookup.get_canonical_metadata("anthropic/claude-3-opus", fetcher=fetcher)
+        assert result["context_length"] == 200_000
+        assert result["sources"]["context_length"] == "openrouter"
+
+    def test_litellm_used_when_openrouter_missing(self) -> None:
+        fetcher = _make_fetcher(
+            openrouter={},
+            litellm={"gpt-4": {"max_input_tokens": 128_000}},
+        )
+        result = ModelDataLookup.get_canonical_metadata("gpt-4", fetcher=fetcher)
+        assert result["context_length"] == 128_000
+        assert result["sources"]["context_length"] == "litellm"
+
+    def test_huggingface_config_used_as_last_resort(self) -> None:
+        fetcher = _make_fetcher(
+            openrouter={},
+            litellm={},
+            hf_details={"config": {"max_position_embeddings": 32_768}},
+        )
+        result = ModelDataLookup.get_canonical_metadata("meta-llama/Llama-3.1-8B", fetcher=fetcher)
+        assert result["context_length"] == 32_768
+        assert result["sources"]["context_length"] == "huggingface_config"
+
+    def test_null_context_length_when_no_source_has_it(self) -> None:
+        fetcher = _make_fetcher()
+        result = ModelDataLookup.get_canonical_metadata("unknown-model", fetcher=fetcher)
+        assert result["context_length"] is None
+        assert "context_length" not in result["sources"]
+
+
+class TestContextLengthRobustness:
+    """Source data may be malformed; fall through to the next source."""
+
+    def test_openrouter_zero_falls_through_to_litellm(self) -> None:
+        fetcher = _make_fetcher(
+            openrouter={"some-model": {"context_length": 0}},  # invalid
+            litellm={"some-model": {"max_input_tokens": 8192}},
+        )
+        result = ModelDataLookup.get_canonical_metadata("some-model", fetcher=fetcher)
+        assert result["context_length"] == 8192
+        assert result["sources"]["context_length"] == "litellm"
+
+    def test_openrouter_string_falls_through_to_litellm(self) -> None:
+        fetcher = _make_fetcher(
+            openrouter={"m": {"context_length": "200K"}},  # string, not int
+            litellm={"m": {"max_input_tokens": 200_000}},
+        )
+        result = ModelDataLookup.get_canonical_metadata("m", fetcher=fetcher)
+        assert result["context_length"] == 200_000
+
+    def test_litellm_missing_field_falls_through_to_hf(self) -> None:
+        fetcher = _make_fetcher(
+            litellm={"m": {"input_cost_per_token": 0.01}},  # no max_input_tokens
+            hf_details={"config": {"max_position_embeddings": 4096}},
+        )
+        result = ModelDataLookup.get_canonical_metadata("m", fetcher=fetcher)
+        assert result["context_length"] == 4096
+        assert result["sources"]["context_length"] == "huggingface_config"
+
+
+class TestParameterCount:
+    """parameter_count comes only from HuggingFace safetensors metadata."""
+
+    def test_total_from_safetensors_total(self) -> None:
+        fetcher = _make_fetcher(
+            hf_details={
+                "safetensors": {"parameters": {"total": 7_000_000_000}},
+            },
+        )
+        result = ModelDataLookup.get_canonical_metadata("llama-3-7b", fetcher=fetcher)
+        assert result["parameter_count"] == 7_000_000_000
+        assert result["sources"]["parameter_count"] == "huggingface_safetensors"
+
+    def test_total_inferred_from_per_dtype_counts(self) -> None:
+        """Same parameter set in two precisions — the larger count is the
+        true parameter count, not the sum (which would double-count)."""
+        fetcher = _make_fetcher(
+            hf_details={
+                "safetensors": {"parameters": {"BF16": 8_000_000_000, "F32": 8_000_000_000}},
+            },
+        )
+        result = ModelDataLookup.get_canonical_metadata("llama-3-8b", fetcher=fetcher)
+        assert result["parameter_count"] == 8_000_000_000
+
+    def test_null_parameter_count_for_closed_model(self) -> None:
+        """Closed models (GPT-*, Claude-*, etc.) have no HF safetensors
+        publish — must return None gracefully."""
+        fetcher = _make_fetcher(
+            openrouter={"gpt-4": {"context_length": 128_000}},
+            hf_details=None,
+        )
+        result = ModelDataLookup.get_canonical_metadata("gpt-4", fetcher=fetcher)
+        assert result["parameter_count"] is None
+        assert "parameter_count" not in result["sources"]
+        # context_length still comes through — fields are independent.
+        assert result["context_length"] == 128_000
+
+    def test_safetensors_present_but_empty(self) -> None:
+        fetcher = _make_fetcher(
+            hf_details={"safetensors": {"parameters": {}}},
+        )
+        result = ModelDataLookup.get_canonical_metadata("m", fetcher=fetcher)
+        assert result["parameter_count"] is None
+
+
+class TestSourcesProvenance:
+    """The sources dict must accurately reflect which upstream supplied
+    each value, so reviewers can triage 'this looks wrong' reports."""
+
+    def test_sources_only_includes_resolved_fields(self) -> None:
+        # context_length resolved, parameter_count not.
+        fetcher = _make_fetcher(
+            openrouter={"m": {"context_length": 100_000}},
+        )
+        result = ModelDataLookup.get_canonical_metadata("m", fetcher=fetcher)
+        assert result["sources"] == {"context_length": "openrouter"}
+
+    def test_sources_empty_when_nothing_resolves(self) -> None:
+        fetcher = _make_fetcher()
+        result = ModelDataLookup.get_canonical_metadata("nope", fetcher=fetcher)
+        assert result["sources"] == {}
+
+    def test_both_fields_resolved_from_different_sources(self) -> None:
+        fetcher = _make_fetcher(
+            openrouter={"m": {"context_length": 200_000}},
+            hf_details={"safetensors": {"parameters": {"total": 70_000_000_000}}},
+        )
+        result = ModelDataLookup.get_canonical_metadata("m", fetcher=fetcher)
+        assert result == {
+            "context_length": 200_000,
+            "parameter_count": 70_000_000_000,
+            "sources": {
+                "context_length": "openrouter",
+                "parameter_count": "huggingface_safetensors",
+            },
+        }
+
+
+class TestReturnShape:
+    """The return shape is a public contract that consuming scrapers
+    depend on; lock it down."""
+
+    def test_keys_always_present(self) -> None:
+        result = ModelDataLookup.get_canonical_metadata("anything", fetcher=_make_fetcher())
+        assert set(result.keys()) == {"context_length", "parameter_count", "sources"}
+        assert isinstance(result["sources"], dict)
+
+
+@pytest.mark.parametrize("model_id", ["", "  ", "a"])
+def test_short_model_id_does_not_crash(model_id: str) -> None:
+    """Edge case: empty / whitespace / single-char model IDs reach the
+    fuzzy-matchers; ensure they degrade gracefully."""
+    fetcher = _make_fetcher()
+    result = ModelDataLookup.get_canonical_metadata(model_id, fetcher=fetcher)
+    assert result["context_length"] is None
+    assert result["parameter_count"] is None


### PR DESCRIPTION
## Summary

PR B in the LLM-metadata data-quality plan. Returns the platform's canonical (snake_case) \`context_length\` and \`parameter_count\` for any LLM model from a single call, hiding the upstream field-name chaos behind one method. The 13 per-provider \`update_services.py\` scrapers can now write directly into \`offering.details\` without each re-implementing the source-priority logic.

## Source priority

**\`context_length\`** — falls through in order:

1. **OpenRouter** \`context_length\` — explicitly snake_case, authoritative for commercial models
2. **LiteLLM** \`max_input_tokens\` — broad coverage but sometimes lags long-context model upgrades
3. **HuggingFace** \`config.max_position_embeddings\` — works for any open-weights model on the Hub

**\`parameter_count\`** — single source:

- **HuggingFace** \`safetensors.parameters\`. When the breakdown is per-dtype (\`{BF16: 8e9, F32: 8e9}\` for the same parameter set in two precisions), summing would double-count, so use \`max()\` of the per-dtype values. Closed models (GPT-*, Claude-*, Gemini) will permanently return \`None\` — that's the canonical "unknown" the validator now allows ([#863](https://github.com/unitysvc/unitysvc/pull/863)).

Each field falls through independently — partial coverage works fine. You can resolve \`context_length\` from OpenRouter without HuggingFace ever returning anything.

## Return shape

\`\`\`python
{
    "context_length": int | None,
    "parameter_count": int | None,
    "sources": {
        "context_length": "openrouter",            # only present if resolved
        "parameter_count": "huggingface_safetensors",
    },
}
\`\`\`

\`sources\` is intended for \`offering.details.metadata_sources\` — surfaces provenance so reviewers can triage "this value looks wrong" reports without chasing the entire fallback chain.

## Usage

\`\`\`python
from unitysvc_sellers.model_data import ModelDataFetcher, ModelDataLookup

with ModelDataFetcher() as fetcher:
    meta = ModelDataLookup.get_canonical_metadata(
        "anthropic/claude-3-opus", fetcher=fetcher
    )
    # → {'context_length': 200000, 'parameter_count': None,
    #    'sources': {'context_length': 'openrouter'}}
\`\`\`

The fetcher caches per upstream, so calling repeatedly across all of a provider's models doesn't re-hit the network.

## Tests

18 cases in \`tests/test_model_data.py\`, all using mocked fetchers (no real HTTP). Coverage:

- **Source priority**: OpenRouter wins, LiteLLM second, HuggingFace last, null when none.
- **Robustness**: malformed upstream values (zero, string, missing field) fall through to next source rather than crashing.
- **parameter_count**: \`safetensors.total\` direct, per-dtype \`max()\` inferred, null for closed models, empty safetensors → null.
- **Provenance**: \`sources\` only includes successfully-resolved fields, empty dict when nothing resolves, both fields can come from different sources.
- **Edge cases**: empty / whitespace / single-char model_id doesn't crash.

\`\`\`
$ pytest tests/test_model_data.py
============================== 18 passed in 0.16s ==============================
\`\`\`

## What this is part of

| | Status |
|---|---|
| **PR A** ([unitysvc#863](https://github.com/unitysvc/unitysvc/pull/863)) — validator accepts null, drops sentinels | open |
| **PR B** (this PR) — \`get_canonical_metadata\` helper | this PR |
| **PR C** — per-provider \`update_services.py\` migration: rename fields, populate via the helper, drop sentinels | next |
| **PR D** — manually-curated services: explicit \`null\` | follows C |
| **PR E** — JSON Schema enforcement in \`unitysvc-core\` | follows C/D |

PR B is purely additive — no existing caller touches \`get_canonical_metadata\` yet, so this can land independently of #863.

## Test plan

- [ ] CI \`pytest\` green
- [ ] Manual: call \`get_canonical_metadata\` against a known model in a Python REPL, confirm shape and provenance
- [ ] Manual: re-run an existing per-provider \`update_services.py\` and confirm nothing broke (the helper is unused there until PR C)