### PR TITLE
upload: surface service_id on the per-service success line

### DIFF
--- a/src/unitysvc_sellers/upload.py
+++ b/src/unitysvc_sellers/upload.py
@@ -532,10 +532,11 @@ def upload_directory(
 
                 if status_value == "completed":
                     result.services.success += 1
-                    _emit("service", "ok", name, f"task_id={task_id}")
-                    # Write override file with service_id and name from the task result.
-                    # The ingest task returns {"service": {"id": "...", "name": "..."}, ...}.
-                    # name is a derived field (computed by the backend from listing/offering).
+                    # Pull service_id (and the backend-derived service name) out
+                    # of the task result up front so the success line surfaces
+                    # the id sellers actually act on, and the override file
+                    # below pins the same value.  The ingest task returns
+                    # {"service": {"id": "...", "name": "..."}, ...}.
                     task_result = status_dict.get("result") or {}
                     service_id = None
                     service_name = None
@@ -544,6 +545,12 @@ def upload_directory(
                         if isinstance(service_data, dict):
                             service_id = service_data.get("id")
                             service_name = service_data.get("name")
+                    detail = (
+                        f"service_id={service_id}"
+                        if service_id
+                        else f"task_id={task_id}"
+                    )
+                    _emit("service", "ok", name, detail)
                     if service_id:
                         override = {"service_id": str(service_id)}
                         if service_name:


### PR DESCRIPTION
## Summary

After ``usvc_seller data upload`` finishes, the success line now shows ``service_id=<uuid>`` instead of ``task_id=<uuid>``. The backend already returns the service id in the ingest task result, and we already extract it to write the listing-level override file — this just threads it into the progress line so the operator sees the identifier they'll actually use next.

## Output

Before:

```
↳ queued service: http-relay (task_id=2636cb7c-44b2-4c97-90f9-4ad103939eb9)
✓ ingested service: http-relay (task_id=2636cb7c-44b2-4c97-90f9-4ad103939eb9)
```

After:

```
↳ queued service: http-relay (task_id=2636cb7c-44b2-4c97-90f9-4ad103939eb9)
✓ ingested service: http-relay (service_id=45d7a628-3915-448e-bcde-6ac270ca82b1)
```

The seller can now copy that id straight into ``usvc_seller services show <id>`` or ``services run-tests <id>`` without having to ``services list`` and grep by name.

Falls back to ``task_id=...`` if the ingest task didn't return a service id (only relevant against backend versions predating the structured-result rollout).

## Test plan

- [x] ``ruff check`` / ``mypy`` clean.
- [x] ``pytest tests/`` — 164 passed, 1 deselected (pre-existing unrelated failure).
- [ ] Manual: ``usvc_seller data upload`` against a local services repo prints ``service_id=<uuid>`` on each success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)