### PR TITLE
Restrict publish --from-data to active unlisted services

### DIFF
--- a/src/unitysvc_sellers/commands/services.py
+++ b/src/unitysvc_sellers/commands/services.py
@@ -468,6 +468,7 @@ def _resolve_or_fetch_ids(
     use_from_data: bool = False,
     data_dir: Path = Path("."),
     visibilities_when_all: list[str] | None = None,
+    visibilities_when_from_data: list[str] | None = None,
 ) -> list[str]:
     """Resolve the target service IDs from exactly one of three mutually exclusive sources.
 
@@ -482,7 +483,9 @@ def _resolve_or_fetch_ids(
       ran on a subset.
 
     ``visibilities_when_all`` further restricts the fetch to
-    services whose current visibility is in the given list.
+    services whose current visibility is in the given list. Use
+    ``visibilities_when_from_data`` when the local-id path needs a narrower
+    visibility filter than ``--all``.
     """
     # --- strict mutual exclusivity ---
     modes = sum([bool(service_ids), use_all, use_from_data])
@@ -525,7 +528,7 @@ def _resolve_or_fetch_ids(
                     client,
                     ids,
                     statuses=statuses_when_all,
-                    visibilities=visibilities_when_all,
+                    visibilities=visibilities_when_from_data or visibilities_when_all,
                 )
 
         eligible, skipped = run_async(
@@ -723,6 +726,7 @@ def publish_service(
         flag_name="all",
         use_from_data=from_data,
         data_dir=data_dir,
+        visibilities_when_from_data=["unlisted"],
     )
     _bulk_visibility_change(
         api_key=api_key,

--- a/tests/test_services_from_data.py
+++ b/tests/test_services_from_data.py
@@ -147,9 +147,13 @@ class TestResolveFromData:
 
     _BASE = "https://api.example.test"
 
-    def _setup_state(self, **id_to_status: str) -> None:
+    def _setup_state(self, **id_to_state: str | tuple[str, str]) -> None:
         """Mock ``GET /services/{id}`` responses with the given statuses."""
-        for sid, status in id_to_status.items():
+        for sid, state in id_to_state.items():
+            if isinstance(state, tuple):
+                status, visibility = state
+            else:
+                status, visibility = state, "public"
             _respx.get(f"{self._BASE}/services/{sid}").mock(
                 return_value=_httpx.Response(
                     200,
@@ -157,7 +161,7 @@ class TestResolveFromData:
                         "service_id": sid,
                         "service_name": "svc",
                         "status": status,
-                        "visibility": "public",
+                        "visibility": visibility,
                         "documents": [],
                         "interfaces": [],
                     },
@@ -170,6 +174,8 @@ class TestResolveFromData:
         provider: str | None = None,
         *,
         statuses_when_all: list[str] | None = None,
+        visibilities_when_all: list[str] | None = None,
+        visibilities_when_from_data: list[str] | None = None,
     ) -> list[str]:
         return _resolve_or_fetch_ids(
             api_key="svcpass_test",
@@ -181,6 +187,8 @@ class TestResolveFromData:
             flag_name="all",
             use_from_data=True,
             data_dir=data_dir,
+            visibilities_when_all=visibilities_when_all,
+            visibilities_when_from_data=visibilities_when_from_data,
         )
 
     @_respx.mock
@@ -261,6 +269,30 @@ class TestResolveFromData:
         # ``submit`` allows draft → pending only.
         result = self._call(tmp_path, statuses_when_all=["draft", "rejected"])
         assert result == ["drft-001"]
+
+    @_respx.mock
+    def test_from_data_can_use_narrower_visibility_filter(self, tmp_path: Path) -> None:
+        _write_listing(
+            tmp_path / "acme" / "services" / "svc1" / "listing.json",
+            {"service_id": "unlisted-001"},
+        )
+        _write_listing(
+            tmp_path / "acme" / "services" / "svc2" / "listing.json",
+            {"service_id": "private-002"},
+        )
+        self._setup_state(
+            **{
+                "unlisted-001": ("active", "unlisted"),
+                "private-002": ("active", "private"),
+            }
+        )
+        result = self._call(
+            tmp_path,
+            statuses_when_all=["active"],
+            visibilities_when_all=["unlisted", "private"],
+            visibilities_when_from_data=["unlisted"],
+        )
+        assert result == ["unlisted-001"]
 
     @_respx.mock
     def test_all_ids_filtered_out_exits_zero(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- keep the merged --from-data state inspection from #49
- allow the local-data path to use a narrower visibility filter than --all
- restrict services publish --from-data to active services currently visibility=unlisted

## Tests
- uv run --extra test pytest tests/test_services_from_data.py
- uv run --extra test ruff check src/unitysvc_sellers/commands/services.py tests/test_services_from_data.py