### PR TITLE
data run-tests: render upstream_access_config into the Jinja2 namespace

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 ]
 dependencies = [
   "unitysvc-core>=0.1.7",
-  "unitysvc-data>=0.1.6",
+  "unitysvc-data>=0.1.7",
   "typer",
   "rich",
   "jinja2",

--- a/src/unitysvc_sellers/example.py
+++ b/src/unitysvc_sellers/example.py
@@ -155,6 +155,28 @@ def extract_code_examples_from_listing(listing_data: dict[str, Any], listing_fil
     return code_examples
 
 
+def build_upstream_template_context(interface: dict[str, Any]) -> dict[str, Any]:
+    """Flatten an upstream_access_config interface into Jinja2 render kwargs.
+
+    unitysvc-data v0.1.7+ templates expect upstream fields at the top level of
+    the render namespace (``{{ service_base_url }}``, ``{{ routing_key.model }}``,
+    ``{{ host }}``, ``{{ region }}``, …) so that ``run-tests`` rendering matches
+    gateway-side rendering exactly.  ``base_url`` is renamed to
+    ``service_base_url`` to match the data-package naming convention, and
+    ``api_key`` is intentionally dropped — keys are never inlined into rendered
+    output; templates read ``UNITYSVC_API_KEY`` from the environment instead.
+    """
+    context: dict[str, Any] = {}
+    for field, value in interface.items():
+        if field == "api_key":
+            continue
+        if field == "base_url":
+            context["service_base_url"] = value
+        else:
+            context[field] = value
+    return context
+
+
 def extract_upstream_interfaces_from_offering(
     listing_file: Path,
 ) -> dict[str, dict[str, Any]]:
@@ -519,6 +541,8 @@ def execute_code_example(code_example: dict[str, Any], credentials: dict[str, An
         upstream_config = offering_data.get("upstream_access_config", {})
         first_upstream: dict = next(iter(upstream_config.values()), {}) if upstream_config else {}
 
+        upstream_context = build_upstream_template_context(first_upstream)
+
         try:
             file_content, actual_filename = render_template_file(
                 original_path,
@@ -528,6 +552,7 @@ def execute_code_example(code_example: dict[str, Any], credentials: dict[str, An
                 seller=related_data.get("seller", {}),
                 interface=first_upstream or code_example.get("interface", {}),
                 local_testing=True,
+                **upstream_context,
             )
         except Exception as e:
             result["error"] = f"Template rendering failed: {str(e)}"
@@ -542,22 +567,14 @@ def execute_code_example(code_example: dict[str, Any], credentials: dict[str, An
         result["listing_file"] = listing_file
         result["actual_filename"] = actual_filename
 
-        # Prepare environment variables from upstream_access_config
-        # (see docs/upstream-test-context-algorithm.py for the full algorithm)
+        # The only environment variable the rendered script reads is the
+        # platform API key — every other upstream field is inlined at template
+        # render time (see ``upstream_context`` above).  Keys are deliberately
+        # never written into rendered output, so they have to come through env.
         env_vars: dict[str, str] = {}
-        for field, value in credentials.items():
-            if field == "routing_key" and isinstance(value, dict):
-                # Flatten routing_key dict: {"username": "foo"} -> USERNAME=foo
-                for sub_key, sub_val in value.items():
-                    env_vars[sub_key.upper()] = str(sub_val)
-            elif not isinstance(value, (str, int, float, bool)):
-                continue
-            elif field == "base_url":
-                env_vars["SERVICE_BASE_URL"] = str(value)
-            elif field == "api_key":
-                env_vars["UNITYSVC_API_KEY"] = str(value)
-            else:
-                env_vars[field.upper()] = str(value)
+        api_key = credentials.get("api_key")
+        if isinstance(api_key, (str, int, float, bool)):
+            env_vars["UNITYSVC_API_KEY"] = str(api_key)
 
         # Expose the full env the subprocess actually sees so the caller
         # can persist it for reproduction (see failure-dump code).

--- a/src/unitysvc_sellers/utils.py
+++ b/src/unitysvc_sellers/utils.py
@@ -221,6 +221,7 @@ def render_template_file(
     seller: dict[str, Any] | None = None,
     interface: dict[str, Any] | None = None,
     local_testing: bool = False,
+    **extra_context: Any,
 ) -> tuple[str, str]:
     """Render a Jinja2 template file and return content and new filename.
 
@@ -240,6 +241,10 @@ def render_template_file(
             upstream (no gateway / set_body transformer).  When False (default), templates
             render the clean, user-facing version where the gateway injects parameters from
             the enrollment automatically.
+        **extra_context: Additional top-level Jinja2 variables.  ``run-tests`` uses this to
+            spread the upstream interface fields (``service_base_url``, ``routing_key``,
+            ``host``, ``region``, …) directly into the render namespace so unitysvc-data
+            v0.1.7+ templates resolve identically to gateway-side rendering.
 
     Returns:
         Tuple of (rendered_content, new_filename_without_j2)
@@ -268,6 +273,7 @@ def render_template_file(
             seller=seller or {},
             interface=interface or {},
             local_testing=local_testing,
+            **extra_context,
         )
 
         # Strip .j2 from filename

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -1,0 +1,47 @@
+"""Tests for unitysvc_sellers.example helpers."""
+
+from unitysvc_sellers.example import build_upstream_template_context
+
+
+def test_build_upstream_template_context_renames_base_url() -> None:
+    """``base_url`` is exposed as ``service_base_url`` to match unitysvc-data."""
+    ctx = build_upstream_template_context({"base_url": "https://api.example.com"})
+    assert ctx == {"service_base_url": "https://api.example.com"}
+
+
+def test_build_upstream_template_context_drops_api_key() -> None:
+    """``api_key`` is never inlined into rendered output.
+
+    Templates read ``UNITYSVC_API_KEY`` from the environment instead, so the
+    key must not leak into the Jinja2 namespace.
+    """
+    ctx = build_upstream_template_context(
+        {"base_url": "https://api.example.com", "api_key": "sk-secret"}
+    )
+    assert "api_key" not in ctx
+    assert ctx == {"service_base_url": "https://api.example.com"}
+
+
+def test_build_upstream_template_context_passes_other_fields_through() -> None:
+    """Non-special fields keep their names — including nested dicts."""
+    ctx = build_upstream_template_context(
+        {
+            "base_url": "https://api.example.com",
+            "routing_key": {"model": "gpt-4o"},
+            "host": "smtp.example.com",
+            "port": 465,
+            "region": "us-west-2",
+        }
+    )
+    assert ctx == {
+        "service_base_url": "https://api.example.com",
+        "routing_key": {"model": "gpt-4o"},
+        "host": "smtp.example.com",
+        "port": 465,
+        "region": "us-west-2",
+    }
+
+
+def test_build_upstream_template_context_empty() -> None:
+    """An empty interface yields an empty context (no defaults)."""
+    assert build_upstream_template_context({}) == {}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -486,3 +486,30 @@ def test_render_template_file_non_template(tmp_path: Path) -> None:
 
     assert content == "print('{{ not a template }}')"
     assert filename == "script.py"
+
+
+def test_render_template_file_extra_context(tmp_path: Path) -> None:
+    """Extra kwargs are spread into the top-level Jinja2 namespace.
+
+    ``run-tests`` uses this to mirror the gateway's render context — the
+    upstream interface fields (``service_base_url``, ``routing_key``, ``host``,
+    ``region``, …) appear as bare top-level variables, not under
+    ``interface.*``, so unitysvc-data v0.1.7+ templates render the same way
+    locally as they will on the backend.
+    """
+    template_file = tmp_path / "call.py.j2"
+    template_file.write_text(
+        'requests.post("{{ service_base_url }}/v1/chat", '
+        'json={"model": "{{ routing_key.model }}"})'
+    )
+
+    content, _filename = render_template_file(
+        template_file,
+        service_base_url="https://api.example.com",
+        routing_key={"model": "gpt-4o"},
+    )
+
+    assert content == (
+        'requests.post("https://api.example.com/v1/chat", '
+        'json={"model": "gpt-4o"})'
+    )


### PR DESCRIPTION
## Summary

Pairs with [unitysvc-data#16](https://github.com/unitysvc/unitysvc-data/pull/16) (v0.1.7) and the recently-merged [#36](https://github.com/unitysvc/unitysvc-sellers/pull/36).

unitysvc-data v0.1.7 moved every code-example / connectivity-test template off the env-var convention. Templates now read upstream fields as **top-level Jinja2 variables** — `{{ service_base_url }}`, `{{ routing_key.model }}`, `{{ host }}`, `{{ region }}`, … — and only `UNITYSVC_API_KEY` still comes from the environment (keys are never inlined into rendered output).

`usvc_seller data run-tests` was still building env vars (`SERVICE_BASE_URL`, `MODEL`, `BUCKET`/`REGION`/`HOST`/…) and passing only the raw `interface` dict to Jinja2, so against v0.1.7 templates it produced unresolved `{{ service_base_url }}` placeholders.

This PR:
- Spreads the first upstream interface into the Jinja2 render namespace via a new `build_upstream_template_context()` helper (`base_url` → `service_base_url`; `api_key` is deliberately dropped).
- Drops env-var exposure of upstream fields entirely. Only `UNITYSVC_API_KEY` is set on the subprocess env now.
- Adds `**extra_context` to `render_template_file` so callers can add top-level Jinja2 variables without growing the named-arg list.
- Bumps the `unitysvc-data` floor to `>=0.1.7` — the env-var → Jinja2 cutover is a paired contract.

After this lands, `run-tests` rendering matches gateway-side rendering (#36) exactly: same template, same context, same output.

## Sequencing

CI on this PR will fail until [unitysvc-data v0.1.7](https://github.com/unitysvc/unitysvc-data/pull/16) is merged and published to PyPI. Order of operations:
1. Merge & release `unitysvc-data` v0.1.7
2. Wait for the auto-publish workflow to push to PyPI
3. Re-run CI on this PR — it should go green
4. Merge

## Test plan

- [x] `uv run pytest -q` — 164 passed (with local `unitysvc-data` v0.1.7 sourced via `[tool.uv.sources]`; override stripped before commit)
- [x] `uv run ruff check src/ tests/` — clean
- [x] New `tests/test_example.py` covers `build_upstream_template_context` (rename, api_key drop, passthrough, empty)
- [x] New `test_render_template_file_extra_context` in `tests/test_utils.py` covers the spread path end-to-end
- [ ] Once `unitysvc-data` v0.1.7 is on PyPI: smoke-test `usvc_seller data run-tests` against a real listing (LLM + S3 + SMTP) to confirm rendered scripts run

🤖 Generated with [Claude Code](https://claude.com/claude-code)