### PR TITLE
deps: bump unitysvc-core to >=0.1.10 (hierarchical-name validator)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-  "unitysvc-core>=0.1.9",
+  "unitysvc-core>=0.1.10",
   "unitysvc-data>=0.1.18",
   "typer",
   "rich",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-  "unitysvc-core>=0.1.8",
+  "unitysvc-core>=0.1.9",
   "unitysvc-data>=0.1.18",
   "typer",
   "rich",


### PR DESCRIPTION
## Summary

- Bumps `unitysvc-core` minimum from `>=0.1.8` to `>=0.1.9`.
- The 0.1.9 release adds the platform service-naming convention validators introduced in [unitysvc-core#16](https://github.com/unitysvc/unitysvc-core/pull/16):
  - `validate_service_identifier` — enforces the structural rule on offering / listing `name` fields
  - `validate_listing_gateway_base_urls` — enforces the rule on `${API_GATEWAY_BASE_URL}/...` paths in `user_access_interfaces`
- Background and rationale: [unitysvc/unitysvc#1138](https://github.com/unitysvc/unitysvc/issues/1138).

## What this unblocks

Once merged, `usvc_seller data validate` will reject `${API_GATEWAY_BASE_URL}/p/<provider>` legacy patterns and other structural violations in seller data. Fan-out PRs across the `unitysvc-labs/unitysvc-services-*` repos to clean up the existing data are in flight.

## Test plan

- [x] `uv lock --upgrade-package unitysvc-core` resolves to 0.1.9 in lockfile
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)