### PR TITLE
cli: rename --from-data to --local-ids; make it pick up revisions

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -464,7 +464,7 @@ Default mode uses cursor-based pagination over the seller&#x27;s full
 catalog: pass ``--cursor`` for a specific page or ``--all`` to follow
 cursors to completion.
 
-With ``--from-data``, only the services whose IDs are recorded in
+With ``--local-ids``, only the services whose IDs are recorded in
 ``listing.{json,toml}`` (or the merged ``listing.override.{json,toml}``)
 files under ``--data-dir`` are fetched and shown — handy for
 inspecting just the services managed by the current data repo
@@ -490,8 +490,8 @@ $ usvc_seller services list [OPTIONS]
 * `--provider TEXT`: Filter by provider name (case-insensitive partial match).
 * `--fields TEXT`: Comma-separated list of columns to display.  [default: id,name,provider_name,service_type,status,visibility]
 * `-f, --format TEXT`: Output format: table | json.  [default: table]
-* `--from-data`: Act on services whose IDs are found in listing_v1 files under --data-dir.
-* `--data-dir DIRECTORY`: Data directory for --from-data (default: current directory).  [default: .]
+* `-l, --local-ids`: Restrict to services whose IDs are recorded in listing_v1 files under --data-dir.
+* `--data-dir DIRECTORY`: Data directory for --local-ids (default: current directory).  [default: .]
 * `--api-key TEXT`: Seller API key (svcpass_...). Defaults to $UNITYSVC_SELLER_API_KEY.  [env var: UNITYSVC_SELLER_API_KEY]
 * `--base-url TEXT`: Backend base URL.  [env var: UNITYSVC_SELLER_API_URL; default: https://seller.unitysvc.com/v1]
 * `--help`: Show this message and exit.
@@ -534,9 +534,9 @@ $ usvc_seller services submit [OPTIONS] [SERVICE_IDS]...
 **Options**:
 
 * `--all`: Submit all draft and rejected services.
-* `--from-data`: Act on services whose IDs are found in listing_v1 files under --data-dir.
-* `--data-dir DIRECTORY`: Data directory for --from-data (default: current directory).  [default: .]
-* `--provider TEXT`: Filter by provider when --all or --from-data is set.
+* `-l, --local-ids`: Restrict to services whose IDs are recorded in listing_v1 files under --data-dir.
+* `--data-dir DIRECTORY`: Data directory for --local-ids (default: current directory).  [default: .]
+* `--provider TEXT`: Filter by provider when --all or --local-ids is set.
 * `-y, --yes`: Skip confirmation prompt.
 * `--api-key TEXT`: Seller API key (svcpass_...). Defaults to $UNITYSVC_SELLER_API_KEY.  [env var: UNITYSVC_SELLER_API_KEY]
 * `--base-url TEXT`: Backend base URL.  [env var: UNITYSVC_SELLER_API_URL; default: https://seller.unitysvc.com/v1]
@@ -559,9 +559,9 @@ $ usvc_seller services withdraw [OPTIONS] [SERVICE_IDS]...
 **Options**:
 
 * `--all`: Withdraw all pending and rejected services.
-* `--from-data`: Act on services whose IDs are found in listing_v1 files under --data-dir.
-* `--data-dir DIRECTORY`: Data directory for --from-data (default: current directory).  [default: .]
-* `--provider TEXT`: Filter by provider when --all or --from-data is set.
+* `-l, --local-ids`: Restrict to services whose IDs are recorded in listing_v1 files under --data-dir.
+* `--data-dir DIRECTORY`: Data directory for --local-ids (default: current directory).  [default: .]
+* `--provider TEXT`: Filter by provider when --all or --local-ids is set.
 * `-y, --yes`: Skip confirmation prompt.
 * `--api-key TEXT`: Seller API key (svcpass_...). Defaults to $UNITYSVC_SELLER_API_KEY.  [env var: UNITYSVC_SELLER_API_KEY]
 * `--base-url TEXT`: Backend base URL.  [env var: UNITYSVC_SELLER_API_URL; default: https://seller.unitysvc.com/v1]
@@ -584,9 +584,9 @@ $ usvc_seller services deprecate [OPTIONS] [SERVICE_IDS]...
 **Options**:
 
 * `--all`: Deprecate all active services.
-* `--from-data`: Act on services whose IDs are found in listing_v1 files under --data-dir.
-* `--data-dir DIRECTORY`: Data directory for --from-data (default: current directory).  [default: .]
-* `--provider TEXT`: Filter by provider when --all or --from-data is set.
+* `-l, --local-ids`: Restrict to services whose IDs are recorded in listing_v1 files under --data-dir.
+* `--data-dir DIRECTORY`: Data directory for --local-ids (default: current directory).  [default: .]
+* `--provider TEXT`: Filter by provider when --all or --local-ids is set.
 * `-y, --yes`: Skip confirmation prompt.
 * `--api-key TEXT`: Seller API key (svcpass_...). Defaults to $UNITYSVC_SELLER_API_KEY.  [env var: UNITYSVC_SELLER_API_KEY]
 * `--base-url TEXT`: Backend base URL.  [env var: UNITYSVC_SELLER_API_URL; default: https://seller.unitysvc.com/v1]
@@ -609,9 +609,9 @@ $ usvc_seller services publish [OPTIONS] [SERVICE_IDS]...
 **Options**:
 
 * `--all`: Publish all active services that aren&#x27;t already public.
-* `--from-data`: Act on services whose IDs are found in listing_v1 files under --data-dir.
-* `--data-dir DIRECTORY`: Data directory for --from-data (default: current directory).  [default: .]
-* `--provider TEXT`: Filter by provider when --all or --from-data is set.
+* `-l, --local-ids`: Restrict to services whose IDs are recorded in listing_v1 files under --data-dir.
+* `--data-dir DIRECTORY`: Data directory for --local-ids (default: current directory).  [default: .]
+* `--provider TEXT`: Filter by provider when --all or --local-ids is set.
 * `-y, --yes`: Skip confirmation prompt.
 * `--api-key TEXT`: Seller API key (svcpass_...). Defaults to $UNITYSVC_SELLER_API_KEY.  [env var: UNITYSVC_SELLER_API_KEY]
 * `--base-url TEXT`: Backend base URL.  [env var: UNITYSVC_SELLER_API_URL; default: https://seller.unitysvc.com/v1]
@@ -634,9 +634,9 @@ $ usvc_seller services unlist [OPTIONS] [SERVICE_IDS]...
 **Options**:
 
 * `--all`: Unlist all active services that aren&#x27;t already unlisted.
-* `--from-data`: Act on services whose IDs are found in listing_v1 files under --data-dir.
-* `--data-dir DIRECTORY`: Data directory for --from-data (default: current directory).  [default: .]
-* `--provider TEXT`: Filter by provider when --all or --from-data is set.
+* `-l, --local-ids`: Restrict to services whose IDs are recorded in listing_v1 files under --data-dir.
+* `--data-dir DIRECTORY`: Data directory for --local-ids (default: current directory).  [default: .]
+* `--provider TEXT`: Filter by provider when --all or --local-ids is set.
 * `-y, --yes`: Skip confirmation prompt.
 * `--api-key TEXT`: Seller API key (svcpass_...). Defaults to $UNITYSVC_SELLER_API_KEY.  [env var: UNITYSVC_SELLER_API_KEY]
 * `--base-url TEXT`: Backend base URL.  [env var: UNITYSVC_SELLER_API_URL; default: https://seller.unitysvc.com/v1]
@@ -659,9 +659,9 @@ $ usvc_seller services hide [OPTIONS] [SERVICE_IDS]...
 **Options**:
 
 * `--all`: Hide all active services that aren&#x27;t already private.
-* `--from-data`: Act on services whose IDs are found in listing_v1 files under --data-dir.
-* `--data-dir DIRECTORY`: Data directory for --from-data (default: current directory).  [default: .]
-* `--provider TEXT`: Filter by provider when --all or --from-data is set.
+* `-l, --local-ids`: Restrict to services whose IDs are recorded in listing_v1 files under --data-dir.
+* `--data-dir DIRECTORY`: Data directory for --local-ids (default: current directory).  [default: .]
+* `--provider TEXT`: Filter by provider when --all or --local-ids is set.
 * `-y, --yes`: Skip confirmation prompt.
 * `--api-key TEXT`: Seller API key (svcpass_...). Defaults to $UNITYSVC_SELLER_API_KEY.  [env var: UNITYSVC_SELLER_API_KEY]
 * `--base-url TEXT`: Backend base URL.  [env var: UNITYSVC_SELLER_API_URL; default: https://seller.unitysvc.com/v1]
@@ -684,10 +684,10 @@ $ usvc_seller services delete [OPTIONS] [SERVICE_IDS]...
 **Options**:
 
 * `--all`: Delete all deletable services (draft, pending, review, rejected, suspended, deprecated).
-* `--from-data`: Act on services whose IDs are found in listing_v1 files under --data-dir.
-* `--data-dir DIRECTORY`: Data directory for --from-data (default: current directory).  [default: .]
+* `-l, --local-ids`: Restrict to services whose IDs are recorded in listing_v1 files under --data-dir.
+* `--data-dir DIRECTORY`: Data directory for --local-ids (default: current directory).  [default: .]
 * `--status TEXT`: Restrict --all to a single deletable status.
-* `--provider TEXT`: Filter by provider when --all or --from-data is set.
+* `--provider TEXT`: Filter by provider when --all or --local-ids is set.
 * `--dryrun`: Show what would be deleted without doing it.
 * `-y, --yes`: Skip confirmation prompt.
 * `--api-key TEXT`: Seller API key (svcpass_...). Defaults to $UNITYSVC_SELLER_API_KEY.  [env var: UNITYSVC_SELLER_API_KEY]

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -773,30 +773,30 @@ flowchart LR
 
 The CLI handles this order automatically. Incorrect order will result in foreign key errors.
 
-## Bulk Operations with --from-data
+## Bulk Operations with --local-ids
 
 After running `usvc_seller data upload`, each listing file gets a `listing.override.json`
 (or `.override.toml`) written alongside it containing the backend-assigned `service_id`.
-The `--from-data` flag on all bulk service commands reads those IDs automatically, so you
+The `--local-ids` flag on all bulk service commands reads those IDs automatically, so you
 don't have to copy-paste UUIDs from the upload output.
 
 ```bash
 # Submit all services whose override files live under the current directory
-usvc_seller services submit --from-data --yes
+usvc_seller services submit --local-ids --yes
 
 # Withdraw services for a specific provider only
-usvc_seller services withdraw --from-data --provider acme --yes
+usvc_seller services withdraw --local-ids --provider acme --yes
 
 # Submit services whose listing files are in a data/ subdirectory
-usvc_seller services submit --from-data --data-dir data --yes
+usvc_seller services submit --local-ids --data-dir data --yes
 
 # Publish all active services in a data subdirectory
-usvc_seller services publish --from-data --data-dir ./data --yes
+usvc_seller services publish --local-ids --data-dir ./data --yes
 ```
 
 ### How it works
 
-1. `--from-data` tells the command to scan for `listing_v1` files under `--data-dir`
+1. `--local-ids` tells the command to scan for `listing_v1` files under `--data-dir`
    (default: current directory).
 2. For each listing file found, the corresponding `*.override.*` file is merged in
    automatically. The `service_id` field from the merged result is collected.
@@ -825,19 +825,19 @@ usvc_seller services publish --from-data --data-dir ./data --yes
   env:
     UNITYSVC_SELLER_API_KEY: ${{ secrets.UNITYSVC_SELLER_API_KEY }}
     UNITYSVC_SELLER_API_URL: ${{ secrets.UNITYSVC_SELLER_API_URL }}
-  run: usvc_seller services submit --from-data --data-dir data --yes
+  run: usvc_seller services submit --local-ids --data-dir data --yes
 ```
 
 ### Mutual exclusivity
 
-`--from-data`, `--all`, and explicit service ID arguments are mutually exclusive.
+`--local-ids`, `--all`, and explicit service ID arguments are mutually exclusive.
 Only one source may be active per invocation.
 
 | Source | When to use |
 |--------|-------------|
 | Explicit IDs | You know the exact UUIDs |
 | `--all` | Operate on all services in the seller account matching a status/visibility |
-| `--from-data` | Operate on services whose listings live in the local data directory |
+| `--local-ids` | Restrict to services whose IDs are recorded in local listing files |
 
 ## Deleting Services
 

--- a/src/unitysvc_sellers/commands/services.py
+++ b/src/unitysvc_sellers/commands/services.py
@@ -48,13 +48,13 @@ from ._helpers import (
     run_async,
 )
 
-_FROM_DATA_OPTION = typer.Option(
-    False, "--from-data",
-    help="Act on services whose IDs are found in listing_v1 files under --data-dir.",
+_LOCAL_IDS_OPTION = typer.Option(
+    False, "--local-ids", "-l",
+    help="Restrict to services whose IDs are recorded in listing_v1 files under --data-dir.",
 )
 _DATA_DIR_OPTION = typer.Option(
     Path("."), "--data-dir",
-    help="Data directory for --from-data (default: current directory).",
+    help="Data directory for --local-ids (default: current directory).",
     exists=True, file_okay=False, dir_okay=True,
 )
 
@@ -112,7 +112,7 @@ def list_services(
         help="Comma-separated list of columns to display.",
     ),
     output_format: str = typer.Option("table", "--format", "-f", help="Output format: table | json."),
-    from_data: bool = _FROM_DATA_OPTION,
+    local_ids: bool = _LOCAL_IDS_OPTION,
     data_dir: Path = _DATA_DIR_OPTION,
     api_key: str | None = api_key_option(),
     base_url: str = base_url_option(),
@@ -123,7 +123,7 @@ def list_services(
     catalog: pass ``--cursor`` for a specific page or ``--all`` to follow
     cursors to completion.
 
-    With ``--from-data``, only the services whose IDs are recorded in
+    With ``--local-ids``, only the services whose IDs are recorded in
     ``listing.{json,toml}`` (or the merged ``listing.override.{json,toml}``)
     files under ``--data-dir`` are fetched and shown — handy for
     inspecting just the services managed by the current data repo
@@ -138,7 +138,7 @@ def list_services(
 
         collected: list[dict[str, Any]] = []
         async with async_client(api_key, base_url) as client:
-            if from_data:
+            if local_ids:
                 raw_ids = _read_ids_from_data_dir(data_dir)
                 if not raw_ids:
                     console.print(
@@ -407,52 +407,61 @@ async def _filter_ids_by_state(
     statuses: list[str],
     visibilities: list[str] | None,
 ) -> tuple[list[str], list[tuple[str, str]]]:
-    """Fetch each id and partition into (eligible, skipped).
+    """Resolve eligible service ids for a state-restricted action.
 
-    ``--all`` filters by status/visibility *server-side* via the list
-    endpoint, so the action only ever runs on services the operation
-    is actually valid for. ``--from-data`` starts from a fixed local
-    set, so we mirror that filtering on the client by fetching each
-    service and inspecting its current state.
+    Uses the seller list endpoint with the ``ids`` filter (one round-trip,
+    follows cursors for large data dirs).  Crucially, the backend expands
+    ``ids`` to also include any service whose ``revision_of`` matches one
+    of the requested ids (see backend PR #915), so submitting against a
+    data dir of active services correctly picks up their pending draft
+    revisions.  Status / visibility filtering is applied client-side
+    against the returned set so callers can pass multiple acceptable
+    statuses in one call.
 
     Returns:
-        A ``(eligible, skipped)`` tuple where ``eligible`` is the list of
-        ids whose ``status`` is in ``statuses`` and (if provided)
-        ``visibility`` is in ``visibilities``, and ``skipped`` is a list
-        of ``(id, reason)`` pairs for everything filtered out (wrong state)
-        or unreachable (404 / network error). The caller is expected to
-        surface these so the operator knows why the action ran on a subset.
+        A ``(eligible, skipped)`` tuple. ``skipped`` only contains
+        ``(id, reason)`` pairs for the rare list-endpoint failures
+        (network / auth) — those are real problems the caller should
+        surface. State / visibility mismatches are silently dropped;
+        the summary ``Eligible: X of Y`` count makes the partition
+        obvious without per-id noise.
     """
-    import asyncio
+    from uuid import UUID
 
-    async def _check(sid: str) -> tuple[str, str | None, str | None, str | None]:
-        try:
-            svc = model_to_dict(await client.services.get(sid))
-            return (
-                sid,
-                str(svc.get("status") or "") or None,
-                str(svc.get("visibility") or "") or None,
-                None,
-            )
-        except SellerSDKError as exc:
-            return (sid, None, None, f"could not fetch: {exc}")
+    uuid_ids = [UUID(sid) for sid in ids]
+    # Page size is capped at 200 server-side; if the data dir + their
+    # revisions exceed that we'll follow cursors below.
+    page_limit = min(max(len(uuid_ids) * 2, 50), 200)
 
-    results = await asyncio.gather(*(_check(sid) for sid in ids))
     eligible: list[str] = []
     skipped: list[tuple[str, str]] = []
-    for sid, status, vis, fetch_err in results:
-        if fetch_err:
-            skipped.append((sid, fetch_err))
-            continue
-        if status not in statuses:
-            skipped.append((sid, f"status={status!r}, expected one of {statuses}"))
-            continue
-        if visibilities and vis not in visibilities:
-            skipped.append(
-                (sid, f"visibility={vis!r}, expected one of {visibilities}")
+    current_cursor: str | None = None
+    try:
+        while True:
+            response = await client.services.list(
+                ids=uuid_ids,
+                limit=page_limit,
+                cursor=current_cursor,
             )
-            continue
-        eligible.append(sid)
+            for svc in model_list(response):
+                row = svc if isinstance(svc, dict) else model_to_dict(svc)
+                status = (str(row.get("status") or "")) or None
+                vis = (str(row.get("visibility") or "")) or None
+                if status not in statuses:
+                    continue
+                if visibilities and vis not in visibilities:
+                    continue
+                sid = row.get("id")
+                if sid:
+                    eligible.append(str(sid))
+            next_cursor = getattr(response, "next_cursor", None)
+            has_more = getattr(response, "has_more", False)
+            if not has_more or not next_cursor:
+                break
+            current_cursor = str(next_cursor)
+    except SellerSDKError as exc:
+        skipped.append(("?", f"could not list services: {exc}"))
+
     return eligible, skipped
 
 
@@ -465,7 +474,7 @@ def _resolve_or_fetch_ids(
     statuses_when_all: list[str],
     provider: str | None,
     flag_name: str,
-    use_from_data: bool = False,
+    use_local_ids: bool = False,
     data_dir: Path = Path("."),
     visibilities_when_all: list[str] | None = None,
 ) -> list[str]:
@@ -475,26 +484,27 @@ def _resolve_or_fetch_ids(
     - explicit positional ``service_ids`` — used as-is, no state check.
     - ``--all``: fetch from the API filtered server-side by
       status/visibility/provider, so only eligible services are returned.
-    - ``--from-data``: read IDs from listing_v1 files under ``data_dir``,
-      then fetch each and apply the *same* status/visibility filter
-      ``--all`` would have applied server-side. Skipped services are
-      reported with a reason so the operator can see why the action
-      ran on a subset.
+    - ``--local-ids``: read IDs from listing_v1 files under ``data_dir``
+      and resolve them via the seller list endpoint with the ``ids``
+      filter (which the backend expands to also include any pending
+      revisions of the requested ids — see backend PR #915). The same
+      status/visibility filter ``--all`` would have applied server-side
+      is then applied client-side against the returned set.
 
     ``visibilities_when_all`` further restricts the fetch to
     services whose current visibility is in the given list.
     """
     # --- strict mutual exclusivity ---
-    modes = sum([bool(service_ids), use_all, use_from_data])
+    modes = sum([bool(service_ids), use_all, use_local_ids])
     if modes > 1:
         console.print(
-            "[red]Error:[/red] --all, --from-data, and explicit service IDs are mutually exclusive. "
+            "[red]Error:[/red] --all, --local-ids, and explicit service IDs are mutually exclusive. "
             "Provide exactly one."
         )
         raise typer.Exit(code=1)
 
-    # --- --from-data: local listing_v1 files ---
-    if use_from_data:
+    # --- --local-ids: local listing_v1 files ---
+    if use_local_ids:
         ids = _read_ids_from_data_dir(data_dir)
         if provider:
             from unitysvc_core.utils import find_files_by_schema
@@ -517,7 +527,7 @@ def _resolve_or_fetch_ids(
         # is valid for.  Without this step the action runs on the whole
         # local set and the operator gets a wall of 400s for services
         # that were never going to be eligible (e.g. ``submit
-        # --from-data`` against a repo with already-active services
+        # --local-ids`` against a repo with already-active services
         # would always 400 on those).
         async def _filter_local() -> tuple[list[str], list[tuple[str, str]]]:
             async with async_client(api_key, base_url) as client:
@@ -568,11 +578,11 @@ def _resolve_or_fetch_ids(
 
     # --- explicit IDs ---
     if provider:
-        console.print("[red]Error:[/red] --provider requires --all or --from-data")
+        console.print("[red]Error:[/red] --provider requires --all or --local-ids")
         raise typer.Exit(code=1)
     if not service_ids:
         console.print(
-            f"[red]Error:[/red] Provide service IDs, --{flag_name}, or --from-data"
+            f"[red]Error:[/red] Provide service IDs, --{flag_name}, or --local-ids"
         )
         raise typer.Exit(code=1)
     return list(service_ids)
@@ -587,10 +597,10 @@ def _resolve_or_fetch_ids(
 def submit_service(
     service_ids: list[str] = typer.Argument(None, help="Service ID(s) to submit (≥8 chars)."),
     all_drafts: bool = typer.Option(False, "--all", help="Submit all draft and rejected services."),
-    from_data: bool = _FROM_DATA_OPTION,
+    local_ids: bool = _LOCAL_IDS_OPTION,
     data_dir: Path = _DATA_DIR_OPTION,
     provider: str | None = typer.Option(
-        None, "--provider", help="Filter by provider when --all or --from-data is set."
+        None, "--provider", help="Filter by provider when --all or --local-ids is set."
     ),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
     api_key: str | None = api_key_option(),
@@ -605,7 +615,7 @@ def submit_service(
         statuses_when_all=["draft", "rejected"],
         provider=provider,
         flag_name="all",
-        use_from_data=from_data,
+        use_local_ids=local_ids,
         data_dir=data_dir,
     )
     _bulk_status_change(
@@ -623,10 +633,10 @@ def submit_service(
 def withdraw_service(
     service_ids: list[str] = typer.Argument(None, help="Service ID(s) to withdraw (≥8 chars)."),
     all_pending: bool = typer.Option(False, "--all", help="Withdraw all pending and rejected services."),
-    from_data: bool = _FROM_DATA_OPTION,
+    local_ids: bool = _LOCAL_IDS_OPTION,
     data_dir: Path = _DATA_DIR_OPTION,
     provider: str | None = typer.Option(
-        None, "--provider", help="Filter by provider when --all or --from-data is set."
+        None, "--provider", help="Filter by provider when --all or --local-ids is set."
     ),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
     api_key: str | None = api_key_option(),
@@ -641,7 +651,7 @@ def withdraw_service(
         statuses_when_all=["pending", "rejected"],
         provider=provider,
         flag_name="all",
-        use_from_data=from_data,
+        use_local_ids=local_ids,
         data_dir=data_dir,
     )
     _bulk_status_change(
@@ -659,10 +669,10 @@ def withdraw_service(
 def deprecate_service(
     service_ids: list[str] = typer.Argument(None, help="Service ID(s) to deprecate (≥8 chars)."),
     all_active: bool = typer.Option(False, "--all", help="Deprecate all active services."),
-    from_data: bool = _FROM_DATA_OPTION,
+    local_ids: bool = _LOCAL_IDS_OPTION,
     data_dir: Path = _DATA_DIR_OPTION,
     provider: str | None = typer.Option(
-        None, "--provider", help="Filter by provider when --all or --from-data is set."
+        None, "--provider", help="Filter by provider when --all or --local-ids is set."
     ),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
     api_key: str | None = api_key_option(),
@@ -677,7 +687,7 @@ def deprecate_service(
         statuses_when_all=["active"],
         provider=provider,
         flag_name="all",
-        use_from_data=from_data,
+        use_local_ids=local_ids,
         data_dir=data_dir,
     )
     _bulk_status_change(
@@ -702,10 +712,10 @@ def publish_service(
         "--all",
         help="Publish all active services that aren't already public.",
     ),
-    from_data: bool = _FROM_DATA_OPTION,
+    local_ids: bool = _LOCAL_IDS_OPTION,
     data_dir: Path = _DATA_DIR_OPTION,
     provider: str | None = typer.Option(
-        None, "--provider", help="Filter by provider when --all or --from-data is set."
+        None, "--provider", help="Filter by provider when --all or --local-ids is set."
     ),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
     api_key: str | None = api_key_option(),
@@ -721,7 +731,7 @@ def publish_service(
         visibilities_when_all=["unlisted", "private"],
         provider=provider,
         flag_name="all",
-        use_from_data=from_data,
+        use_local_ids=local_ids,
         data_dir=data_dir,
     )
     _bulk_visibility_change(
@@ -743,10 +753,10 @@ def unlist_service(
         "--all",
         help="Unlist all active services that aren't already unlisted.",
     ),
-    from_data: bool = _FROM_DATA_OPTION,
+    local_ids: bool = _LOCAL_IDS_OPTION,
     data_dir: Path = _DATA_DIR_OPTION,
     provider: str | None = typer.Option(
-        None, "--provider", help="Filter by provider when --all or --from-data is set."
+        None, "--provider", help="Filter by provider when --all or --local-ids is set."
     ),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
     api_key: str | None = api_key_option(),
@@ -762,7 +772,7 @@ def unlist_service(
         visibilities_when_all=["public", "private"],
         provider=provider,
         flag_name="all",
-        use_from_data=from_data,
+        use_local_ids=local_ids,
         data_dir=data_dir,
     )
     _bulk_visibility_change(
@@ -784,10 +794,10 @@ def hide_service(
         "--all",
         help="Hide all active services that aren't already private.",
     ),
-    from_data: bool = _FROM_DATA_OPTION,
+    local_ids: bool = _LOCAL_IDS_OPTION,
     data_dir: Path = _DATA_DIR_OPTION,
     provider: str | None = typer.Option(
-        None, "--provider", help="Filter by provider when --all or --from-data is set."
+        None, "--provider", help="Filter by provider when --all or --local-ids is set."
     ),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
     api_key: str | None = api_key_option(),
@@ -803,7 +813,7 @@ def hide_service(
         visibilities_when_all=["public", "unlisted"],
         provider=provider,
         flag_name="all",
-        use_from_data=from_data,
+        use_local_ids=local_ids,
         data_dir=data_dir,
     )
     _bulk_visibility_change(
@@ -828,11 +838,11 @@ def delete_service(
         "--all",
         help="Delete all deletable services (draft, pending, review, rejected, suspended, deprecated).",
     ),
-    from_data: bool = _FROM_DATA_OPTION,
+    local_ids: bool = _LOCAL_IDS_OPTION,
     data_dir: Path = _DATA_DIR_OPTION,
     status: str | None = typer.Option(None, "--status", help="Restrict --all to a single deletable status."),
     provider: str | None = typer.Option(
-        None, "--provider", help="Filter by provider when --all or --from-data is set."
+        None, "--provider", help="Filter by provider when --all or --local-ids is set."
     ),
     dryrun: bool = typer.Option(False, "--dryrun", help="Show what would be deleted without doing it."),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
@@ -858,7 +868,7 @@ def delete_service(
         statuses_when_all=statuses,
         provider=provider,
         flag_name="all",
-        use_from_data=from_data,
+        use_local_ids=local_ids,
         data_dir=data_dir,
     )
 

--- a/tests/test_services_local_ids.py
+++ b/tests/test_services_local_ids.py
@@ -1,10 +1,10 @@
-"""Tests for ``--from-data`` / ``--data-dir`` in ``usvc_seller services``.
+"""Tests for ``--local-ids`` / ``--data-dir`` in ``usvc_seller services``.
 
 Covers:
 - ``_read_ids_from_data_dir``: collects service_id from listing_v1 files,
   including via merged override files; skips listings without a service_id.
-- ``_resolve_or_fetch_ids``: mutual exclusivity enforcement; --from-data path;
-  --provider filter in --from-data mode; explicit-IDs path.
+- ``_resolve_or_fetch_ids``: mutual exclusivity enforcement; --local-ids path;
+  --provider filter in --local-ids mode; explicit-IDs path.
 """
 
 from __future__ import annotations
@@ -26,6 +26,13 @@ from unitysvc_sellers.commands.services import _read_ids_from_data_dir, _resolve
 # Helpers
 # ---------------------------------------------------------------------------
 
+# Fixed UUIDs used by the list-mode mocks (``_filter_ids_by_state`` casts the
+# ``ids`` list through ``UUID(sid)`` before passing them to the SDK, so test
+# fixtures must look like real UUIDs).
+_UUID_A = "11111111-1111-1111-1111-111111111111"
+_UUID_B = "22222222-2222-2222-2222-222222222222"
+
+
 def _write_listing(path: Path, extra: dict | None = None) -> Path:
     """Write a minimal listing_v1 JSON file, with optional extra fields."""
     data: dict = {"schema": "listing_v1", "status": "ready"}
@@ -43,6 +50,29 @@ def _write_override(listing_path: Path, override: dict) -> Path:
     override_path = listing_path.with_name(f"{stem}.override{suffix}")
     override_path.write_text(json.dumps(override))
     return override_path
+
+
+def _list_page(items: list[dict], *, has_more: bool = False, next_cursor: str | None = None) -> dict:
+    """Build a CursorPageServicePublic-shaped list response payload."""
+    return {"data": items, "has_more": has_more, "next_cursor": next_cursor}
+
+
+def _public_payload(service_id: str, **overrides) -> dict:
+    """Build a ServicePublic-shaped payload for list endpoint mocks."""
+    return {
+        "id": service_id,
+        "name": overrides.pop("name", "svc"),
+        "status": overrides.pop("status", "active"),
+        "visibility": overrides.pop("visibility", "public"),
+        "provider_name": overrides.pop("provider_name", "acme"),
+        "service_type": overrides.pop("service_type", "llm"),
+        "display_name": None,
+        "created_at": "2024-01-01T00:00:00Z",
+        "seller_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "offering_id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+        "listing_id": "cccccccc-cccc-cccc-cccc-cccccccccccc",
+        **overrides,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -96,7 +126,7 @@ class TestMutualExclusivity:
             statuses_when_all=["draft"],
             provider=None,
             flag_name="all",
-            use_from_data=False,
+            use_local_ids=False,
             data_dir=Path("."),
         )
         defaults.update(kwargs)
@@ -107,16 +137,16 @@ class TestMutualExclusivity:
             self._call(service_ids=["abc-123"], use_all=True)
         assert exc.value.exit_code == 1
 
-    def test_ids_and_from_data_together_is_error(self, tmp_path: Path) -> None:
+    def test_ids_and_local_ids_together_is_error(self, tmp_path: Path) -> None:
         _write_listing(tmp_path / "p" / "services" / "s" / "listing.json", {"service_id": "x"})
         with pytest.raises(typer.Exit) as exc:
-            self._call(service_ids=["abc-123"], use_from_data=True, data_dir=tmp_path)
+            self._call(service_ids=["abc-123"], use_local_ids=True, data_dir=tmp_path)
         assert exc.value.exit_code == 1
 
-    def test_all_and_from_data_together_is_error(self, tmp_path: Path) -> None:
+    def test_all_and_local_ids_together_is_error(self, tmp_path: Path) -> None:
         _write_listing(tmp_path / "p" / "services" / "s" / "listing.json", {"service_id": "x"})
         with pytest.raises(typer.Exit) as exc:
-            self._call(use_all=True, use_from_data=True, data_dir=tmp_path)
+            self._call(use_all=True, use_local_ids=True, data_dir=tmp_path)
         assert exc.value.exit_code == 1
 
     def test_no_mode_and_no_ids_is_error(self) -> None:
@@ -124,7 +154,7 @@ class TestMutualExclusivity:
             self._call()
         assert exc.value.exit_code == 1
 
-    def test_provider_without_all_or_from_data_is_error(self) -> None:
+    def test_provider_without_all_or_local_ids_is_error(self) -> None:
         with pytest.raises(typer.Exit) as exc:
             self._call(service_ids=["abc-123"], provider="acme")
         assert exc.value.exit_code == 1
@@ -135,34 +165,26 @@ class TestMutualExclusivity:
 
 
 # ---------------------------------------------------------------------------
-# _resolve_or_fetch_ids — --from-data path
+# _resolve_or_fetch_ids — --local-ids path
 # ---------------------------------------------------------------------------
+#
+# ``_filter_ids_by_state`` now resolves eligible ids via a single
+# ``services.list(ids=...)`` call (the backend expands the filter to also
+# include any service whose ``revision_of`` matches a requested id — see
+# backend PR #915).  Status / visibility filtering is then applied
+# client-side.  Tests mock the ``GET /services`` list endpoint accordingly.
 
-class TestResolveFromData:
-    """``--from-data`` reads ids from the data dir, then fetches each
-    service and filters by ``statuses_when_all`` so the action runs only
-    on services in the right starting state — same contract as ``--all``,
-    just sourced from local data instead of a server-side list query.
-    """
+_BASE = "https://api.example.test"
 
-    _BASE = "https://api.example.test"
 
-    def _setup_state(self, **id_to_status: str) -> None:
-        """Mock ``GET /services/{id}`` responses with the given statuses."""
-        for sid, status in id_to_status.items():
-            _respx.get(f"{self._BASE}/services/{sid}").mock(
-                return_value=_httpx.Response(
-                    200,
-                    json={
-                        "service_id": sid,
-                        "service_name": "svc",
-                        "status": status,
-                        "visibility": "public",
-                        "documents": [],
-                        "interfaces": [],
-                    },
-                )
-            )
+class TestResolveLocalIds:
+    """``--local-ids`` reads ids from the data dir, then resolves them via
+    the seller list endpoint (one round-trip, follows cursors)."""
+
+    def _mock_list(self, *items: dict) -> None:
+        _respx.get(f"{_BASE}/services").mock(
+            return_value=_httpx.Response(200, json=_list_page(list(items))),
+        )
 
     def _call(
         self,
@@ -173,13 +195,13 @@ class TestResolveFromData:
     ) -> list[str]:
         return _resolve_or_fetch_ids(
             api_key="svcpass_test",
-            base_url=self._BASE,
+            base_url=_BASE,
             service_ids=None,
             use_all=False,
             statuses_when_all=statuses_when_all or ["draft"],
             provider=provider,
             flag_name="all",
-            use_from_data=True,
+            use_local_ids=True,
             data_dir=data_dir,
         )
 
@@ -187,10 +209,10 @@ class TestResolveFromData:
     def test_ids_collected_from_listing_files(self, tmp_path: Path) -> None:
         _write_listing(
             tmp_path / "acme" / "services" / "svc1" / "listing.json",
-            {"service_id": "svc-001"},
+            {"service_id": _UUID_A},
         )
-        self._setup_state(**{"svc-001": "draft"})
-        assert self._call(tmp_path) == ["svc-001"]
+        self._mock_list(_public_payload(_UUID_A, status="draft"))
+        assert self._call(tmp_path) == [_UUID_A]
 
     def test_empty_dir_exits_with_zero(self, tmp_path: Path) -> None:
         with pytest.raises(typer.Exit) as exc:
@@ -201,30 +223,31 @@ class TestResolveFromData:
     def test_provider_filter_keeps_matching(self, tmp_path: Path) -> None:
         _write_listing(
             tmp_path / "acme" / "services" / "svc1" / "listing.json",
-            {"service_id": "acme-001", "provider_name": "Acme Corp"},
+            {"service_id": _UUID_A, "provider_name": "Acme Corp"},
         )
         _write_listing(
             tmp_path / "other" / "services" / "svc2" / "listing.json",
-            {"service_id": "other-002", "provider_name": "Other Inc"},
+            {"service_id": _UUID_B, "provider_name": "Other Inc"},
         )
-        self._setup_state(**{"acme-001": "draft", "other-002": "draft"})
+        # Only the acme id reaches the list call (provider filter trims locally).
+        self._mock_list(_public_payload(_UUID_A, status="draft"))
         result = self._call(tmp_path, provider="acme")
-        assert result == ["acme-001"]
+        assert result == [_UUID_A]
 
     @_respx.mock
     def test_provider_filter_case_insensitive(self, tmp_path: Path) -> None:
         _write_listing(
             tmp_path / "acme" / "services" / "svc1" / "listing.json",
-            {"service_id": "acme-001", "provider_name": "ACME"},
+            {"service_id": _UUID_A, "provider_name": "ACME"},
         )
-        self._setup_state(**{"acme-001": "draft"})
+        self._mock_list(_public_payload(_UUID_A, status="draft"))
         result = self._call(tmp_path, provider="acme")
-        assert result == ["acme-001"]
+        assert result == [_UUID_A]
 
     def test_provider_filter_no_match_exits_zero(self, tmp_path: Path) -> None:
         _write_listing(
             tmp_path / "acme" / "services" / "svc1" / "listing.json",
-            {"service_id": "acme-001", "provider_name": "Acme Corp"},
+            {"service_id": _UUID_A, "provider_name": "Acme Corp"},
         )
         with pytest.raises(typer.Exit) as exc:
             self._call(tmp_path, provider="nobody")
@@ -236,72 +259,48 @@ class TestResolveFromData:
             tmp_path / "acme" / "services" / "svc1" / "listing.json",
             {"provider_name": "Acme Corp"},
         )
-        _write_override(listing, {"service_id": "from-override"})
-        self._setup_state(**{"from-override": "draft"})
+        _write_override(listing, {"service_id": _UUID_A})
+        self._mock_list(_public_payload(_UUID_A, status="draft"))
         result = self._call(tmp_path)
-        assert result == ["from-override"]
+        assert result == [_UUID_A]
 
     @_respx.mock
     def test_status_filter_drops_ineligible_services(self, tmp_path: Path) -> None:
-        """The whole point of mirroring ``--all``'s server-side filter
-        on the client when ``--from-data`` is set: services in the
-        wrong state get skipped instead of producing 400s downstream
-        (e.g. ``submit --from-data`` against a repo that mixes
-        ``draft`` and ``active`` services).
-        """
+        """``submit --local-ids`` allows draft → pending only.  When the
+        list call returns both an ``active`` and a ``draft`` service, only
+        the draft is eligible; the active one is silently filtered out."""
         _write_listing(
             tmp_path / "acme" / "services" / "svc1" / "listing.json",
-            {"service_id": "drft-001"},
+            {"service_id": _UUID_A},
         )
         _write_listing(
             tmp_path / "acme" / "services" / "svc2" / "listing.json",
-            {"service_id": "actv-002"},
+            {"service_id": _UUID_B},
         )
-        self._setup_state(**{"drft-001": "draft", "actv-002": "active"})
-        # ``submit`` allows draft → pending only.
+        self._mock_list(
+            _public_payload(_UUID_A, status="draft"),
+            _public_payload(_UUID_B, status="active"),
+        )
         result = self._call(tmp_path, statuses_when_all=["draft", "rejected"])
-        assert result == ["drft-001"]
+        assert result == [_UUID_A]
 
     @_respx.mock
     def test_all_ids_filtered_out_exits_zero(self, tmp_path: Path) -> None:
         _write_listing(
             tmp_path / "acme" / "services" / "svc1" / "listing.json",
-            {"service_id": "actv-001"},
+            {"service_id": _UUID_A},
         )
-        self._setup_state(**{"actv-001": "active"})
+        self._mock_list(_public_payload(_UUID_A, status="active"))
         with pytest.raises(typer.Exit) as exc:
             self._call(tmp_path, statuses_when_all=["draft", "rejected"])
         assert exc.value.exit_code == 0
 
 
 # ---------------------------------------------------------------------------
-# CLI: ``services list --from-data``
+# CLI: ``services list --local-ids``
 # ---------------------------------------------------------------------------
 
 _BASE_URL = "https://seller.test.unitysvc"
-
-
-def _list_page(items: list[dict], *, has_more: bool = False, next_cursor: str | None = None) -> dict:
-    """Build a CursorPageServicePublic-shaped list response payload."""
-    return {"data": items, "has_more": has_more, "next_cursor": next_cursor}
-
-
-def _public_payload(service_id: str, **overrides) -> dict:
-    """Build a ServicePublic-shaped payload for list endpoint mocks."""
-    return {
-        "id": service_id,
-        "name": overrides.pop("name", "svc"),
-        "status": overrides.pop("status", "active"),
-        "visibility": overrides.pop("visibility", "public"),
-        "provider_name": overrides.pop("provider_name", "acme"),
-        "service_type": overrides.pop("service_type", "llm"),
-        "display_name": None,
-        "created_at": "2024-01-01T00:00:00Z",
-        "seller_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-        "offering_id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
-        "listing_id": "cccccccc-cccc-cccc-cccc-cccccccccccc",
-        **overrides,
-    }
 
 
 @pytest.fixture
@@ -315,8 +314,8 @@ def _env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("UNITYSVC_SELLER_API_URL", _BASE_URL)
 
 
-class TestListFromData:
-    """``services list --from-data`` reads ids from the local data dir and
+class TestListLocalIds:
+    """``services list --local-ids`` reads ids from the local data dir and
     calls ``GET /services?ids=...`` rather than paging the full catalog."""
 
     @_respx.mock
@@ -325,19 +324,19 @@ class TestListFromData:
     ) -> None:
         _write_listing(
             tmp_path / "acme" / "services" / "svc1" / "listing.json",
-            {"service_id": "11111111-1111-1111-1111-111111111111"},
+            {"service_id": _UUID_A},
         )
         _write_listing(
             tmp_path / "acme" / "services" / "svc2" / "listing.json",
-            {"service_id": "22222222-2222-2222-2222-222222222222"},
+            {"service_id": _UUID_B},
         )
 
         _respx.get(f"{_BASE_URL}/services").mock(
             return_value=_httpx.Response(
                 200,
                 json=_list_page([
-                    _public_payload("11111111-1111-1111-1111-111111111111", name="alpha"),
-                    _public_payload("22222222-2222-2222-2222-222222222222", name="beta"),
+                    _public_payload(_UUID_A, name="alpha"),
+                    _public_payload(_UUID_B, name="beta"),
                 ]),
             )
         )
@@ -349,7 +348,7 @@ class TestListFromData:
             _cli_app,
             [
                 "services", "list",
-                "--from-data", "--data-dir", str(tmp_path),
+                "--local-ids", "--data-dir", str(tmp_path),
                 "--format", "json",
             ],
         )
@@ -366,7 +365,7 @@ class TestListFromData:
     ) -> None:
         result = _runner.invoke(
             _cli_app,
-            ["services", "list", "--from-data", "--data-dir", str(tmp_path)],
+            ["services", "list", "--local-ids", "--data-dir", str(tmp_path)],
         )
 
         assert result.exit_code == 0
@@ -380,11 +379,11 @@ class TestListFromData:
         endpoint returns only the matching services."""
         _write_listing(
             tmp_path / "acme" / "services" / "svc1" / "listing.json",
-            {"service_id": "11111111-1111-1111-1111-111111111111"},
+            {"service_id": _UUID_A},
         )
         _write_listing(
             tmp_path / "acme" / "services" / "svc2" / "listing.json",
-            {"service_id": "22222222-2222-2222-2222-222222222222"},
+            {"service_id": _UUID_B},
         )
 
         # Backend returns only the active service (as it would for ?status=active).
@@ -392,11 +391,7 @@ class TestListFromData:
             return_value=_httpx.Response(
                 200,
                 json=_list_page([
-                    _public_payload(
-                        "11111111-1111-1111-1111-111111111111",
-                        name="alpha",
-                        status="active",
-                    ),
+                    _public_payload(_UUID_A, name="alpha", status="active"),
                 ]),
             )
         )
@@ -405,7 +400,7 @@ class TestListFromData:
             _cli_app,
             [
                 "services", "list",
-                "--from-data", "--data-dir", str(tmp_path),
+                "--local-ids", "--data-dir", str(tmp_path),
                 "--status", "active",
                 "--format", "json",
             ],
@@ -425,11 +420,11 @@ class TestListFromData:
         because the backend silently omits IDs it doesn't know about."""
         _write_listing(
             tmp_path / "acme" / "services" / "svc1" / "listing.json",
-            {"service_id": "11111111-1111-1111-1111-111111111111"},
+            {"service_id": _UUID_A},
         )
         _write_listing(
             tmp_path / "acme" / "services" / "svc2" / "listing.json",
-            {"service_id": "22222222-2222-2222-2222-222222222222"},
+            {"service_id": _UUID_B},
         )
 
         # Backend silently omits the second id (deleted / not found).
@@ -437,7 +432,7 @@ class TestListFromData:
             return_value=_httpx.Response(
                 200,
                 json=_list_page([
-                    _public_payload("11111111-1111-1111-1111-111111111111", name="alpha"),
+                    _public_payload(_UUID_A, name="alpha"),
                 ]),
             )
         )
@@ -446,7 +441,7 @@ class TestListFromData:
             _cli_app,
             [
                 "services", "list",
-                "--from-data", "--data-dir", str(tmp_path),
+                "--local-ids", "--data-dir", str(tmp_path),
                 "--format", "json",
             ],
         )


### PR DESCRIPTION
## Summary

Two changes that ship together because they touch the same code path:

### 1. Rename `--from-data` → `--local-ids`

`--from-data` was opaque ("from what data?"). The flag's actual meaning is *restrict the operation's scope to services whose IDs are recorded in local listing_v1 files under \`--data-dir\`*. `--local-ids` says exactly that. Help text, docstrings, error messages, `docs/workflows.md`, and the auto-generated `docs/cli-reference.md` are all updated. Tests renamed from `test_services_from_data.py` → `test_services_local_ids.py`.

### 2. `--local-ids` now picks up pending revisions

After backend PR unitysvc/unitysvc#915 the seller list endpoint expands `ids=` to also return services whose `revision_of` matches a requested id. But `_filter_ids_by_state` was doing N parallel `services.get()` calls on each local id and filtering client-side — bypassing the id-expansion entirely.

Result: a data dir tracking 15 active services + 1 pending revision would correctly show all 16 in `services list --local-ids`, but `services submit --local-ids` would fail with "No services match the required state" because the revision id wasn't in the local file set and never reached the filter.

Switch `_filter_ids_by_state` to a single `client.services.list(ids=local_ids)` call (cursor-paged for large dirs), then filter status/visibility client-side:

- revisions picked up automatically — server does the `revision_of` join
- N round-trips collapse to 1 in the common case (≤ 200 services)
- per-id \`⊘ skipping\` wall of text disappears as a side-effect; the existing `Eligible: X of Y` summary already conveys the partition
- fetch failures still surface as `(?, \"could not list services: ...\")` so network/auth errors aren't hidden

## Before
\`\`\`
\$ usvc_seller services submit --from-data
Found 15 service ID(s) from .
⊘ skipping e7df2770…: status='active', expected one of ['draft', 'rejected']
... (14 more lines)
No services in the data dir match the required state for this action.
\`\`\`

## After
\`\`\`
\$ usvc_seller services submit --local-ids
Found 15 service ID(s) from .
Eligible: 1 of 15 service(s)
[submits the pending revision...]
\`\`\`

## Test plan
- [x] all 23 tests in `test_services_local_ids.py` pass (rewritten to mock the list endpoint)
- [x] ruff + mypy clean
- [ ] `services submit --local-ids` against a repo with 1 pending revision picks it up
- [ ] `services publish --local-ids` against an all-active repo prints just the summary
- [ ] Fetch errors (e.g. invalid api key) still surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)