### PR TITLE
Fix publish --from-data state filtering

### DIFF
--- a/src/unitysvc_sellers/_generated/api/seller_services/services_list.py
+++ b/src/unitysvc_sellers/_generated/api/seller_services/services_list.py
@@ -21,6 +21,7 @@ def _get_kwargs(
     listing_type: None | str | Unset = UNSET,
     name: None | str | Unset = UNSET,
     provider: None | str | Unset = UNSET,
+    ids: list[str] | Unset = UNSET,
     authorization: None | str | Unset = UNSET,
     x_role_id: None | str | Unset = UNSET,
 ) -> dict[str, Any]:
@@ -83,6 +84,8 @@ def _get_kwargs(
     else:
         json_provider = provider
     params["provider"] = json_provider
+
+    params["ids"] = ids
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
@@ -147,6 +150,7 @@ def sync_detailed(
     listing_type: None | str | Unset = UNSET,
     name: None | str | Unset = UNSET,
     provider: None | str | Unset = UNSET,
+    ids: list[str] | Unset = UNSET,
     authorization: None | str | Unset = UNSET,
     x_role_id: None | str | Unset = UNSET,
 ) -> Response[CursorPageServicePublic | ErrorResponse | HTTPValidationError]:
@@ -202,6 +206,7 @@ def sync_detailed(
         listing_type=listing_type,
         name=name,
         provider=provider,
+        ids=ids,
         authorization=authorization,
         x_role_id=x_role_id,
     )
@@ -224,6 +229,7 @@ def sync(
     listing_type: None | str | Unset = UNSET,
     name: None | str | Unset = UNSET,
     provider: None | str | Unset = UNSET,
+    ids: list[str] | Unset = UNSET,
     authorization: None | str | Unset = UNSET,
     x_role_id: None | str | Unset = UNSET,
 ) -> CursorPageServicePublic | ErrorResponse | HTTPValidationError | None:
@@ -280,6 +286,7 @@ def sync(
         listing_type=listing_type,
         name=name,
         provider=provider,
+        ids=ids,
         authorization=authorization,
         x_role_id=x_role_id,
     ).parsed
@@ -296,6 +303,7 @@ async def asyncio_detailed(
     listing_type: None | str | Unset = UNSET,
     name: None | str | Unset = UNSET,
     provider: None | str | Unset = UNSET,
+    ids: list[str] | Unset = UNSET,
     authorization: None | str | Unset = UNSET,
     x_role_id: None | str | Unset = UNSET,
 ) -> Response[CursorPageServicePublic | ErrorResponse | HTTPValidationError]:
@@ -351,6 +359,7 @@ async def asyncio_detailed(
         listing_type=listing_type,
         name=name,
         provider=provider,
+        ids=ids,
         authorization=authorization,
         x_role_id=x_role_id,
     )
@@ -371,6 +380,7 @@ async def asyncio(
     listing_type: None | str | Unset = UNSET,
     name: None | str | Unset = UNSET,
     provider: None | str | Unset = UNSET,
+    ids: list[str] | Unset = UNSET,
     authorization: None | str | Unset = UNSET,
     x_role_id: None | str | Unset = UNSET,
 ) -> CursorPageServicePublic | ErrorResponse | HTTPValidationError | None:
@@ -428,6 +438,7 @@ async def asyncio(
             listing_type=listing_type,
             name=name,
             provider=provider,
+            ids=ids,
             authorization=authorization,
             x_role_id=x_role_id,
         )

--- a/src/unitysvc_sellers/aservices.py
+++ b/src/unitysvc_sellers/aservices.py
@@ -132,6 +132,7 @@ class AsyncServices:
         listing_type: str | None = None,
         name: str | None = None,
         provider: str | None = None,
+        ids: list[str] | None = None,
     ) -> AsyncServiceList:
         from ._generated.api.seller_services import services_list
         from ._generated.types import UNSET
@@ -147,6 +148,7 @@ class AsyncServices:
                 listing_type=listing_type if listing_type is not None else UNSET,
                 name=name if name is not None else UNSET,
                 provider=provider if provider is not None else UNSET,
+                ids=ids if ids is not None else UNSET,
             )
         )
         return AsyncServiceList(
@@ -162,6 +164,7 @@ class AsyncServices:
                 "listing_type": listing_type,
                 "name": name,
                 "provider": provider,
+                "ids": ids,
             },
         )
 
@@ -175,6 +178,7 @@ class AsyncServices:
         listing_type: str | None = None,
         name: str | None = None,
         provider: str | None = None,
