### PR TITLE
Bump version to 0.1.8, require unitysvc-core>=0.1.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "unitysvc-sellers"
-version = "0.1.7"
+version = "0.1.8"
 description = "Seller-facing tools for UnitySVC: HTTP SDK + usvc_seller CLI"
 readme = "README.md"
 authors = [{ name = "Bo Peng", email = "bo.peng@unitysvc.com" }]
@@ -17,7 +17,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-  "unitysvc-core>=0.1.7",
+  "unitysvc-core>=0.1.8",
   "unitysvc-data>=0.1.7",
   "typer",
   "rich",


### PR DESCRIPTION
## Summary

unitysvc-core 0.1.8 was just released. Bump the dependency floor and the unitysvc-sellers package version together so a fresh install picks up the new core.

## Changes

- ``pyproject.toml``: ``version = "0.1.8"``, ``unitysvc-core>=0.1.8``.

## Test plan

- [x] ``ruff check`` / ``mypy`` clean.
- [x] ``pytest tests/`` — 164 passed, 1 deselected (pre-existing unrelated failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)