### PR TITLE
services submit: add --from-data flag

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -522,8 +522,9 @@ $ usvc_seller services submit [OPTIONS] [SERVICE_IDS]...
 **Options**:
 
 * `--all`: Submit all draft and rejected services.
-* `--from-data DIRECTORY`: Act on services whose IDs are found in listing_v1 files under DATA_DIR.
-* `--provider TEXT`: Filter by provider when --all is set.
+* `--from-data`: Act on services whose IDs are found in listing_v1 files under --data-dir.
+* `--data-dir DIRECTORY`: Data directory for --from-data (default: current directory).  [default: .]
+* `--provider TEXT`: Filter by provider when --all or --from-data is set.
 * `-y, --yes`: Skip confirmation prompt.
 * `--api-key TEXT`: Seller API key (svcpass_...). Defaults to $UNITYSVC_SELLER_API_KEY.  [env var: UNITYSVC_SELLER_API_KEY]
 * `--base-url TEXT`: Backend base URL.  [env var: UNITYSVC_SELLER_API_URL; default: https://seller.unitysvc.com/v1]
@@ -546,8 +547,9 @@ $ usvc_seller services withdraw [OPTIONS] [SERVICE_IDS]...
 **Options**:
 
 * `--all`: Withdraw all pending and rejected services.
-* `--from-data DIRECTORY`: Act on services whose IDs are found in listing_v1 files under DATA_DIR.
-* `--provider TEXT`: Filter by provider when --all is set.
+* `--from-data`: Act on services whose IDs are found in listing_v1 files under --data-dir.
+* `--data-dir DIRECTORY`: Data directory for --from-data (default: current directory).  [default: .]
+* `--provider TEXT`: Filter by provider when --all or --from-data is set.
 * `-y, --yes`: Skip confirmation prompt.
 * `--api-key TEXT`: Seller API key (svcpass_...). Defaults to $UNITYSVC_SELLER_API_KEY.  [env var: UNITYSVC_SELLER_API_KEY]
 * `--base-url TEXT`: Backend base URL.  [env var: UNITYSVC_SELLER_API_URL; default: https://seller.unitysvc.com/v1]
@@ -570,8 +572,9 @@ $ usvc_seller services deprecate [OPTIONS] [SERVICE_IDS]...
 **Options**:
 
 * `--all`: Deprecate all active services.
-* `--from-data DIRECTORY`: Act on services whose IDs are found in listing_v1 files under DATA_DIR.
-* `--provider TEXT`: Filter by provider when --all is set.
+* `--from-data`: Act on services whose IDs are found in listing_v1 files under --data-dir.
+* `--data-dir DIRECTORY`: Data directory for --from-data (default: current directory).  [default: .]
+* `--provider TEXT`: Filter by provider when --all or --from-data is set.
 * `-y, --yes`: Skip confirmation prompt.
 * `--api-key TEXT`: Seller API key (svcpass_...). Defaults to $UNITYSVC_SELLER_API_KEY.  [env var: UNITYSVC_SELLER_API_KEY]
 * `--base-url TEXT`: Backend base URL.  [env var: UNITYSVC_SELLER_API_URL; default: https://seller.unitysvc.com/v1]
@@ -594,8 +597,9 @@ $ usvc_seller services publish [OPTIONS] [SERVICE_IDS]...
 **Options**:
 
 * `--all`: Publish all active services that aren&#x27;t already public.
-* `--from-data DIRECTORY`: Act on services whose IDs are found in listing_v1 files under DATA_DIR.
-* `--provider TEXT`: Filter by provider when --all is set.
+* `--from-data`: Act on services whose IDs are found in listing_v1 files under --data-dir.
+* `--data-dir DIRECTORY`: Data directory for --from-data (default: current directory).  [default: .]
+* `--provider TEXT`: Filter by provider when --all or --from-data is set.
 * `-y, --yes`: Skip confirmation prompt.
 * `--api-key TEXT`: Seller API key (svcpass_...). Defaults to $UNITYSVC_SELLER_API_KEY.  [env var: UNITYSVC_SELLER_API_KEY]
 * `--base-url TEXT`: Backend base URL.  [env var: UNITYSVC_SELLER_API_URL; default: https://seller.unitysvc.com/v1]
@@ -618,8 +622,9 @@ $ usvc_seller services unlist [OPTIONS] [SERVICE_IDS]...
 **Options**:
 
 * `--all`: Unlist all active services that aren&#x27;t already unlisted.
-* `--from-data DIRECTORY`: Act on services whose IDs are found in listing_v1 files under DATA_DIR.
-* `--provider TEXT`: Filter by provider when --all is set.
+* `--from-data`: Act on services whose IDs are found in listing_v1 files under --data-dir.
+* `--data-dir DIRECTORY`: Data directory for --from-data (default: current directory).  [default: .]
+* `--provider TEXT`: Filter by provider when --all or --from-data is set.
 * `-y, --yes`: Skip confirmation prompt.
 * `--api-key TEXT`: Seller API key (svcpass_...). Defaults to $UNITYSVC_SELLER_API_KEY.  [env var: UNITYSVC_SELLER_API_KEY]
 * `--base-url TEXT`: Backend base URL.  [env var: UNITYSVC_SELLER_API_URL; default: https://seller.unitysvc.com/v1]
@@ -642,8 +647,9 @@ $ usvc_seller services hide [OPTIONS] [SERVICE_IDS]...
 **Options**:
 
 * `--all`: Hide all active services that aren&#x27;t already private.
-* `--from-data DIRECTORY`: Act on services whose IDs are found in listing_v1 files under DATA_DIR.
-* `--provider TEXT`: Filter by provider when --all is set.
+* `--from-data`: Act on services whose IDs are found in listing_v1 files under --data-dir.
+* `--data-dir DIRECTORY`: Data directory for --from-data (default: current directory).  [default: .]
+* `--provider TEXT`: Filter by provider when --all or --from-data is set.
 * `-y, --yes`: Skip confirmation prompt.
 * `--api-key TEXT`: Seller API key (svcpass_...). Defaults to $UNITYSVC_SELLER_API_KEY.  [env var: UNITYSVC_SELLER_API_KEY]
 * `--base-url TEXT`: Backend base URL.  [env var: UNITYSVC_SELLER_API_URL; default: https://seller.unitysvc.com/v1]
@@ -666,9 +672,10 @@ $ usvc_seller services delete [OPTIONS] [SERVICE_IDS]...
 **Options**:
 
 * `--all`: Delete all deletable services (draft, pending, review, rejected, suspended, deprecated).
-* `--from-data DIRECTORY`: Act on services whose IDs are found in listing_v1 files under DATA_DIR.
+* `--from-data`: Act on services whose IDs are found in listing_v1 files under --data-dir.
+* `--data-dir DIRECTORY`: Data directory for --from-data (default: current directory).  [default: .]
 * `--status TEXT`: Restrict --all to a single deletable status.
-* `--provider TEXT`: Filter by provider when --all is set.
+* `--provider TEXT`: Filter by provider when --all or --from-data is set.
 * `--dryrun`: Show what would be deleted without doing it.
 * `-y, --yes`: Skip confirmation prompt.
 * `--api-key TEXT`: Seller API key (svcpass_...). Defaults to $UNITYSVC_SELLER_API_KEY.  [env var: UNITYSVC_SELLER_API_KEY]

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -522,7 +522,7 @@ $ usvc_seller services submit [OPTIONS] [SERVICE_IDS]...
 **Options**:
 
 * `--all`: Submit all draft and rejected services.
-* `--from-data DIRECTORY`: Submit services whose IDs are found in listing_v1 files under DATA_DIR.
+* `--from-data DIRECTORY`: Act on services whose IDs are found in listing_v1 files under DATA_DIR.
 * `--provider TEXT`: Filter by provider when --all is set.
 * `-y, --yes`: Skip confirmation prompt.
 * `--api-key TEXT`: Seller API key (svcpass_...). Defaults to $UNITYSVC_SELLER_API_KEY.  [env var: UNITYSVC_SELLER_API_KEY]
@@ -546,6 +546,7 @@ $ usvc_seller services withdraw [OPTIONS] [SERVICE_IDS]...
 **Options**:
 
 * `--all`: Withdraw all pending and rejected services.
+* `--from-data DIRECTORY`: Act on services whose IDs are found in listing_v1 files under DATA_DIR.
 * `--provider TEXT`: Filter by provider when --all is set.
 * `-y, --yes`: Skip confirmation prompt.
 * `--api-key TEXT`: Seller API key (svcpass_...). Defaults to $UNITYSVC_SELLER_API_KEY.  [env var: UNITYSVC_SELLER_API_KEY]
@@ -569,6 +570,7 @@ $ usvc_seller services deprecate [OPTIONS] [SERVICE_IDS]...
 **Options**:
 
 * `--all`: Deprecate all active services.
+* `--from-data DIRECTORY`: Act on services whose IDs are found in listing_v1 files under DATA_DIR.
 * `--provider TEXT`: Filter by provider when --all is set.
 * `-y, --yes`: Skip confirmation prompt.
 * `--api-key TEXT`: Seller API key (svcpass_...). Defaults to $UNITYSVC_SELLER_API_KEY.  [env var: UNITYSVC_SELLER_API_KEY]
@@ -592,6 +594,7 @@ $ usvc_seller services publish [OPTIONS] [SERVICE_IDS]...
 **Options**:
 
 * `--all`: Publish all active services that aren&#x27;t already public.
+* `--from-data DIRECTORY`: Act on services whose IDs are found in listing_v1 files under DATA_DIR.
 * `--provider TEXT`: Filter by provider when --all is set.
 * `-y, --yes`: Skip confirmation prompt.
 * `--api-key TEXT`: Seller API key (svcpass_...). Defaults to $UNITYSVC_SELLER_API_KEY.  [env var: UNITYSVC_SELLER_API_KEY]
@@ -615,6 +618,7 @@ $ usvc_seller services unlist [OPTIONS] [SERVICE_IDS]...
 **Options**:
 
 * `--all`: Unlist all active services that aren&#x27;t already unlisted.
+* `--from-data DIRECTORY`: Act on services whose IDs are found in listing_v1 files under DATA_DIR.
 * `--provider TEXT`: Filter by provider when --all is set.
 * `-y, --yes`: Skip confirmation prompt.
 * `--api-key TEXT`: Seller API key (svcpass_...). Defaults to $UNITYSVC_SELLER_API_KEY.  [env var: UNITYSVC_SELLER_API_KEY]
@@ -638,6 +642,7 @@ $ usvc_seller services hide [OPTIONS] [SERVICE_IDS]...
 **Options**:
 
 * `--all`: Hide all active services that aren&#x27;t already private.
+* `--from-data DIRECTORY`: Act on services whose IDs are found in listing_v1 files under DATA_DIR.
 * `--provider TEXT`: Filter by provider when --all is set.
 * `-y, --yes`: Skip confirmation prompt.
 * `--api-key TEXT`: Seller API key (svcpass_...). Defaults to $UNITYSVC_SELLER_API_KEY.  [env var: UNITYSVC_SELLER_API_KEY]
@@ -661,6 +666,7 @@ $ usvc_seller services delete [OPTIONS] [SERVICE_IDS]...
 **Options**:
 
 * `--all`: Delete all deletable services (draft, pending, review, rejected, suspended, deprecated).
+* `--from-data DIRECTORY`: Act on services whose IDs are found in listing_v1 files under DATA_DIR.
 * `--status TEXT`: Restrict --all to a single deletable status.
 * `--provider TEXT`: Filter by provider when --all is set.
 * `--dryrun`: Show what would be deleted without doing it.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -522,6 +522,7 @@ $ usvc_seller services submit [OPTIONS] [SERVICE_IDS]...
 **Options**:
 
 * `--all`: Submit all draft and rejected services.
+* `--from-data DIRECTORY`: Submit services whose IDs are found in listing_v1 files under DATA_DIR.
 * `--provider TEXT`: Filter by provider when --all is set.
 * `-y, --yes`: Skip confirmation prompt.
 * `--api-key TEXT`: Seller API key (svcpass_...). Defaults to $UNITYSVC_SELLER_API_KEY.  [env var: UNITYSVC_SELLER_API_KEY]

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -773,6 +773,69 @@ flowchart LR
 
 The CLI handles this order automatically. Incorrect order will result in foreign key errors.
 
+## Bulk Operations with --from-data
+
+After running `usvc_seller data upload`, each listing file gets a `listing.override.json`
+(or `.override.toml`) written alongside it containing the backend-assigned `service_id`.
+The `--from-data` flag on all bulk service commands reads those IDs automatically, so you
+don't have to copy-paste UUIDs from the upload output.
+
+```bash
+# Submit all services whose override files live under the current directory
+usvc_seller services submit --from-data . --yes
+
+# Withdraw services for a specific provider only
+usvc_seller services withdraw --from-data . --provider acme --yes
+
+# Publish all active services in a data subdirectory
+usvc_seller services publish --data-dir ./data --from-data --yes
+```
+
+### How it works
+
+1. `--from-data` tells the command to scan for `listing_v1` files under `--data-dir`
+   (default: current directory).
+2. For each listing file found, the corresponding `*.override.*` file is merged in
+   automatically. The `service_id` field from the merged result is collected.
+3. Listings that have no `service_id` yet (i.e. not yet uploaded) are silently skipped.
+4. `--provider NAME` filters the collected IDs to those whose listing contains a
+   `provider_name` matching `NAME` (case-insensitive substring match).
+
+### Typical CI/CD upload-and-submit pattern
+
+```yaml
+- name: Upload data
+  env:
+    UNITYSVC_SELLER_API_KEY: ${{ secrets.UNITYSVC_SELLER_API_KEY }}
+    UNITYSVC_SELLER_API_URL: ${{ secrets.UNITYSVC_SELLER_API_URL }}
+  run: usvc_seller data upload
+
+- name: Commit back override files
+  run: |
+    git config user.name "GitHub Actions"
+    git config user.email "actions@github.com"
+    git add -A '*.override.*'
+    git diff --staged --quiet || git commit -m "chore: update service override files [skip ci]"
+    git push
+
+- name: Submit for review
+  env:
+    UNITYSVC_SELLER_API_KEY: ${{ secrets.UNITYSVC_SELLER_API_KEY }}
+    UNITYSVC_SELLER_API_URL: ${{ secrets.UNITYSVC_SELLER_API_URL }}
+  run: usvc_seller services submit --from-data . --yes
+```
+
+### Mutual exclusivity
+
+`--from-data`, `--all`, and explicit service ID arguments are mutually exclusive.
+Only one source may be active per invocation.
+
+| Source | When to use |
+|--------|-------------|
+| Explicit IDs | You know the exact UUIDs |
+| `--all` | Operate on all services in the seller account matching a status/visibility |
+| `--from-data` | Operate on services whose listings live in the local data directory |
+
 ## Deleting Services
 
 Use `usvc_seller services delete` to remove services from the backend:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "unitysvc-sellers"
-version = "0.1.7"
+version = "0.1.8"
 description = "Seller-facing tools for UnitySVC: HTTP SDK + usvc_seller CLI"
 readme = "README.md"
 authors = [{ name = "Bo Peng", email = "bo.peng@unitysvc.com" }]
@@ -17,8 +17,8 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-  "unitysvc-core>=0.1.7",
-  "unitysvc-data>=0.1.7",
+  "unitysvc-core>=0.1.8",
+  "unitysvc-data>=0.1.10",
   "typer",
   "rich",
   "jinja2",

--- a/src/unitysvc_sellers/commands/services.py
+++ b/src/unitysvc_sellers/commands/services.py
@@ -25,8 +25,6 @@ instead.
 
 from __future__ import annotations
 
-import json
-import tomllib
 from pathlib import Path
 from typing import Any
 
@@ -393,22 +391,14 @@ def _resolve_or_fetch_ids(
 # ---------------------------------------------------------------------------
 
 def _read_ids_from_data_dir(data_dir: Path) -> list[str]:
-    """Collect service_ids from listing.override.* files under data_dir."""
+    """Collect service_ids from all listing_v1 files (with overrides merged) under data_dir."""
+    from unitysvc_core.utils import find_files_by_schema
+
     ids: list[str] = []
-    for path in sorted(data_dir.rglob("listing.override.json")):
-        try:
-            sid = json.loads(path.read_text()).get("service_id")
-            if sid:
-                ids.append(str(sid))
-        except Exception:
-            pass
-    for path in sorted(data_dir.rglob("listing.override.toml")):
-        try:
-            sid = tomllib.loads(path.read_text()).get("service_id")
-            if sid:
-                ids.append(str(sid))
-        except Exception:
-            pass
+    for _path, _fmt, data in find_files_by_schema(data_dir, "listing_v1"):
+        sid = data.get("service_id")
+        if sid:
+            ids.append(str(sid))
     return ids
 
 

--- a/src/unitysvc_sellers/commands/services.py
+++ b/src/unitysvc_sellers/commands/services.py
@@ -410,7 +410,7 @@ def submit_service(
     from_data: Path | None = typer.Option(
         None,
         "--from-data",
-        help="Submit services whose IDs are recorded in listing.override.* files under DATA_DIR.",
+        help="Submit services whose IDs are found in listing_v1 files under DATA_DIR.",
         exists=True,
         file_okay=False,
         dir_okay=True,

--- a/src/unitysvc_sellers/commands/services.py
+++ b/src/unitysvc_sellers/commands/services.py
@@ -45,6 +45,15 @@ from ._helpers import (
     run_async,
 )
 
+_FROM_DATA_OPTION = typer.Option(
+    None,
+    "--from-data",
+    help="Act on services whose IDs are found in listing_v1 files under DATA_DIR.",
+    exists=True,
+    file_okay=False,
+    dir_okay=True,
+)
+
 console = Console()
 
 app = typer.Typer(
@@ -330,6 +339,18 @@ def _bulk_visibility_change(
             raise typer.Exit(code=1)
 
 
+def _read_ids_from_data_dir(data_dir: Path) -> list[str]:
+    """Collect service_ids from all listing_v1 files (with overrides merged) under data_dir."""
+    from unitysvc_core.utils import find_files_by_schema
+
+    ids: list[str] = []
+    for _path, _fmt, data in find_files_by_schema(data_dir, "listing_v1"):
+        sid = data.get("service_id")
+        if sid:
+            ids.append(str(sid))
+    return ids
+
+
 def _resolve_or_fetch_ids(
     *,
     api_key: str | None,
@@ -339,15 +360,29 @@ def _resolve_or_fetch_ids(
     statuses_when_all: list[str],
     provider: str | None,
     flag_name: str,
+    from_data: Path | None = None,
     visibilities_when_all: list[str] | None = None,
 ) -> list[str]:
     """Validate args and either return the explicit ids or fetch by status.
+
+    Three mutually exclusive sources (first match wins):
+    - ``from_data``: read service_ids from listing_v1 files under that directory.
+    - ``use_all``: fetch from the API filtered by status/visibility.
+    - explicit ``service_ids`` positional arguments.
 
     ``visibilities_when_all`` further restricts the ``--all`` fetch to
     services whose current visibility is in the given list. Used by
     ``publish/unlist/hide --all`` to skip services that already have
     the target visibility.
     """
+    if from_data is not None:
+        ids = _read_ids_from_data_dir(from_data)
+        if not ids:
+            console.print("[yellow]No service IDs found in listing_v1 files under the given directory.[/yellow]")
+            raise typer.Exit(code=0)
+        console.print(f"[cyan]Found {len(ids)} service ID(s) from {from_data}[/cyan]\n")
+        return ids
+
     if provider and not use_all:
         console.print(f"[red]Error:[/red] --provider can only be used with --{flag_name} flag")
         raise typer.Exit(code=1)
@@ -391,17 +426,6 @@ def _resolve_or_fetch_ids(
 # submit / withdraw / deprecate
 # ---------------------------------------------------------------------------
 
-def _read_ids_from_data_dir(data_dir: Path) -> list[str]:
-    """Collect service_ids from all listing_v1 files (with overrides merged) under data_dir."""
-    from unitysvc_core.utils import find_files_by_schema
-
-    ids: list[str] = []
-    for _path, _fmt, data in find_files_by_schema(data_dir, "listing_v1"):
-        sid = data.get("service_id")
-        if sid:
-            ids.append(str(sid))
-    return ids
-
 
 @app.command("submit")
 def submit_service(
@@ -410,7 +434,7 @@ def submit_service(
     from_data: Path | None = typer.Option(
         None,
         "--from-data",
-        help="Submit services whose IDs are found in listing_v1 files under DATA_DIR.",
+        help="Act on services whose IDs are found in listing_v1 files under DATA_DIR.",
         exists=True,
         file_okay=False,
         dir_okay=True,
@@ -421,22 +445,16 @@ def submit_service(
     base_url: str = base_url_option(),
 ) -> None:
     """Submit services for review (draft|rejected → pending)."""
-    if from_data is not None:
-        ids = _read_ids_from_data_dir(from_data)
-        if not ids:
-            console.print("[yellow]No service IDs found in override files under the given directory.[/yellow]")
-            raise typer.Exit(code=0)
-        console.print(f"[cyan]Found {len(ids)} service ID(s) from override files in {from_data}[/cyan]\n")
-    else:
-        ids = _resolve_or_fetch_ids(
-            api_key=api_key,
-            base_url=base_url,
-            service_ids=service_ids,
-            use_all=all_drafts,
-            statuses_when_all=["draft", "rejected"],
-            provider=provider,
-            flag_name="all",
-        )
+    ids = _resolve_or_fetch_ids(
+        api_key=api_key,
+        base_url=base_url,
+        service_ids=service_ids,
+        use_all=all_drafts,
+        statuses_when_all=["draft", "rejected"],
+        provider=provider,
+        flag_name="all",
+        from_data=from_data,
+    )
     _bulk_status_change(
         api_key=api_key,
         base_url=base_url,
@@ -452,6 +470,7 @@ def submit_service(
 def withdraw_service(
     service_ids: list[str] = typer.Argument(None, help="Service ID(s) to withdraw (≥8 chars)."),
     all_pending: bool = typer.Option(False, "--all", help="Withdraw all pending and rejected services."),
+    from_data: Path | None = _FROM_DATA_OPTION,
     provider: str | None = typer.Option(None, "--provider", help="Filter by provider when --all is set."),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
     api_key: str | None = api_key_option(),
@@ -466,6 +485,7 @@ def withdraw_service(
         statuses_when_all=["pending", "rejected"],
         provider=provider,
         flag_name="all",
+        from_data=from_data,
     )
     _bulk_status_change(
         api_key=api_key,
@@ -482,6 +502,7 @@ def withdraw_service(
 def deprecate_service(
     service_ids: list[str] = typer.Argument(None, help="Service ID(s) to deprecate (≥8 chars)."),
     all_active: bool = typer.Option(False, "--all", help="Deprecate all active services."),
+    from_data: Path | None = _FROM_DATA_OPTION,
     provider: str | None = typer.Option(None, "--provider", help="Filter by provider when --all is set."),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
     api_key: str | None = api_key_option(),
@@ -496,6 +517,7 @@ def deprecate_service(
         statuses_when_all=["active"],
         provider=provider,
         flag_name="all",
+        from_data=from_data,
     )
     _bulk_status_change(
         api_key=api_key,
@@ -519,6 +541,7 @@ def publish_service(
         "--all",
         help="Publish all active services that aren't already public.",
     ),
+    from_data: Path | None = _FROM_DATA_OPTION,
     provider: str | None = typer.Option(None, "--provider", help="Filter by provider when --all is set."),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
     api_key: str | None = api_key_option(),
@@ -534,6 +557,7 @@ def publish_service(
         visibilities_when_all=["unlisted", "private"],
         provider=provider,
         flag_name="all",
+        from_data=from_data,
     )
     _bulk_visibility_change(
         api_key=api_key,
@@ -554,6 +578,7 @@ def unlist_service(
         "--all",
         help="Unlist all active services that aren't already unlisted.",
     ),
+    from_data: Path | None = _FROM_DATA_OPTION,
     provider: str | None = typer.Option(None, "--provider", help="Filter by provider when --all is set."),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
     api_key: str | None = api_key_option(),
@@ -569,6 +594,7 @@ def unlist_service(
         visibilities_when_all=["public", "private"],
         provider=provider,
         flag_name="all",
+        from_data=from_data,
     )
     _bulk_visibility_change(
         api_key=api_key,
@@ -589,6 +615,7 @@ def hide_service(
         "--all",
         help="Hide all active services that aren't already private.",
     ),
+    from_data: Path | None = _FROM_DATA_OPTION,
     provider: str | None = typer.Option(None, "--provider", help="Filter by provider when --all is set."),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
     api_key: str | None = api_key_option(),
@@ -604,6 +631,7 @@ def hide_service(
         visibilities_when_all=["public", "unlisted"],
         provider=provider,
         flag_name="all",
+        from_data=from_data,
     )
     _bulk_visibility_change(
         api_key=api_key,
@@ -627,6 +655,7 @@ def delete_service(
         "--all",
         help="Delete all deletable services (draft, pending, review, rejected, suspended, deprecated).",
     ),
+    from_data: Path | None = _FROM_DATA_OPTION,
     status: str | None = typer.Option(None, "--status", help="Restrict --all to a single deletable status."),
     provider: str | None = typer.Option(None, "--provider", help="Filter by provider when --all is set."),
     dryrun: bool = typer.Option(False, "--dryrun", help="Show what would be deleted without doing it."),
@@ -653,6 +682,7 @@ def delete_service(
         statuses_when_all=statuses,
         provider=provider,
         flag_name="all",
+        from_data=from_data,
     )
 
     count = len(ids)

--- a/src/unitysvc_sellers/commands/services.py
+++ b/src/unitysvc_sellers/commands/services.py
@@ -26,6 +26,8 @@ instead.
 from __future__ import annotations
 
 import json
+import tomllib
+from pathlib import Path
 from typing import Any
 
 import typer
@@ -389,25 +391,61 @@ def _resolve_or_fetch_ids(
 # ---------------------------------------------------------------------------
 # submit / withdraw / deprecate
 # ---------------------------------------------------------------------------
+
+def _read_ids_from_data_dir(data_dir: Path) -> list[str]:
+    """Collect service_ids from listing.override.* files under data_dir."""
+    ids: list[str] = []
+    for path in sorted(data_dir.rglob("listing.override.json")):
+        try:
+            sid = json.loads(path.read_text()).get("service_id")
+            if sid:
+                ids.append(str(sid))
+        except Exception:
+            pass
+    for path in sorted(data_dir.rglob("listing.override.toml")):
+        try:
+            sid = tomllib.loads(path.read_text()).get("service_id")
+            if sid:
+                ids.append(str(sid))
+        except Exception:
+            pass
+    return ids
+
+
 @app.command("submit")
 def submit_service(
     service_ids: list[str] = typer.Argument(None, help="Service ID(s) to submit (≥8 chars)."),
     all_drafts: bool = typer.Option(False, "--all", help="Submit all draft and rejected services."),
+    from_data: Path | None = typer.Option(
+        None,
+        "--from-data",
+        help="Submit services whose IDs are recorded in listing.override.* files under DATA_DIR.",
+        exists=True,
+        file_okay=False,
+        dir_okay=True,
+    ),
     provider: str | None = typer.Option(None, "--provider", help="Filter by provider when --all is set."),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
     api_key: str | None = api_key_option(),
     base_url: str = base_url_option(),
 ) -> None:
     """Submit services for review (draft|rejected → pending)."""
-    ids = _resolve_or_fetch_ids(
-        api_key=api_key,
-        base_url=base_url,
-        service_ids=service_ids,
-        use_all=all_drafts,
-        statuses_when_all=["draft", "rejected"],
-        provider=provider,
-        flag_name="all",
-    )
+    if from_data is not None:
+        ids = _read_ids_from_data_dir(from_data)
+        if not ids:
+            console.print("[yellow]No service IDs found in override files under the given directory.[/yellow]")
+            raise typer.Exit(code=0)
+        console.print(f"[cyan]Found {len(ids)} service ID(s) from override files in {from_data}[/cyan]\n")
+    else:
+        ids = _resolve_or_fetch_ids(
+            api_key=api_key,
+            base_url=base_url,
+            service_ids=service_ids,
+            use_all=all_drafts,
+            statuses_when_all=["draft", "rejected"],
+            provider=provider,
+            flag_name="all",
+        )
     _bulk_status_change(
         api_key=api_key,
         base_url=base_url,

--- a/src/unitysvc_sellers/commands/services.py
+++ b/src/unitysvc_sellers/commands/services.py
@@ -46,12 +46,13 @@ from ._helpers import (
 )
 
 _FROM_DATA_OPTION = typer.Option(
-    None,
-    "--from-data",
-    help="Act on services whose IDs are found in listing_v1 files under DATA_DIR.",
-    exists=True,
-    file_okay=False,
-    dir_okay=True,
+    False, "--from-data",
+    help="Act on services whose IDs are found in listing_v1 files under --data-dir.",
+)
+_DATA_DIR_OPTION = typer.Option(
+    Path("."), "--data-dir",
+    help="Data directory for --from-data (default: current directory).",
+    exists=True, file_okay=False, dir_okay=True,
 )
 
 console = Console()
@@ -360,22 +361,23 @@ def _resolve_or_fetch_ids(
     statuses_when_all: list[str],
     provider: str | None,
     flag_name: str,
-    from_data: Path | None = None,
+    use_from_data: bool = False,
+    data_dir: Path = Path("."),
     visibilities_when_all: list[str] | None = None,
 ) -> list[str]:
     """Resolve the target service IDs from exactly one of three mutually exclusive sources.
 
-    Sources (in precedence order — only one may be active):
+    Sources (only one may be active):
     - explicit positional ``service_ids``
     - ``--all``: fetch from the API filtered by status/visibility/provider.
-    - ``--from-data DIR``: read IDs from listing_v1 files; ``--provider``
-      filters by the ``provider_name`` field in each listing.
+    - ``--from-data``: read IDs from listing_v1 files under ``data_dir``;
+      ``--provider`` filters by the ``provider_name`` field in each listing.
 
     ``visibilities_when_all`` further restricts the ``--all`` fetch to
     services whose current visibility is in the given list.
     """
     # --- strict mutual exclusivity ---
-    modes = sum([bool(service_ids), use_all, from_data is not None])
+    modes = sum([bool(service_ids), use_all, use_from_data])
     if modes > 1:
         console.print(
             "[red]Error:[/red] --all, --from-data, and explicit service IDs are mutually exclusive. "
@@ -384,15 +386,15 @@ def _resolve_or_fetch_ids(
         raise typer.Exit(code=1)
 
     # --- --from-data: local listing_v1 files ---
-    if from_data is not None:
-        ids = _read_ids_from_data_dir(from_data)
+    if use_from_data:
+        ids = _read_ids_from_data_dir(data_dir)
         if provider:
             from unitysvc_core.utils import find_files_by_schema
 
             provider_lower = provider.lower()
             allowed = {
                 str(data["service_id"])
-                for _, _, data in find_files_by_schema(from_data, "listing_v1")
+                for _, _, data in find_files_by_schema(data_dir, "listing_v1")
                 if provider_lower in (data.get("provider_name") or "").lower()
                 and data.get("service_id")
             }
@@ -400,7 +402,7 @@ def _resolve_or_fetch_ids(
         if not ids:
             console.print("[yellow]No service IDs found in listing_v1 files under the given directory.[/yellow]")
             raise typer.Exit(code=0)
-        console.print(f"[cyan]Found {len(ids)} service ID(s) from {from_data}[/cyan]\n")
+        console.print(f"[cyan]Found {len(ids)} service ID(s) from {data_dir}[/cyan]\n")
         return ids
 
     # --- --all: remote API ---
@@ -450,15 +452,11 @@ def _resolve_or_fetch_ids(
 def submit_service(
     service_ids: list[str] = typer.Argument(None, help="Service ID(s) to submit (≥8 chars)."),
     all_drafts: bool = typer.Option(False, "--all", help="Submit all draft and rejected services."),
-    from_data: Path | None = typer.Option(
-        None,
-        "--from-data",
-        help="Act on services whose IDs are found in listing_v1 files under DATA_DIR.",
-        exists=True,
-        file_okay=False,
-        dir_okay=True,
+    from_data: bool = _FROM_DATA_OPTION,
+    data_dir: Path = _DATA_DIR_OPTION,
+    provider: str | None = typer.Option(
+        None, "--provider", help="Filter by provider when --all or --from-data is set."
     ),
-    provider: str | None = typer.Option(None, "--provider", help="Filter by provider when --all is set."),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
     api_key: str | None = api_key_option(),
     base_url: str = base_url_option(),
@@ -472,7 +470,8 @@ def submit_service(
         statuses_when_all=["draft", "rejected"],
         provider=provider,
         flag_name="all",
-        from_data=from_data,
+        use_from_data=from_data,
+        data_dir=data_dir,
     )
     _bulk_status_change(
         api_key=api_key,
@@ -489,8 +488,11 @@ def submit_service(
 def withdraw_service(
     service_ids: list[str] = typer.Argument(None, help="Service ID(s) to withdraw (≥8 chars)."),
     all_pending: bool = typer.Option(False, "--all", help="Withdraw all pending and rejected services."),
-    from_data: Path | None = _FROM_DATA_OPTION,
-    provider: str | None = typer.Option(None, "--provider", help="Filter by provider when --all is set."),
+    from_data: bool = _FROM_DATA_OPTION,
+    data_dir: Path = _DATA_DIR_OPTION,
+    provider: str | None = typer.Option(
+        None, "--provider", help="Filter by provider when --all or --from-data is set."
+    ),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
     api_key: str | None = api_key_option(),
     base_url: str = base_url_option(),
@@ -504,7 +506,8 @@ def withdraw_service(
         statuses_when_all=["pending", "rejected"],
         provider=provider,
         flag_name="all",
-        from_data=from_data,
+        use_from_data=from_data,
+        data_dir=data_dir,
     )
     _bulk_status_change(
         api_key=api_key,
@@ -521,8 +524,11 @@ def withdraw_service(
 def deprecate_service(
     service_ids: list[str] = typer.Argument(None, help="Service ID(s) to deprecate (≥8 chars)."),
     all_active: bool = typer.Option(False, "--all", help="Deprecate all active services."),
-    from_data: Path | None = _FROM_DATA_OPTION,
-    provider: str | None = typer.Option(None, "--provider", help="Filter by provider when --all is set."),
+    from_data: bool = _FROM_DATA_OPTION,
+    data_dir: Path = _DATA_DIR_OPTION,
+    provider: str | None = typer.Option(
+        None, "--provider", help="Filter by provider when --all or --from-data is set."
+    ),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
     api_key: str | None = api_key_option(),
     base_url: str = base_url_option(),
@@ -536,7 +542,8 @@ def deprecate_service(
         statuses_when_all=["active"],
         provider=provider,
         flag_name="all",
-        from_data=from_data,
+        use_from_data=from_data,
+        data_dir=data_dir,
     )
     _bulk_status_change(
         api_key=api_key,
@@ -560,8 +567,11 @@ def publish_service(
         "--all",
         help="Publish all active services that aren't already public.",
     ),
-    from_data: Path | None = _FROM_DATA_OPTION,
-    provider: str | None = typer.Option(None, "--provider", help="Filter by provider when --all is set."),
+    from_data: bool = _FROM_DATA_OPTION,
+    data_dir: Path = _DATA_DIR_OPTION,
+    provider: str | None = typer.Option(
+        None, "--provider", help="Filter by provider when --all or --from-data is set."
+    ),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
     api_key: str | None = api_key_option(),
     base_url: str = base_url_option(),
@@ -576,7 +586,8 @@ def publish_service(
         visibilities_when_all=["unlisted", "private"],
         provider=provider,
         flag_name="all",
-        from_data=from_data,
+        use_from_data=from_data,
+        data_dir=data_dir,
     )
     _bulk_visibility_change(
         api_key=api_key,
@@ -597,8 +608,11 @@ def unlist_service(
         "--all",
         help="Unlist all active services that aren't already unlisted.",
     ),
-    from_data: Path | None = _FROM_DATA_OPTION,
-    provider: str | None = typer.Option(None, "--provider", help="Filter by provider when --all is set."),
+    from_data: bool = _FROM_DATA_OPTION,
+    data_dir: Path = _DATA_DIR_OPTION,
+    provider: str | None = typer.Option(
+        None, "--provider", help="Filter by provider when --all or --from-data is set."
+    ),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
     api_key: str | None = api_key_option(),
     base_url: str = base_url_option(),
@@ -613,7 +627,8 @@ def unlist_service(
         visibilities_when_all=["public", "private"],
         provider=provider,
         flag_name="all",
-        from_data=from_data,
+        use_from_data=from_data,
+        data_dir=data_dir,
     )
     _bulk_visibility_change(
         api_key=api_key,
@@ -634,8 +649,11 @@ def hide_service(
         "--all",
         help="Hide all active services that aren't already private.",
     ),
-    from_data: Path | None = _FROM_DATA_OPTION,
-    provider: str | None = typer.Option(None, "--provider", help="Filter by provider when --all is set."),
+    from_data: bool = _FROM_DATA_OPTION,
+    data_dir: Path = _DATA_DIR_OPTION,
+    provider: str | None = typer.Option(
+        None, "--provider", help="Filter by provider when --all or --from-data is set."
+    ),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
     api_key: str | None = api_key_option(),
     base_url: str = base_url_option(),
@@ -650,7 +668,8 @@ def hide_service(
         visibilities_when_all=["public", "unlisted"],
         provider=provider,
         flag_name="all",
-        from_data=from_data,
+        use_from_data=from_data,
+        data_dir=data_dir,
     )
     _bulk_visibility_change(
         api_key=api_key,
@@ -674,9 +693,12 @@ def delete_service(
         "--all",
         help="Delete all deletable services (draft, pending, review, rejected, suspended, deprecated).",
     ),
-    from_data: Path | None = _FROM_DATA_OPTION,
+    from_data: bool = _FROM_DATA_OPTION,
+    data_dir: Path = _DATA_DIR_OPTION,
     status: str | None = typer.Option(None, "--status", help="Restrict --all to a single deletable status."),
-    provider: str | None = typer.Option(None, "--provider", help="Filter by provider when --all is set."),
+    provider: str | None = typer.Option(
+        None, "--provider", help="Filter by provider when --all or --from-data is set."
+    ),
     dryrun: bool = typer.Option(False, "--dryrun", help="Show what would be deleted without doing it."),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
     api_key: str | None = api_key_option(),
@@ -701,7 +723,8 @@ def delete_service(
         statuses_when_all=statuses,
         provider=provider,
         flag_name="all",
-        from_data=from_data,
+        use_from_data=from_data,
+        data_dir=data_dir,
     )
 
     count = len(ids)

--- a/src/unitysvc_sellers/commands/services.py
+++ b/src/unitysvc_sellers/commands/services.py
@@ -363,34 +363,48 @@ def _resolve_or_fetch_ids(
     from_data: Path | None = None,
     visibilities_when_all: list[str] | None = None,
 ) -> list[str]:
-    """Validate args and either return the explicit ids or fetch by status.
+    """Resolve the target service IDs from exactly one of three mutually exclusive sources.
 
-    Three mutually exclusive sources (first match wins):
-    - ``from_data``: read service_ids from listing_v1 files under that directory.
-    - ``use_all``: fetch from the API filtered by status/visibility.
-    - explicit ``service_ids`` positional arguments.
+    Sources (in precedence order — only one may be active):
+    - explicit positional ``service_ids``
+    - ``--all``: fetch from the API filtered by status/visibility/provider.
+    - ``--from-data DIR``: read IDs from listing_v1 files; ``--provider``
+      filters by the ``provider_name`` field in each listing.
 
     ``visibilities_when_all`` further restricts the ``--all`` fetch to
-    services whose current visibility is in the given list. Used by
-    ``publish/unlist/hide --all`` to skip services that already have
-    the target visibility.
+    services whose current visibility is in the given list.
     """
+    # --- strict mutual exclusivity ---
+    modes = sum([bool(service_ids), use_all, from_data is not None])
+    if modes > 1:
+        console.print(
+            "[red]Error:[/red] --all, --from-data, and explicit service IDs are mutually exclusive. "
+            "Provide exactly one."
+        )
+        raise typer.Exit(code=1)
+
+    # --- --from-data: local listing_v1 files ---
     if from_data is not None:
         ids = _read_ids_from_data_dir(from_data)
+        if provider:
+            from unitysvc_core.utils import find_files_by_schema
+
+            provider_lower = provider.lower()
+            allowed = {
+                str(data["service_id"])
+                for _, _, data in find_files_by_schema(from_data, "listing_v1")
+                if provider_lower in (data.get("provider_name") or "").lower()
+                and data.get("service_id")
+            }
+            ids = [i for i in ids if i in allowed]
         if not ids:
             console.print("[yellow]No service IDs found in listing_v1 files under the given directory.[/yellow]")
             raise typer.Exit(code=0)
         console.print(f"[cyan]Found {len(ids)} service ID(s) from {from_data}[/cyan]\n")
         return ids
 
-    if provider and not use_all:
-        console.print(f"[red]Error:[/red] --provider can only be used with --{flag_name} flag")
-        raise typer.Exit(code=1)
-
+    # --- --all: remote API ---
     if use_all:
-        if service_ids:
-            console.print(f"[red]Error:[/red] Cannot specify both service IDs and --{flag_name}")
-            raise typer.Exit(code=1)
         msg = f"[cyan]Fetching services with status: {', '.join(statuses_when_all)}"
         if visibilities_when_all:
             msg += f", visibility: {', '.join(visibilities_when_all)}"
@@ -415,10 +429,15 @@ def _resolve_or_fetch_ids(
         console.print(f"[green]Found {len(ids)} service(s)[/green]\n")
         return ids
 
-    if not service_ids:
-        console.print(f"[red]Error:[/red] Either provide service IDs or use --{flag_name} flag")
+    # --- explicit IDs ---
+    if provider:
+        console.print("[red]Error:[/red] --provider requires --all or --from-data")
         raise typer.Exit(code=1)
-
+    if not service_ids:
+        console.print(
+            f"[red]Error:[/red] Provide service IDs, --{flag_name}, or --from-data"
+        )
+        raise typer.Exit(code=1)
     return list(service_ids)
 
 

--- a/src/unitysvc_sellers/commands/services.py
+++ b/src/unitysvc_sellers/commands/services.py
@@ -25,6 +25,7 @@ instead.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any
 

--- a/tests/test_services_from_data.py
+++ b/tests/test_services_from_data.py
@@ -17,7 +17,6 @@ import typer
 
 from unitysvc_sellers.commands.services import _read_ids_from_data_dir, _resolve_or_fetch_ids
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/tests/test_services_from_data.py
+++ b/tests/test_services_from_data.py
@@ -1,0 +1,199 @@
+"""Tests for ``--from-data`` / ``--data-dir`` in ``usvc_seller services``.
+
+Covers:
+- ``_read_ids_from_data_dir``: collects service_id from listing_v1 files,
+  including via merged override files; skips listings without a service_id.
+- ``_resolve_or_fetch_ids``: mutual exclusivity enforcement; --from-data path;
+  --provider filter in --from-data mode; explicit-IDs path.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import typer
+
+from unitysvc_sellers.commands.services import _read_ids_from_data_dir, _resolve_or_fetch_ids
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write_listing(path: Path, extra: dict | None = None) -> Path:
+    """Write a minimal listing_v1 JSON file, with optional extra fields."""
+    data: dict = {"schema": "listing_v1", "status": "ready"}
+    if extra:
+        data.update(extra)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data))
+    return path
+
+
+def _write_override(listing_path: Path, override: dict) -> Path:
+    """Write a <stem>.override.<ext> alongside the listing file."""
+    stem = listing_path.stem
+    suffix = listing_path.suffix
+    override_path = listing_path.with_name(f"{stem}.override{suffix}")
+    override_path.write_text(json.dumps(override))
+    return override_path
+
+
+# ---------------------------------------------------------------------------
+# _read_ids_from_data_dir
+# ---------------------------------------------------------------------------
+
+class TestReadIdsFromDataDir:
+    def test_single_listing_with_inline_service_id(self, tmp_path: Path) -> None:
+        _write_listing(
+            tmp_path / "acme" / "services" / "svc1" / "listing.json",
+            {"service_id": "aaa-111"},
+        )
+        assert _read_ids_from_data_dir(tmp_path) == ["aaa-111"]
+
+    def test_service_id_from_override_file(self, tmp_path: Path) -> None:
+        listing = _write_listing(tmp_path / "acme" / "services" / "svc1" / "listing.json")
+        _write_override(listing, {"service_id": "bbb-222"})
+        assert _read_ids_from_data_dir(tmp_path) == ["bbb-222"]
+
+    def test_listing_without_service_id_skipped(self, tmp_path: Path) -> None:
+        _write_listing(tmp_path / "acme" / "services" / "svc1" / "listing.json")
+        assert _read_ids_from_data_dir(tmp_path) == []
+
+    def test_multiple_listings_all_ids_collected(self, tmp_path: Path) -> None:
+        _write_listing(
+            tmp_path / "acme" / "services" / "svc1" / "listing.json",
+            {"service_id": "id-1"},
+        )
+        listing2 = _write_listing(tmp_path / "acme" / "services" / "svc2" / "listing.json")
+        _write_override(listing2, {"service_id": "id-2"})
+        _write_listing(tmp_path / "acme" / "services" / "svc3" / "listing.json")
+
+        ids = _read_ids_from_data_dir(tmp_path)
+        assert sorted(ids) == ["id-1", "id-2"]
+
+    def test_empty_directory_returns_empty(self, tmp_path: Path) -> None:
+        assert _read_ids_from_data_dir(tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# _resolve_or_fetch_ids — mutual exclusivity
+# ---------------------------------------------------------------------------
+
+class TestMutualExclusivity:
+    def _call(self, **kwargs) -> list[str]:
+        defaults = dict(
+            api_key=None,
+            base_url="https://api.example.test",
+            service_ids=None,
+            use_all=False,
+            statuses_when_all=["draft"],
+            provider=None,
+            flag_name="all",
+            use_from_data=False,
+            data_dir=Path("."),
+        )
+        defaults.update(kwargs)
+        return _resolve_or_fetch_ids(**defaults)
+
+    def test_ids_and_all_together_is_error(self, tmp_path: Path) -> None:
+        with pytest.raises(typer.Exit) as exc:
+            self._call(service_ids=["abc-123"], use_all=True)
+        assert exc.value.exit_code == 1
+
+    def test_ids_and_from_data_together_is_error(self, tmp_path: Path) -> None:
+        _write_listing(tmp_path / "p" / "services" / "s" / "listing.json", {"service_id": "x"})
+        with pytest.raises(typer.Exit) as exc:
+            self._call(service_ids=["abc-123"], use_from_data=True, data_dir=tmp_path)
+        assert exc.value.exit_code == 1
+
+    def test_all_and_from_data_together_is_error(self, tmp_path: Path) -> None:
+        _write_listing(tmp_path / "p" / "services" / "s" / "listing.json", {"service_id": "x"})
+        with pytest.raises(typer.Exit) as exc:
+            self._call(use_all=True, use_from_data=True, data_dir=tmp_path)
+        assert exc.value.exit_code == 1
+
+    def test_no_mode_and_no_ids_is_error(self) -> None:
+        with pytest.raises(typer.Exit) as exc:
+            self._call()
+        assert exc.value.exit_code == 1
+
+    def test_provider_without_all_or_from_data_is_error(self) -> None:
+        with pytest.raises(typer.Exit) as exc:
+            self._call(service_ids=["abc-123"], provider="acme")
+        assert exc.value.exit_code == 1
+
+    def test_explicit_ids_returned_directly(self) -> None:
+        result = self._call(service_ids=["id-a", "id-b"])
+        assert result == ["id-a", "id-b"]
+
+
+# ---------------------------------------------------------------------------
+# _resolve_or_fetch_ids — --from-data path
+# ---------------------------------------------------------------------------
+
+class TestResolveFromData:
+    def _call(self, data_dir: Path, provider: str | None = None) -> list[str]:
+        return _resolve_or_fetch_ids(
+            api_key=None,
+            base_url="https://api.example.test",
+            service_ids=None,
+            use_all=False,
+            statuses_when_all=["draft"],
+            provider=provider,
+            flag_name="all",
+            use_from_data=True,
+            data_dir=data_dir,
+        )
+
+    def test_ids_collected_from_listing_files(self, tmp_path: Path) -> None:
+        _write_listing(
+            tmp_path / "acme" / "services" / "svc1" / "listing.json",
+            {"service_id": "svc-001"},
+        )
+        assert self._call(tmp_path) == ["svc-001"]
+
+    def test_empty_dir_exits_with_zero(self, tmp_path: Path) -> None:
+        with pytest.raises(typer.Exit) as exc:
+            self._call(tmp_path)
+        assert exc.value.exit_code == 0
+
+    def test_provider_filter_keeps_matching(self, tmp_path: Path) -> None:
+        _write_listing(
+            tmp_path / "acme" / "services" / "svc1" / "listing.json",
+            {"service_id": "acme-001", "provider_name": "Acme Corp"},
+        )
+        _write_listing(
+            tmp_path / "other" / "services" / "svc2" / "listing.json",
+            {"service_id": "other-002", "provider_name": "Other Inc"},
+        )
+        result = self._call(tmp_path, provider="acme")
+        assert result == ["acme-001"]
+
+    def test_provider_filter_case_insensitive(self, tmp_path: Path) -> None:
+        _write_listing(
+            tmp_path / "acme" / "services" / "svc1" / "listing.json",
+            {"service_id": "acme-001", "provider_name": "ACME"},
+        )
+        result = self._call(tmp_path, provider="acme")
+        assert result == ["acme-001"]
+
+    def test_provider_filter_no_match_exits_zero(self, tmp_path: Path) -> None:
+        _write_listing(
+            tmp_path / "acme" / "services" / "svc1" / "listing.json",
+            {"service_id": "acme-001", "provider_name": "Acme Corp"},
+        )
+        with pytest.raises(typer.Exit) as exc:
+            self._call(tmp_path, provider="nobody")
+        assert exc.value.exit_code == 0
+
+    def test_service_id_from_override_is_included(self, tmp_path: Path) -> None:
+        listing = _write_listing(
+            tmp_path / "acme" / "services" / "svc1" / "listing.json",
+            {"provider_name": "Acme Corp"},
+        )
+        _write_override(listing, {"service_id": "from-override"})
+        result = self._call(tmp_path)
+        assert result == ["from-override"]


### PR DESCRIPTION
## Summary

- Adds `--from-data <dir>` option to `usvc_seller services submit`
- Reads `service_id` from `listing.override.{json,toml}` files under the given directory and submits exactly those services
- Avoids `--all` which is account-wide and would affect draft services across unrelated repos sharing the same seller account

## Motivation

The `upload-data` CI workflow in seller data repos needs to auto-submit after upload, but `--all` operates across the entire seller account (which manages 20+ repos via a shared API key). `--from-data data` scopes the submit to only the services in the current repo's data directory by reading their IDs from the override files written by the upload step.

## Workflow usage

\`\`\`yaml
- name: Upload services
  run: usvc_seller data upload

- name: Submit services for review
  run: usvc_seller services submit --from-data data --yes
\`\`\`

## Test plan

- [ ] `usvc_seller services submit --help` shows `--from-data`
- [ ] With override files present: submits exactly those service IDs
- [ ] With no override files: exits 0 with "No service IDs found" message
- [ ] Existing `--all` and explicit ID paths unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)