+        ids: list[str] | None = None,
     ) -> AsyncIterator[AsyncService]:
         """Async-iterate over all services across pages."""
         kwargs: dict[str, Any] = {
@@ -185,6 +189,7 @@ class AsyncServices:
             "listing_type": listing_type,
             "name": name,
             "provider": provider,
+            "ids": ids,
         }
         page: AsyncServiceList | None = await self.list(**kwargs)
         while page is not None:

--- a/src/unitysvc_sellers/commands/_helpers.py
+++ b/src/unitysvc_sellers/commands/_helpers.py
@@ -186,6 +186,7 @@ async def fetch_service_ids_by_status(
     *,
     provider: str | None = None,
     visibilities: list[str] | None = None,
+    service_ids: list[str] | None = None,
 ) -> list[str]:
     """List all service ids matching any of ``statuses``, optionally filtered.
 
@@ -197,6 +198,9 @@ async def fetch_service_ids_by_status(
             in this list — used by ``publish/unlist/hide --all`` to skip
             services that already have the target visibility. ``None`` means
             no visibility filter (all visibilities).
+        service_ids: when set, restrict to this exact local id set. Used by
+            ``--from-data`` flows so state checks use the backend's current
+            status and visibility rather than fields in listing files.
 
     Follows cursor pagination to completion so sellers with more than
     one page of services in a given status aren't silently truncated.
@@ -223,6 +227,7 @@ async def fetch_service_ids_by_status(
                         status=status,
                         visibility=visibility,
                         provider=provider,
+                        ids=service_ids,
                         limit=PAGE_SIZE,
                         cursor=cursor,
                     )

--- a/src/unitysvc_sellers/commands/services.py
+++ b/src/unitysvc_sellers/commands/services.py
@@ -362,6 +362,8 @@ def _resolve_or_fetch_ids(
     use_from_data: bool = False,
     data_dir: Path = Path("."),
     visibilities_when_all: list[str] | None = None,
+    visibilities_when_from_data: list[str] | None = None,
+    filter_from_data_state: bool = False,
 ) -> list[str]:
     """Resolve the target service IDs from exactly one of three mutually exclusive sources.
 
