### PR TITLE
services run-tests: stop writing .env reproduction artifact

### DIFF
--- a/src/unitysvc_sellers/commands/tests.py
+++ b/src/unitysvc_sellers/commands/tests.py
@@ -712,17 +712,14 @@ def run_tests(
                         console.print(f"      [yellow]→ saved:[/yellow] {path}")
                     except Exception as write_err:
                         console.print(f"      [yellow]⚠ could not write {path}: {write_err}[/yellow]")
-                env_path = f"{base}.env"
-                env_vars: dict[str, str] = iface_entry.get("env_vars") or {}
-                try:
-                    Path(env_path).write_text(
-                        "".join(f"{k}={v}\n" for k, v in env_vars.items()),
-                        encoding="utf-8",
-                    )
-                    console.print(f"      [yellow]→ saved:[/yellow] {env_path}")
-                    console.print(f"      [dim]  (source to reproduce: source {env_path})[/dim]")
-                except Exception as write_err:
-                    console.print(f"      [yellow]⚠ could not write {env_path}: {write_err}[/yellow]")
+                # Reproduce with: ``UNITYSVC_API_KEY=... bash failed_*.sh``.
+                # We deliberately don't dump a ``.env`` here even though
+                # ``UNITYSVC_API_KEY`` is the only var the script needs:
+                # the value already lives in the operator's shell env (it
+                # had to, to run this command), so writing it to a file
+                # just widens the secret's escape surface — a stray
+                # ``.env`` next to listing files in a data repo can end
+                # up committed, zipped into a bug report, or backed up.
 
         if entry.get("update_warning"):
             console.print(f"      [yellow](result upload failed: {entry['update_warning']})[/yellow]")


### PR DESCRIPTION
## Summary

When `usvc_seller services run-tests` fails, it writes a `.env` next to the script/stdout/stderr artifacts containing `UNITYSVC_API_KEY` — the only env var the rendered scripts need. But the operator already had `UNITYSVC_API_KEY` in their shell env when they ran the command (it had to be set, otherwise the test wouldn't have authenticated), so the file adds no new information. All it does is widen the secret's escape surface: a stray `.env` sitting in a data-repo cwd can be committed, zipped into a bug report, or backed up — none of which the in-memory env var risks.

## After

Reproduction is the same minus one step:

```bash
# Before: source failed_*.env && bash failed_*.sh
# After:  bash failed_*.sh   (UNITYSVC_API_KEY is already in your shell)
```

If the operator is in a fresh shell, they `export UNITYSVC_API_KEY=...` themselves — same as they would for any other tool.

## Out of scope

The parallel `data run-tests` path in `example.py` writes a materially different `.env` (resolved upstream secrets, enrollment vars, base URLs pulled from the seller's local secrets store, not just an env-var passthrough). That's a more serious concern and should be handled separately — flagged in the commit message.

## Test plan
- [x] ruff + mypy clean
- [x] full pytest suite passes (118/118)
- [ ] `services run-tests` against a failing test no longer writes `failed_*.env`

🤖 Generated with [Claude Code](https://claude.com/claude-code)