### PR TITLE
services delete: shrink deletable_statuses to never-been-active

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -636,6 +636,16 @@ $ usvc_seller services set-visibility [OPTIONS] VISIBILITY [SERVICE_IDS]...
 
 Permanently delete services.
 
+Only services that have **never been active** are deletable:
+``draft``, ``pending``, ``review``, ``rejected``.  Services in
+``active``, ``suspended``, or ``deprecated`` have an archived
+``ServiceData`` history that the platform retains for audit
+purposes; the backend rejects delete attempts on those even when
+they&#x27;re currently inactive.  Status changes don&#x27;t recover
+deletability: a service that was once activated stays
+non-deletable forever, even after a round-trip through
+``deprecated → active → deprecated``.
+
 **Usage**:
 
 ```console
@@ -648,7 +658,7 @@ $ usvc_seller services delete [OPTIONS] [SERVICE_IDS]...
 
 **Options**:
 
-* `--all`: Delete all deletable services (draft, pending, review, rejected, suspended, deprecated).
+* `--all`: Delete all deletable services (draft, pending, review, rejected).
 * `-l, --local-ids`: Restrict to services whose IDs are recorded in listing_v1 files under --data-dir.
 * `--data-dir DIRECTORY`: Data directory for --local-ids (default: current directory).  [default: .]
 * `--status TEXT`: Restrict --all to a single deletable status.

--- a/src/unitysvc_sellers/commands/services.py
+++ b/src/unitysvc_sellers/commands/services.py
@@ -848,7 +848,7 @@ def delete_service(
     all_deletable: bool = typer.Option(
         False,
         "--all",
-        help="Delete all deletable services (draft, pending, review, rejected, suspended, deprecated).",
+        help="Delete all deletable services (draft, pending, review, rejected).",
     ),
     local_ids: bool = _LOCAL_IDS_OPTION,
     data_dir: Path = _DATA_DIR_OPTION,
@@ -861,8 +861,26 @@ def delete_service(
     api_key: str | None = api_key_option(),
     base_url: str = base_url_option(),
 ) -> None:
-    """Permanently delete services."""
-    deletable_statuses = ["draft", "pending", "review", "rejected", "suspended", "deprecated"]
+    """Permanently delete services.
+
+    Only services that have **never been active** are deletable:
+    ``draft``, ``pending``, ``review``, ``rejected``.  Services in
+    ``active``, ``suspended``, or ``deprecated`` have an archived
+    ``ServiceData`` history that the platform retains for audit
+    purposes; the backend rejects delete attempts on those even when
+    they're currently inactive.  Status changes don't recover
+    deletability: a service that was once activated stays
+    non-deletable forever, even after a round-trip through
+    ``deprecated → active → deprecated``.
+    """
+    # Statuses for which the service has never reached ``active``,
+    # i.e. no archived ``ServiceData`` row exists.  Kept in sync with
+    # ``_check_service_deletable`` in
+    # ``backend/app/api/routes/seller/services.py`` (which is the
+    # source of truth — it checks the archived-history table rather
+    # than the status enum, but in practice these are the only
+    # statuses without history).
+    deletable_statuses = ["draft", "pending", "review", "rejected"]
     if status:
         if status not in deletable_statuses:
             valid = ", ".join(deletable_statuses)


### PR DESCRIPTION
## Why
The CLI's ``services delete --all`` flag claimed it could remove services in ``draft, pending, review, rejected, suspended, deprecated``.  The backend has never agreed: ``_check_service_deletable`` in ``backend/app/api/routes/seller/services.py`` rejects any service with archived ``ServiceData`` history — i.e. anything that has been ``active`` at any point.  That covers the entire ``suspended`` / ``deprecated`` set.

So a user running ``services delete --all`` would see the CLI happily fetch N services, attempt each one, and watch the backend reject every single delete with ``"Service was previously active and cannot be deleted"``.  Useless attempts and a misleading help message.

## What changes
Shrink the CLI's ``deletable_statuses`` to the four statuses for which an archived ServiceData row genuinely doesn't exist yet:

```python
deletable_statuses = ["draft", "pending", "review", "rejected"]
```

- ``--all`` help text updated to ``"Delete all deletable services (draft, pending, review, rejected)."``
- Command docstring expanded to explain the rule (never-been-active is the deletability test, status-changes-don't-recover-deletability is the corollary).
- ``--status`` validation now rejects ``suspended`` / ``deprecated`` up front with a clear error rather than waiting for per-id backend rejections.

The backend remains the source of truth — users who really want to try deleting a specific previously-active service id can still pass it explicitly, and the backend will reject as before.

## Test plan
- [x] All 199 existing tests still pass.
- [x] ``usvc_seller services delete --help`` reads correctly with the new help text.
- [x] ``usvc_seller services delete --all --status deprecated`` exits 1 at the CLI with the expected error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)