### PR TITLE
populate: format generated files in-place + release v0.1.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "unitysvc-sellers"
-version = "0.1.9"
+version = "0.1.10"
 description = "Seller-facing tools for UnitySVC: HTTP SDK + usvc_seller CLI"
 readme = "README.md"
 authors = [{ name = "Bo Peng", email = "bo.peng@unitysvc.com" }]
@@ -18,7 +18,7 @@ classifiers = [
 ]
 dependencies = [
   "unitysvc-core>=0.1.8",
-  "unitysvc-data>=0.1.10",
+  "unitysvc-data>=0.1.18",
   "typer",
   "rich",
   "jinja2",

--- a/src/unitysvc_sellers/format_data.py
+++ b/src/unitysvc_sellers/format_data.py
@@ -1,5 +1,6 @@
 """Format command - format data files."""
 
+import json as json_lib
 from pathlib import Path
 
 import typer
@@ -9,29 +10,26 @@ app = typer.Typer(help="Format data files")
 console = Console()
 
 
-@app.command()
-def format_data(
-    data_dir: Path | None = typer.Argument(
-        None,
-        help="Directory containing data files to format (default: current directory)",
-    ),
-    check_only: bool = typer.Option(
-        False,
-        "--check",
-        help="Check if files are formatted without modifying them",
-    ),
-):
-    """
-    Format data files (JSON, TOML, MD) to match pre-commit requirements.
+def format_data_files(data_dir: Path | None, *, check_only: bool = False) -> bool:
+    """Format every JSON / TOML / MD file under ``data_dir`` to match
+    the pre-commit / format-check pipeline's expectations:
 
-    This command:
-    - Formats JSON files with 2-space indentation
-    - Removes trailing whitespace
-    - Ensures files end with a newline
-    - Validates TOML syntax
-    """
-    import json as json_lib
+    - JSON files are re-emitted with sorted keys, 2-space indent, and a
+      trailing newline.
+    - All file types have trailing whitespace stripped from each line and
+      land with exactly one trailing newline.
 
+    Returns ``True`` when every file is already in the canonical form
+    (or, in ``check_only`` mode, would be).  Returns ``False`` when one
+    or more files needed formatting (and were rewritten unless
+    ``check_only`` is set), or when one or more files failed to parse.
+
+    Pure function — no Typer machinery.  Internal callers (e.g. the
+    ``populate`` post-step) invoke this directly so they don't have to
+    worry about ``typer.Option`` defaults leaking through as
+    ``OptionInfo`` instances when the function is called outside the
+    CLI entry point.
+    """
     # Set data directory
     if data_dir is None:
         data_dir = Path.cwd()
@@ -41,7 +39,7 @@ def format_data(
 
     if not data_dir.exists():
         console.print(f"[red]✗[/red] Data directory not found: {data_dir}", style="bold red")
-        raise typer.Exit(code=1)
+        return False
 
     console.print(f"[blue]{'Checking' if check_only else 'Formatting'} files in:[/blue] {data_dir}\n")
 
@@ -52,13 +50,13 @@ def format_data(
 
     if not all_files:
         console.print("[yellow]No files found to format.[/yellow]")
-        return
+        return True
 
     console.print(f"[cyan]Found {len(all_files)} file(s) to process[/cyan]\n")
 
     files_formatted = 0
-    files_with_issues = []
-    files_failed = []
+    files_with_issues: list[str] = []
+    files_failed: list[str] = []
 
     for file_path in sorted(all_files):
         try:
@@ -67,7 +65,7 @@ def format_data(
                 original_content = f.read()
 
             modified_content = original_content
-            changes = []
+            changes: list[str] = []
 
             # Format based on file type
             if file_path.suffix == ".json":
@@ -136,5 +134,30 @@ def format_data(
     if files_failed:
         console.print(f"  [red]✗ Failed: {len(files_failed)}[/red]")
 
-    if files_failed or (check_only and files_with_issues):
+    return not (files_failed or (check_only and files_with_issues))
+
+
+@app.command()
+def format_data(
+    data_dir: Path | None = typer.Argument(
+        None,
+        help="Directory containing data files to format (default: current directory)",
+    ),
+    check_only: bool = typer.Option(
+        False,
+        "--check",
+        help="Check if files are formatted without modifying them",
+    ),
+):
+    """
+    Format data files (JSON, TOML, MD) to match pre-commit requirements.
+
+    This command:
+    - Formats JSON files with 2-space indentation
+    - Removes trailing whitespace
+    - Ensures files end with a newline
+    - Validates TOML syntax
+    """
+    ok = format_data_files(data_dir, check_only=check_only)
+    if not ok:
         raise typer.Exit(code=1)

--- a/src/unitysvc_sellers/populate.py
+++ b/src/unitysvc_sellers/populate.py
@@ -10,7 +10,7 @@ import json5
 import typer
 from rich.console import Console
 
-from .format_data import format_data
+from .format_data import format_data_files
 from .utils import find_files_by_schema
 
 app = typer.Typer(help="Populate services")
@@ -251,8 +251,14 @@ def populate(
         console.print("[dim]Running automatic formatting to ensure data conforms to format specification[/dim]\n")
 
         try:
-            # Run format command on the data directory
-            format_data(data_dir)
+            # Format in-place (``check_only=False``).  Calling the
+            # plain helper rather than the Typer-decorated ``format_data``
+            # command — calling that as a function leaks
+            # ``typer.Option(False)`` defaults through as ``OptionInfo``
+            # objects, which evaluate truthy and silently turn the post-
+            # populate format pass into a check-only run that never
+            # rewrites the generated files.
+            format_data_files(data_dir, check_only=False)
             console.print("\n[green]✓ Formatting completed successfully[/green]")
         except Exception as e:
             console.print(f"\n[yellow]⚠ Warning: Formatting failed: {e}[/yellow]")

--- a/tests/test_format_data.py
+++ b/tests/test_format_data.py
@@ -1,0 +1,114 @@
+"""Tests for ``unitysvc_sellers.format_data``.
+
+Locks in the post-populate post-step regression: the plain
+``format_data_files`` helper must actually rewrite files when
+``check_only=False``, and the Typer-decorated ``format_data`` command
+must keep working as a CLI entry point.
+"""
+
+import json
+from pathlib import Path
+
+from unitysvc_sellers.format_data import format_data_files
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+class TestFormatDataFiles:
+    """Direct unit tests for the plain helper used by ``populate``."""
+
+    def test_rewrites_json_with_sorted_keys_and_trailing_newline(
+        self, tmp_path: Path
+    ) -> None:
+        f = tmp_path / "listing.json"
+        _write(f, '{"name":"x","a":1}')  # unsorted, no trailing newline
+
+        ok = format_data_files(tmp_path, check_only=False)
+
+        assert ok is True
+        # Sorted keys, 2-space indent, trailing newline.
+        assert f.read_text() == '{\n  "a": 1,\n  "name": "x"\n}\n'
+
+    def test_already_formatted_is_idempotent(self, tmp_path: Path) -> None:
+        f = tmp_path / "listing.json"
+        canonical = '{\n  "a": 1,\n  "b": 2\n}\n'
+        _write(f, canonical)
+
+        ok = format_data_files(tmp_path, check_only=False)
+
+        assert ok is True
+        assert f.read_text() == canonical
+
+    def test_check_only_does_not_rewrite(self, tmp_path: Path) -> None:
+        f = tmp_path / "listing.json"
+        original = '{"b":1,"a":2}'
+        _write(f, original)
+
+        ok = format_data_files(tmp_path, check_only=True)
+
+        # File would need formatting → check returns False.
+        assert ok is False
+        # …but the file is left exactly as we wrote it.
+        assert f.read_text() == original
+
+    def test_check_only_passes_when_already_formatted(
+        self, tmp_path: Path
+    ) -> None:
+        f = tmp_path / "listing.json"
+        _write(f, '{\n  "a": 1\n}\n')
+
+        ok = format_data_files(tmp_path, check_only=True)
+
+        assert ok is True
+
+    def test_strips_trailing_whitespace_from_md(self, tmp_path: Path) -> None:
+        f = tmp_path / "doc.md"
+        _write(f, "# Title  \n\nbody  \n")  # trailing spaces
+
+        ok = format_data_files(tmp_path, check_only=False)
+
+        assert ok is True
+        assert f.read_text() == "# Title\n\nbody\n"
+
+    def test_invalid_json_returns_false(self, tmp_path: Path) -> None:
+        f = tmp_path / "listing.json"
+        _write(f, "{not valid json")
+
+        ok = format_data_files(tmp_path, check_only=False)
+
+        assert ok is False
+        # File is left untouched on parse failure.
+        assert f.read_text() == "{not valid json"
+
+
+class TestFormatDataDoesNotLeakTyperDefaults:
+    """Regression: previously ``populate.py`` called the Typer-decorated
+    ``format_data(data_dir)`` as a regular function, and the
+    ``check_only: bool = typer.Option(False, ...)`` default leaked
+    through as an ``OptionInfo`` instance — which is truthy under
+    Python's default ``__bool__``, silently turning every
+    post-populate format pass into a no-op check-only run.
+
+    The fix is to call the plain ``format_data_files`` helper.  These
+    tests lock that contract in: the helper takes a real ``bool``,
+    not a ``typer.Option`` default, and writes when ``check_only=False``.
+    """
+
+    def test_helper_does_not_take_typer_option_defaults(
+        self, tmp_path: Path
+    ) -> None:
+        # Calling without the kwarg uses the helper's plain ``bool`` default
+        # (``False``) and therefore writes — proving no Typer ``OptionInfo``
+        # leak.
+        f = tmp_path / "listing.json"
+        _write(f, '{"b":1,"a":2}')
+
+        format_data_files(tmp_path)  # no check_only kwarg
+
+        # File got rewritten — would not happen if check_only had defaulted
+        # to a truthy ``OptionInfo``.
+        assert json.loads(f.read_text()) == {"a": 2, "b": 1}
+        assert f.read_text().endswith("\n")


### PR DESCRIPTION
Two commits on this branch:

1. ``populate: actually format generated files (was silently a no-op check)``
2. ``release: v0.1.10``

## Symptom (commit 1)
``usvc_seller data populate`` runs an automatic format pass over the data directory after every populator script executes — but the pass was a no-op check.  Every populate run produced files that the format-check workflow then flagged on the very auto-PR populate had just created.

Repro: <https://github.com/unitysvc-labs/unitysvc-services-parasail/actions/runs/25325658647/job/74245664850>

```
✗ Would format: data/parasail/services/Cydonia-24B-v4.1/listing.json
  Changes: reformatted JSON, added end-of-file newline
```

## Root cause
``populate.py`` imported ``format_data`` from ``format_data.py`` and called it as ``format_data(data_dir)``.  ``format_data`` is a Typer-decorated CLI command:

```python
@app.command()
def format_data(
    data_dir: Path | None = typer.Argument(None, ...),
    check_only: bool = typer.Option(False, "--check", ...),
): ...
```

When a Typer-decorated function is called as a regular Python function, the ``typer.Argument`` / ``typer.Option`` defaults **leak through as ``ArgumentInfo`` / ``OptionInfo`` instances** rather than being resolved to ``None`` / ``False``.  ``OptionInfo`` has no custom ``__bool__`` → Python's default ``object.__bool__`` returns ``True`` → ``if check_only:`` enters the check-only branch → the function logs "Would format" lines and returns without writing.

```python
>>> import typer
>>> def f(check_only: bool = typer.Option(False, "--check")): print(type(check_only), bool(check_only))
>>> f()
<class 'typer.models.OptionInfo'> True
```

## Fix (commit 1)
Extract the formatting logic into a plain ``format_data_files(data_dir, *, check_only=False)`` helper that takes a real ``bool`` and returns success / failure.  The Typer command becomes a thin wrapper that calls the helper and maps its return into a ``typer.Exit``.  ``populate.py`` calls the helper directly so the post-populate format pass actually rewrites generated files.

## Release (commit 2)
- Bump ``unitysvc-sellers`` from ``0.1.9`` to ``0.1.10``.
- Bump the ``unitysvc-data`` floor from ``>=0.1.10`` to ``>=0.1.18`` to pull in the parameter-substitution / preset-version-prefix mechanism the recent provider catalogs (cohere transcription / image-embed, ollama BYOE installed-tag map) depend on at populate time.
- ``unitysvc-core`` stays at ``>=0.1.8`` (already at the latest published release).

## Test plan
- [x] 7 new unit tests in ``tests/test_format_data.py`` cover both modes (write / check-only), idempotency, MD trailing-whitespace handling, invalid-JSON passthrough, and a regression guard verifying the helper's default behaviour writes (would not happen if Typer's ``OptionInfo(False)`` leaked through).
- [x] All 199 existing tests still pass.
- [x] Manually verified ``usvc_seller data format /path`` (writes in-place) and ``usvc_seller data format /path --check`` (reports without modifying) still work as CLI entry points.
- [ ] After merge + 0.1.10 release: re-run any populate-services workflow with a dirty catalog (e.g. parasail) and confirm the format-check workflow on the auto-PR is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)