### PR TITLE
services: replace publish/unlist/hide with set-visibility VISIBILITY (v0.1.11)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -426,7 +426,7 @@ $ usvc_seller data list listings [OPTIONS] [DATA_DIR]
 
 ## `usvc_seller services`
 
-Remote service operations (list, show, submit, withdraw, deprecate, publish, unlist, hide, delete, update).
+Remote service operations (list, show, submit, withdraw, deprecate, set-visibility, delete, update).
 
 **Usage**:
 
@@ -445,9 +445,7 @@ $ usvc_seller services [OPTIONS] COMMAND [ARGS]...
 * `submit`: Submit services for review (draft|rejected...
 * `withdraw`: Withdraw services back to draft...
 * `deprecate`: Mark services as deprecated.
-* `publish`: Set visibility to public (visible in the...
-* `unlist`: Set visibility to unlisted (accessible by...
-* `hide`: Set visibility to private (hidden from all...
+* `set-visibility`: Set the visibility of one or more services.
 * `delete`: Permanently delete services.
 * `update`: Update visibility, routing vars, and/or...
 * `list-tests`: List testable documents for one service or...
@@ -592,73 +590,40 @@ $ usvc_seller services deprecate [OPTIONS] [SERVICE_IDS]...
 * `--base-url TEXT`: Backend base URL.  [env var: UNITYSVC_SELLER_API_URL; default: https://seller.unitysvc.com/v1]
 * `--help`: Show this message and exit.
 
-### `usvc_seller services publish`
+### `usvc_seller services set-visibility`
 
-Set visibility to public (visible in the catalog to all users).
+Set the visibility of one or more services.
 
-**Usage**:
+``VISIBILITY`` is one of:
 
-```console
-$ usvc_seller services publish [OPTIONS] [SERVICE_IDS]...
-```
+- ``public``   — service is listed in the public catalog (effective
+  only once the service is in the ``active`` status; setting this
+  on a draft service marks the *intent* to be public when the
+  service is activated).
+- ``unlisted`` — accessible by direct link, hidden from public
+  catalog browse views.
+- ``private``  — hidden from every catalog view; only the seller
+  and admins can see it.
 
-**Arguments**:
-
-* `[SERVICE_IDS]...`: Service ID(s) to publish (≥8 chars).
-
-**Options**:
-
-* `--all`: Publish all active services that aren&#x27;t already public.
-* `-l, --local-ids`: Restrict to services whose IDs are recorded in listing_v1 files under --data-dir.
-* `--data-dir DIRECTORY`: Data directory for --local-ids (default: current directory).  [default: .]
-* `--provider TEXT`: Filter by provider when --all or --local-ids is set.
-* `-y, --yes`: Skip confirmation prompt.
-* `--api-key TEXT`: Seller API key (svcpass_...). Defaults to $UNITYSVC_SELLER_API_KEY.  [env var: UNITYSVC_SELLER_API_KEY]
-* `--base-url TEXT`: Backend base URL.  [env var: UNITYSVC_SELLER_API_URL; default: https://seller.unitysvc.com/v1]
-* `--help`: Show this message and exit.
-
-### `usvc_seller services unlist`
-
-Set visibility to unlisted (accessible by direct link, not shown in catalog).
+This command is a pure flag flip on the visibility column.  It
+does not transition status, does not validate that the service
+*should* be at the requested visibility, and does not interact
+with any review workflow.
 
 **Usage**:
 
 ```console
-$ usvc_seller services unlist [OPTIONS] [SERVICE_IDS]...
+$ usvc_seller services set-visibility [OPTIONS] VISIBILITY [SERVICE_IDS]...
 ```
 
 **Arguments**:
 
-* `[SERVICE_IDS]...`: Service ID(s) to unlist (≥8 chars).
+* `VISIBILITY`: Target visibility: one of public, unlisted, private.  [required]
+* `[SERVICE_IDS]...`: Service ID(s) to update (≥8 chars).
 
 **Options**:
 
-* `--all`: Unlist all active services that aren&#x27;t already unlisted.
-* `-l, --local-ids`: Restrict to services whose IDs are recorded in listing_v1 files under --data-dir.
-* `--data-dir DIRECTORY`: Data directory for --local-ids (default: current directory).  [default: .]
-* `--provider TEXT`: Filter by provider when --all or --local-ids is set.
-* `-y, --yes`: Skip confirmation prompt.
-* `--api-key TEXT`: Seller API key (svcpass_...). Defaults to $UNITYSVC_SELLER_API_KEY.  [env var: UNITYSVC_SELLER_API_KEY]
-* `--base-url TEXT`: Backend base URL.  [env var: UNITYSVC_SELLER_API_URL; default: https://seller.unitysvc.com/v1]
-* `--help`: Show this message and exit.
-
-### `usvc_seller services hide`
-
-Set visibility to private (hidden from all catalog views).
-
-**Usage**:
-
-```console
-$ usvc_seller services hide [OPTIONS] [SERVICE_IDS]...
-```
-
-**Arguments**:
-
-* `[SERVICE_IDS]...`: Service ID(s) to hide (≥8 chars).
-
-**Options**:
-
-* `--all`: Hide all active services that aren&#x27;t already private.
+* `--all`: Apply to all active services not already at the target visibility.
 * `-l, --local-ids`: Restrict to services whose IDs are recorded in listing_v1 files under --data-dir.
 * `--data-dir DIRECTORY`: Data directory for --local-ids (default: current directory).  [default: .]
 * `--provider TEXT`: Filter by provider when --all or --local-ids is set.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -623,7 +623,7 @@ $ usvc_seller services set-visibility [OPTIONS] VISIBILITY [SERVICE_IDS]...
 
 **Options**:
 
-* `--all`: Apply to all active services not already at the target visibility.
+* `--all`: Apply to every non-deprecated service (draft, pending, review, active, rejected, suspended) not already at the target visibility.  Status is irrelevant — visibility is a flag that persists through the lifecycle and only takes effect on ``active``.
 * `-l, --local-ids`: Restrict to services whose IDs are recorded in listing_v1 files under --data-dir.
 * `--data-dir DIRECTORY`: Data directory for --local-ids (default: current directory).  [default: .]
 * `--provider TEXT`: Filter by provider when --all or --local-ids is set.

--- a/docs/seller-lifecycle.md
+++ b/docs/seller-lifecycle.md
@@ -97,22 +97,45 @@ Every service has a visibility setting that controls catalog presence:
 !!! note "Unlisted services are fully functional"
     Unlisted services are not hidden — they are simply not listed in the catalog. Anyone with the direct URL can view the service page, enroll, and use the API without any additional restriction. This makes `unlisted` ideal for sharing with beta customers before a public launch: just send them the link.
 
-**After activation, you must explicitly publish your service** by setting visibility to `public`. This gives you a soft-launch period to:
+### Setting visibility
 
--   Verify billing and usage tracking work correctly
--   Share the direct link with beta customers for early feedback
--   Confirm documentation and pricing are final
+Visibility is **independent** of status — you can set it on a draft, on a service in review, or on an active service.  The flag only takes effect once the service reaches `active`:
 
-### Publishing your service
+-   On a **draft** or **review** service, `visibility=public` records the intent; the service does not appear in the catalog until admin approval activates it.
+-   On an **active** service, `visibility=public` is immediately visible to all users.
 
-**CLI:**
+This means there are two valid publishing patterns:
+
+**Pattern A — soft launch (set visibility after activation).** The default visibility on activation is `unlisted`, so a freshly approved service is live and routable but not in the public catalog.  Use this period to verify billing, share with beta customers via the direct URL, and finalise docs.  Then explicitly switch to public when you're ready:
 
 ```bash
-# Set a single service to public
-usvc_seller services update <service-id> --visibility public
+usvc_seller services set-visibility public <service-id>
+```
 
-# Set all active services to public (bulk)
-usvc_seller services set-visibility --all --visibility public --yes
+**Pattern B — declarative (set visibility before submission).** Set `visibility=public` while the service is still a draft, then submit for review.  When admin activates the service it becomes public immediately — no second step required.  This is what the CI-driven upload workflow does (see [Workflows → upload pipeline](workflows.md#typical-cicd-upload-and-submit-pattern)):
+
+```bash
+usvc_seller data upload
+usvc_seller services set-visibility public --local-ids --data-dir data --yes
+usvc_seller services submit --local-ids --data-dir data --yes
+```
+
+### Switching visibility
+
+**CLI** — set visibility on specific services or in bulk:
+
+```bash
+# Single service
+usvc_seller services set-visibility public <service-id>
+
+# All active services that aren't already public
+usvc_seller services set-visibility public --all --yes
+
+# Take a service back off the public catalog without breaking enrollments
+usvc_seller services set-visibility unlisted <service-id>
+
+# Hide entirely (also keeps it out of internal listings)
+usvc_seller services set-visibility private <service-id>
 ```
 
 **SDK:**
@@ -123,7 +146,7 @@ client.services.update(service_id, {"visibility": "public"})
 
 **Web interface:** Use the visibility toggle on the service detail page.
 
-You can switch back to `unlisted` at any time to temporarily remove a service from the catalog without affecting existing enrollments or routing.
+`unlisted` and `public` can be flipped freely at any time without affecting existing enrollments or routing.
 
 ### Once published
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -178,17 +178,20 @@ usvc_seller services list --status active
 
 #### 8. Publish to Marketplace
 
-After your service is activated (approved by admin), it starts as **unlisted**. Set visibility to `public` when you're ready for it to appear in the catalog:
+A freshly activated service starts as **unlisted** unless you've already set its visibility to `public` on the draft (which the CI upload pipeline does — see below).  Switching visibility is a one-shot command:
 
 ```bash
-# Publish a specific service
-usvc_seller services update <service-id> --visibility public
+# Single service
+usvc_seller services set-visibility public <service-id>
 
-# Or publish all active services at once
-usvc_seller services set-visibility --all --visibility public --yes
+# All active services that aren't already public
+usvc_seller services set-visibility public --all --yes
+
+# Restrict to services whose service_id is recorded under ./data
+usvc_seller services set-visibility public --local-ids --data-dir data --yes
 ```
 
-See [Seller Lifecycle](seller-lifecycle.md#visibility) for details on visibility settings.
+See [Seller Lifecycle → setting visibility](seller-lifecycle.md#setting-visibility) for the full visibility model and when to publish before vs. after admin approval.
 
 ### Version Control Integration
 
@@ -790,8 +793,8 @@ usvc_seller services withdraw --local-ids --provider acme --yes
 # Submit services whose listing files are in a data/ subdirectory
 usvc_seller services submit --local-ids --data-dir data --yes
 
-# Publish all active services in a data subdirectory
-usvc_seller services publish --local-ids --data-dir ./data --yes
+# Set visibility to public for every service in a data subdirectory
+usvc_seller services set-visibility public --local-ids --data-dir ./data --yes
 ```
 
 ### How it works
@@ -821,12 +824,28 @@ usvc_seller services publish --local-ids --data-dir ./data --yes
     git diff --staged --quiet || git commit -m "chore: update service override files [skip ci]"
     git push
 
+# Set visibility=public BEFORE submit-for-review.  The flag has no
+# effect while the service is still draft / under review, but it
+# becomes effective the instant admin approves activation — so a
+# seller running this CI workflow gets a one-step "upload → public"
+# pipeline with no manual publish step after approval.  Sellers who
+# want a soft-launch / verification window should *omit* this step
+# (services activate as ``unlisted`` by default) and run
+# ``set-visibility public`` manually when they're ready.
+- name: Mark visibility public
+  env:
+    UNITYSVC_SELLER_API_KEY: ${{ secrets.UNITYSVC_SELLER_API_KEY }}
+    UNITYSVC_SELLER_API_URL: ${{ secrets.UNITYSVC_SELLER_API_URL }}
+  run: usvc_seller services set-visibility public --local-ids --data-dir data --yes
+
 - name: Submit for review
   env:
     UNITYSVC_SELLER_API_KEY: ${{ secrets.UNITYSVC_SELLER_API_KEY }}
     UNITYSVC_SELLER_API_URL: ${{ secrets.UNITYSVC_SELLER_API_URL }}
   run: usvc_seller services submit --local-ids --data-dir data --yes
 ```
+
+The order — `set-visibility public` **before** `submit` — matters: visibility is a flag, not a transition.  Setting it on a draft is a no-op until activation, but it persists through the review→active transition, so the service appears in the catalog the moment admin approves.  Reversing the order (submit first, then set-visibility) works for an active service but skips the catalog appearance for any window where activation has happened but the second command hasn't run yet.
 
 ### Mutual exclusivity
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "unitysvc-sellers"
-version = "0.1.10"
+version = "0.1.11"
 description = "Seller-facing tools for UnitySVC: HTTP SDK + usvc_seller CLI"
 readme = "README.md"
 authors = [{ name = "Bo Peng", email = "bo.peng@unitysvc.com" }]

--- a/src/unitysvc_sellers/commands/services.py
+++ b/src/unitysvc_sellers/commands/services.py
@@ -712,6 +712,24 @@ _OTHER_VISIBILITIES: dict[str, list[str]] = {
     "private": ["public", "unlisted"],
 }
 
+# Statuses where setting visibility is meaningful.  Visibility is a
+# flag, not a transition — it persists through the entire lifecycle
+# and only takes effect when the service reaches ``active``.  Setting
+# ``visibility=public`` on a ``draft`` is the canonical "Pattern B"
+# behaviour: the seller declares intent, the flag stays on the
+# service through review, and the moment admin approves activation
+# the service is in the public catalog.  ``deprecated`` is the
+# terminal status where flipping visibility is a no-op (the service
+# is permanently removed from routing), so we exclude it.
+_VISIBILITY_TARGETABLE_STATUSES: list[str] = [
+    "active",
+    "draft",
+    "pending",
+    "rejected",
+    "review",
+    "suspended",
+]
+
 
 def _set_visibility_impl(
     *,
@@ -740,7 +758,7 @@ def _set_visibility_impl(
         base_url=base_url,
         service_ids=service_ids,
         use_all=all_active,
-        statuses_when_all=["active"],
+        statuses_when_all=_VISIBILITY_TARGETABLE_STATUSES,
         visibilities_when_all=_OTHER_VISIBILITIES[visibility],
         provider=provider,
         flag_name="all",
@@ -771,7 +789,13 @@ def set_visibility(
     all_active: bool = typer.Option(
         False,
         "--all",
-        help="Apply to all active services not already at the target visibility.",
+        help=(
+            "Apply to every non-deprecated service (draft, pending, review, "
+            "active, rejected, suspended) not already at the target "
+            "visibility.  Status is irrelevant — visibility is a flag that "
+            "persists through the lifecycle and only takes effect on "
+            "``active``."
+        ),
     ),
     local_ids: bool = _LOCAL_IDS_OPTION,
     data_dir: Path = _DATA_DIR_OPTION,

--- a/src/unitysvc_sellers/commands/services.py
+++ b/src/unitysvc_sellers/commands/services.py
@@ -11,9 +11,7 @@ Commands:
 - ``submit``    — draft → pending (sets status='pending')
 - ``withdraw``  — pending|rejected → draft
 - ``deprecate`` — mark services as deprecated
-- ``publish``   — set visibility to public
-- ``unlist``    — set visibility to unlisted
-- ``hide``      — set visibility to private
+- ``set-visibility VISIBILITY`` — set visibility to ``public`` / ``unlisted`` / ``private``
 - ``delete``    — permanently delete services
 - ``update``    — set/remove routing vars and list price
 
@@ -61,7 +59,7 @@ _DATA_DIR_OPTION = typer.Option(
 console = Console()
 
 app = typer.Typer(
-    help="Remote service operations (list, show, submit, withdraw, deprecate, publish, unlist, hide, delete, update).",
+    help="Remote service operations (list, show, submit, withdraw, deprecate, set-visibility, delete, update).",
 )
 
 
@@ -702,15 +700,78 @@ def deprecate_service(
 
 
 # ---------------------------------------------------------------------------
-# publish / unlist / hide
+# set-visibility
 # ---------------------------------------------------------------------------
-@app.command("publish")
-def publish_service(
-    service_ids: list[str] = typer.Argument(None, help="Service ID(s) to publish (≥8 chars)."),
+_VISIBILITIES: tuple[str, ...] = ("public", "unlisted", "private")
+
+# Per-target visibility, the *other* visibilities the ``--all`` filter
+# treats as candidates for change (everything except the target).
+_OTHER_VISIBILITIES: dict[str, list[str]] = {
+    "public": ["unlisted", "private"],
+    "unlisted": ["public", "private"],
+    "private": ["public", "unlisted"],
+}
+
+
+def _set_visibility_impl(
+    *,
+    visibility: str,
+    service_ids: list[str] | None,
+    all_active: bool,
+    local_ids: bool,
+    data_dir: Path,
+    provider: str | None,
+    yes: bool,
+    api_key: str | None,
+    base_url: str,
+) -> None:
+    """Shared implementation for the canonical ``set-visibility`` command
+    and the deprecated ``publish`` / ``unlist`` / ``hide`` aliases."""
+    if visibility not in _VISIBILITIES:
+        console.print(
+            f"[red]✗[/red] Invalid visibility {visibility!r}. "
+            f"Use one of: {', '.join(_VISIBILITIES)}.",
+            style="bold red",
+        )
+        raise typer.Exit(code=2)
+
+    ids = _resolve_or_fetch_ids(
+        api_key=api_key,
+        base_url=base_url,
+        service_ids=service_ids,
+        use_all=all_active,
+        statuses_when_all=["active"],
+        visibilities_when_all=_OTHER_VISIBILITIES[visibility],
+        provider=provider,
+        flag_name="all",
+        use_local_ids=local_ids,
+        data_dir=data_dir,
+    )
+    _bulk_visibility_change(
+        api_key=api_key,
+        base_url=base_url,
+        service_ids=ids,
+        visibility=visibility,
+        success_verb=f"Set to {visibility}",
+        confirm_prompt=f"Set {len(ids)} service(s) to {visibility}?",
+        yes=yes,
+    )
+
+
+@app.command("set-visibility")
+def set_visibility(
+    visibility: str = typer.Argument(
+        ...,
+        help="Target visibility: one of public, unlisted, private.",
+        metavar="VISIBILITY",
+    ),
+    service_ids: list[str] = typer.Argument(
+        None, help="Service ID(s) to update (≥8 chars)."
+    ),
     all_active: bool = typer.Option(
         False,
         "--all",
-        help="Publish all active services that aren't already public.",
+        help="Apply to all active services not already at the target visibility.",
     ),
     local_ids: bool = _LOCAL_IDS_OPTION,
     data_dir: Path = _DATA_DIR_OPTION,
@@ -721,110 +782,37 @@ def publish_service(
     api_key: str | None = api_key_option(),
     base_url: str = base_url_option(),
 ) -> None:
-    """Set visibility to public (visible in the catalog to all users)."""
-    ids = _resolve_or_fetch_ids(
-        api_key=api_key,
-        base_url=base_url,
+    """Set the visibility of one or more services.
+
+    ``VISIBILITY`` is one of:
+
+    - ``public``   — service is listed in the public catalog (effective
+      only once the service is in the ``active`` status; setting this
+      on a draft service marks the *intent* to be public when the
+      service is activated).
+    - ``unlisted`` — accessible by direct link, hidden from public
+      catalog browse views.
+    - ``private``  — hidden from every catalog view; only the seller
+      and admins can see it.
+
+    This command is a pure flag flip on the visibility column.  It
+    does not transition status, does not validate that the service
+    *should* be at the requested visibility, and does not interact
+    with any review workflow.
+    """
+    _set_visibility_impl(
+        visibility=visibility,
         service_ids=service_ids,
-        use_all=all_active,
-        statuses_when_all=["active"],
-        visibilities_when_all=["unlisted", "private"],
-        provider=provider,
-        flag_name="all",
-        use_local_ids=local_ids,
+        all_active=all_active,
+        local_ids=local_ids,
         data_dir=data_dir,
-    )
-    _bulk_visibility_change(
-        api_key=api_key,
-        base_url=base_url,
-        service_ids=ids,
-        visibility="public",
-        success_verb="Published",
-        confirm_prompt=f"Set {len(ids)} service(s) to public?",
-        yes=yes,
-    )
-
-
-@app.command("unlist")
-def unlist_service(
-    service_ids: list[str] = typer.Argument(None, help="Service ID(s) to unlist (≥8 chars)."),
-    all_active: bool = typer.Option(
-        False,
-        "--all",
-        help="Unlist all active services that aren't already unlisted.",
-    ),
-    local_ids: bool = _LOCAL_IDS_OPTION,
-    data_dir: Path = _DATA_DIR_OPTION,
-    provider: str | None = typer.Option(
-        None, "--provider", help="Filter by provider when --all or --local-ids is set."
-    ),
-    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
-    api_key: str | None = api_key_option(),
-    base_url: str = base_url_option(),
-) -> None:
-    """Set visibility to unlisted (accessible by direct link, not shown in catalog)."""
-    ids = _resolve_or_fetch_ids(
-        api_key=api_key,
-        base_url=base_url,
-        service_ids=service_ids,
-        use_all=all_active,
-        statuses_when_all=["active"],
-        visibilities_when_all=["public", "private"],
         provider=provider,
-        flag_name="all",
-        use_local_ids=local_ids,
-        data_dir=data_dir,
-    )
-    _bulk_visibility_change(
+        yes=yes,
         api_key=api_key,
         base_url=base_url,
-        service_ids=ids,
-        visibility="unlisted",
-        success_verb="Unlisted",
-        confirm_prompt=f"Set {len(ids)} service(s) to unlisted?",
-        yes=yes,
     )
 
 
-@app.command("hide")
-def hide_service(
-    service_ids: list[str] = typer.Argument(None, help="Service ID(s) to hide (≥8 chars)."),
-    all_active: bool = typer.Option(
-        False,
-        "--all",
-        help="Hide all active services that aren't already private.",
-    ),
-    local_ids: bool = _LOCAL_IDS_OPTION,
-    data_dir: Path = _DATA_DIR_OPTION,
-    provider: str | None = typer.Option(
-        None, "--provider", help="Filter by provider when --all or --local-ids is set."
-    ),
-    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
-    api_key: str | None = api_key_option(),
-    base_url: str = base_url_option(),
-) -> None:
-    """Set visibility to private (hidden from all catalog views)."""
-    ids = _resolve_or_fetch_ids(
-        api_key=api_key,
-        base_url=base_url,
-        service_ids=service_ids,
-        use_all=all_active,
-        statuses_when_all=["active"],
-        visibilities_when_all=["public", "unlisted"],
-        provider=provider,
-        flag_name="all",
-        use_local_ids=local_ids,
-        data_dir=data_dir,
-    )
-    _bulk_visibility_change(
-        api_key=api_key,
-        base_url=base_url,
-        service_ids=ids,
-        visibility="private",
-        success_verb="Hidden",
-        confirm_prompt=f"Hide {len(ids)} service(s) (set to private)?",
-        yes=yes,
-    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Four commits, ready for release:

| Commit | Purpose |
|---|---|
| ``services: replace publish/unlist/hide with set-visibility VISIBILITY`` | Core rename: one canonical command, three asymmetric verbs deleted |
| ``docs: refresh visibility narrative for set-visibility VISIBILITY`` | CLI reference regen + ``seller-lifecycle.md`` and ``workflows.md`` rewrites covering both publishing patterns |
| ``set-visibility: allow targets at any non-deprecated status`` | Eligibility filter relaxed so the declarative CI workflow actually works on drafts |
| ``release: v0.1.11`` | Version bump |

## Why
The trio ``services {publish,unlist,hide}`` were each thin wrappers around a single visibility-flag flip, but ``publish`` carried workflow-flavoured baggage from when it actually published a service to the catalog.  Today the command does nothing more than ``UPDATE service SET visibility = 'public'`` — and that flag is meaningless for services not yet in the ``active`` status, so calling ``services publish`` on a draft does *not* publish anything visible.

## What changes
Replace the three asymmetric verbs with one canonical command that takes the target visibility as a positional argument:

```
usvc_seller services set-visibility public   [<id>...]
usvc_seller services set-visibility unlisted [<id>...]
usvc_seller services set-visibility private  [<id>...]
```

- Symmetric across all three states.
- Docstring is explicit about scope: "pure flag flip on the visibility column; does not transition status, does not validate, does not interact with any review workflow."
- ``set-visibility`` operates on services at **any non-deprecated** status — including drafts.  Setting ``visibility=public`` on a draft persists through review→active so the service is in the public catalog the moment admin approves.  This is what unblocks the declarative CI upload pattern (upload → set-visibility public → submit).

## Breaking change
The old ``services publish`` / ``services unlist`` / ``services hide`` commands are removed entirely — no deprecation aliases.  Catalog ``upload-data`` workflows and any seller-side scripts still on the old names need to migrate to the new ``services set-visibility VISIBILITY`` form before upgrading to this release.

(Catalog workflows in the unitysvc-labs org will be re-stamped immediately after the 0.1.11 PyPI publish completes.)

## Test plan
- [x] All 199 existing tests still pass.
- [x] ``services set-visibility public/unlisted/private --help`` shows the new command with the new ``--all`` scope.
- [x] Bad visibility (``services set-visibility nonsense X``) exits 2 with a clear error.
- [x] Old ``services publish/unlist/hide`` no longer exist.
- [x] ``./scripts/generate_cli_reference.sh`` produces an empty diff (docs/cli-reference.md is in sync).
- [x] ``mkdocs build --strict`` exits 0.
- [ ] After merge: cut release v0.1.11, then re-stamp the 21 catalog ``upload-data.yml`` files (``services publish`` → ``services set-visibility public``).

🤖 Generated with [Claude Code](https://claude.com/claude-code)