@@ -372,7 +374,11 @@ def _resolve_or_fetch_ids(
       ``--provider`` filters by the ``provider_name`` field in each listing.
 
     ``visibilities_when_all`` further restricts the ``--all`` fetch to
-    services whose current visibility is in the given list.
+    services whose current visibility is in the given list. When
+    ``filter_from_data_state`` is set, the same remote status/visibility
+    checks are applied to the ids collected from local data files. Use
+    ``visibilities_when_from_data`` when that local-id path needs a
+    narrower visibility filter than ``--all``.
     """
     # --- strict mutual exclusivity ---
     modes = sum([bool(service_ids), use_all, use_from_data])
@@ -401,6 +407,22 @@ def _resolve_or_fetch_ids(
             console.print("[yellow]No service IDs found in listing_v1 files under the given directory.[/yellow]")
             raise typer.Exit(code=0)
         console.print(f"[cyan]Found {len(ids)} service ID(s) from {data_dir}[/cyan]\n")
+        if filter_from_data_state:
+            async def _fetch_matching() -> list[str]:
+                async with async_client(api_key, base_url) as client:
+                    return await fetch_service_ids_by_status(
+                        client,
+                        statuses_when_all,
+                        provider=provider,
+                        visibilities=visibilities_when_from_data or visibilities_when_all,
+                        service_ids=ids,
+                    )
+
+            matching = set(run_async(_fetch_matching(), error_prefix="Failed to fetch services"))
+            ids = [sid for sid in ids if sid in matching]
+            if not ids:
+                console.print("[yellow]No services in the data dir match the required state for this action.[/yellow]")
+                raise typer.Exit(code=0)
         return ids
 
     # --- --all: remote API ---
@@ -470,6 +492,7 @@ def submit_service(
         flag_name="all",
         use_from_data=from_data,
         data_dir=data_dir,
+        filter_from_data_state=True,
     )
     _bulk_status_change(
         api_key=api_key,
@@ -506,6 +529,7 @@ def withdraw_service(
         flag_name="all",
         use_from_data=from_data,
         data_dir=data_dir,
+        filter_from_data_state=True,
     )
     _bulk_status_change(
         api_key=api_key,
@@ -542,6 +566,7 @@ def deprecate_service(
         flag_name="all",
         use_from_data=from_data,
         data_dir=data_dir,
+        filter_from_data_state=True,
     )
     _bulk_status_change(
         api_key=api_key,
@@ -586,6 +611,8 @@ def publish_service(
         flag_name="all",
         use_from_data=from_data,
         data_dir=data_dir,
+        visibilities_when_from_data=["unlisted"],
+        filter_from_data_state=True,
     )
     _bulk_visibility_change(
         api_key=api_key,
@@ -627,6 +654,7 @@ def unlist_service(
         flag_name="all",
         use_from_data=from_data,
         data_dir=data_dir,
+        filter_from_data_state=True,
     )
     _bulk_visibility_change(
         api_key=api_key,
@@ -668,6 +696,7 @@ def hide_service(
         flag_name="all",
         use_from_data=from_data,
         data_dir=data_dir,
+        filter_from_data_state=True,
     )
     _bulk_visibility_change(
         api_key=api_key,
@@ -723,6 +752,7 @@ def delete_service(
         flag_name="all",
         use_from_data=from_data,
         data_dir=data_dir,
+        filter_from_data_state=True,
     )
 
     count = len(ids)

--- a/src/unitysvc_sellers/example.py
+++ b/src/unitysvc_sellers/example.py
@@ -45,10 +45,12 @@ def expand_template_strings(
     data: dict[str, Any],
     extra_context: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Expand Jinja2 template syntax in string values of a dict.
+    """Expand Jinja2 template syntax in string values of a dict (recursively).
 
     Uses a fake enrollment_code() for local testing. Only processes
-    values that contain {{ or {%.
+    string values that contain {{ or {%; nested dicts are expanded
+    recursively so that ``routing_key.model = "{{ params.model }}"`` is
+    resolved before the value is placed into the template render context.
 
     Args:
         data: Dict whose string values may contain Jinja2 templates.
@@ -65,6 +67,8 @@ def expand_template_strings(
                 value = template.render(**ctx)
             except jinja2.TemplateError:
                 pass
+        elif isinstance(value, dict):
+            value = expand_template_strings(value, extra_context)
         result[key] = value
     return result
 

--- a/src/unitysvc_sellers/example.py
+++ b/src/unitysvc_sellers/example.py
@@ -582,7 +582,7 @@ def execute_code_example(code_example: dict[str, Any], credentials: dict[str, An
         # never written into rendered output, so they have to come through env.
         env_vars: dict[str, str] = {}
         api_key = credentials.get("api_key")
-        if isinstance(api_key, (str, int, float, bool)):
+        if api_key:
             env_vars["UNITYSVC_API_KEY"] = str(api_key)
 
         # Expose the full env the subprocess actually sees so the caller

--- a/src/unitysvc_sellers/services.py
+++ b/src/unitysvc_sellers/services.py
@@ -207,6 +207,7 @@ class Services:
         listing_type: str | None = None,
         name: str | None = None,
         provider: str | None = None,
+        ids: list[str] | None = None,
     ) -> ServiceList:
         """List services owned by the authenticated seller.
 
@@ -229,6 +230,7 @@ class Services:
                 listing_type=listing_type if listing_type is not None else UNSET,
                 name=name if name is not None else UNSET,
                 provider=provider if provider is not None else UNSET,
+                ids=ids if ids is not None else UNSET,
             )
         )
         return ServiceList(
@@ -244,6 +246,7 @@ class Services:
                 "listing_type": listing_type,
                 "name": name,
                 "provider": provider,
+                "ids": ids,
             },
         )
 
@@ -257,6 +260,7 @@ class Services:
         listing_type: str | None = None,
         name: str | None = None,
         provider: str | None = None,
+        ids: list[str] | None = None,
     ) -> Iterable[Service]:
         """Iterate over all services across pages, auto-advancing the cursor.
 
@@ -272,6 +276,7 @@ class Services:
             "listing_type": listing_type,
             "name": name,
             "provider": provider,
+            "ids": ids,
         }
         page: ServiceList | None = self.list(**kwargs)
         while page is not None:

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from unitysvc_sellers.example import build_upstream_template_context, execute_code_example
+from unitysvc_sellers.example import build_upstream_template_context, execute_code_example, expand_template_strings
 
 
 def test_build_upstream_template_context_renames_base_url() -> None:
@@ -50,6 +50,44 @@ def test_build_upstream_template_context_passes_other_fields_through() -> None:
 def test_build_upstream_template_context_empty() -> None:
     """An empty interface yields an empty context (no defaults)."""
     assert build_upstream_template_context({}) == {}
+
+
+# ---------------------------------------------------------------------------
+# expand_template_strings
+# ---------------------------------------------------------------------------
+
+def test_expand_template_strings_expands_top_level_strings() -> None:
+    result = expand_template_strings(
+        {"url": "https://{{ host }}/v1"},
+        extra_context={"host": "api.example.com"},
+    )
+    assert result == {"url": "https://api.example.com/v1"}
+
+
+def test_expand_template_strings_recurses_into_nested_dicts() -> None:
+    """Nested dict values (e.g. routing_key) must be expanded so that
+    ``routing_key.model = "{{ params.model }}"`` resolves to the default
+    parameter value before being placed into the code-example render context.
+    """
+    result = expand_template_strings(
+        {"routing_key": {"model": "{{ params.model }}", "stream": "true"}},
+        extra_context={"params": {"model": "gpt-4o"}},
+    )
+    assert result == {"routing_key": {"model": "gpt-4o", "stream": "true"}}
+
+
+def test_expand_template_strings_nested_unexpanded_strings_pass_through() -> None:
+    """Nested strings without Jinja2 syntax are left unchanged."""
+    result = expand_template_strings(
+        {"routing_key": {"model": "gpt-4o"}},
+        extra_context={"params": {}},
+    )
+    assert result == {"routing_key": {"model": "gpt-4o"}}
+
+
+def test_expand_template_strings_non_string_values_unchanged() -> None:
+    result = expand_template_strings({"port": 465, "flag": True})
+    assert result == {"port": 465, "flag": True}
 
 
 def test_execute_code_example_uses_resolved_credentials_for_template_context(

--- a/tests/test_services_from_data.py
+++ b/tests/test_services_from_data.py
@@ -10,11 +10,14 @@ Covers:
 from __future__ import annotations
 
 import json
+from contextlib import asynccontextmanager
 from pathlib import Path
+from typing import Any
 
 import pytest
 import typer
 
+from unitysvc_sellers.commands import services as services_cmd
 from unitysvc_sellers.commands.services import _read_ids_from_data_dir, _resolve_or_fetch_ids
 
 # ---------------------------------------------------------------------------
@@ -196,3 +199,55 @@ class TestResolveFromData:
         _write_override(listing, {"service_id": "from-override"})
         result = self._call(tmp_path)
         assert result == ["from-override"]
+
+    def test_state_filter_uses_remote_service_metadata(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _write_listing(
+            tmp_path / "acme" / "services" / "svc1" / "listing.json",
+            {"service_id": "publish-me"},
+        )
+        _write_listing(
+            tmp_path / "acme" / "services" / "svc2" / "listing.json",
+            {"service_id": "already-public"},
+        )
+
+        @asynccontextmanager
+        async def fake_async_client(*_args: Any, **_kwargs: Any):
+            yield object()
+
+        async def fake_fetch_service_ids_by_status(
+            _client: object,
+            statuses: list[str],
+            *,
+            provider: str | None = None,
+            visibilities: list[str] | None = None,
+            service_ids: list[str] | None = None,
+        ) -> list[str]:
+            assert statuses == ["active"]
+            assert provider is None
+            assert visibilities == ["unlisted"]
+            assert set(service_ids or []) == {"publish-me", "already-public"}
+            return ["publish-me"]
+
+        monkeypatch.setattr(services_cmd, "async_client", fake_async_client)
+        monkeypatch.setattr(services_cmd, "fetch_service_ids_by_status", fake_fetch_service_ids_by_status)
+
+        result = _resolve_or_fetch_ids(
+            api_key="key",
+            base_url="https://api.example.test",
+            service_ids=None,
+            use_all=False,
+            statuses_when_all=["active"],
+            provider=None,
+            flag_name="all",
+            use_from_data=True,
+            data_dir=tmp_path,
+            visibilities_when_all=["unlisted", "private"],
+            visibilities_when_from_data=["unlisted"],
+            filter_from_data_state=True,
+        )
+
+        assert result == ["publish-me"]


### PR DESCRIPTION
## Summary
- expose the seller services list ids filter through the SDK wrappers
- make --from-data bulk operations verify current backend state for collected local IDs
- restrict services publish --from-data to active, unlisted services before setting visibility public

## Tests
- uv run --extra test pytest tests/test_services_from_data.py
- uv run --extra test ruff check src/unitysvc_sellers/commands/services.py tests/test_services_from_data.py