### PR TITLE
fix: silence "identical content" 400 on services submit no-ops

### DIFF
--- a/src/unitysvc_sellers/commands/services.py
+++ b/src/unitysvc_sellers/commands/services.py
@@ -292,6 +292,40 @@ def show_service(
 # ---------------------------------------------------------------------------
 # Bulk-status helpers
 # ---------------------------------------------------------------------------
+
+# Backend 400 messages that mean "this status change is a no-op", not
+# that the request was broken.  They originate from the duplicate-content
+# check on the submit-for-review path
+# (``backend/app/api/routes/seller/services.py:815-844``): when a draft
+# is content-identical to an existing active service the same seller
+# owns, the backend rejects the submit and returns 400.  For CI flows
+# that re-run ``services submit`` after every PR merge that's a normal
+# steady state — the service is already where the seller wanted it.
+# Treating these as failures makes CI flap on every "no real changes"
+# merge, which is exactly what #(this commit) suppresses.
+_NOOP_400_PHRASES: tuple[str, ...] = (
+    "A service with identical content already exists",
+    "No changes detected",
+)
+
+
+def _is_noop_status_change(exc: Exception) -> bool:
+    """Return ``True`` if ``exc`` is a backend 400 that means "nothing
+    to do" rather than a real failure.
+
+    Specifically matches the ``submit-for-review`` duplicate-content
+    rejections so reruns / CI uploads don't fail when the catalog is
+    already in the desired state.  ``status_code`` is checked when
+    available so unrelated 400s with overlapping wording (none today,
+    but defensively) wouldn't be silenced.
+    """
+    status_code = getattr(exc, "status_code", None)
+    if status_code is not None and status_code != 400:
+        return False
+    msg = str(exc)
+    return any(phrase in msg for phrase in _NOOP_400_PHRASES)
+
+
 def _bulk_status_change(
     *,
     api_key: str | None,
@@ -323,17 +357,29 @@ def _bulk_status_change(
     results = run_async(_impl(), error_prefix=f"{success_verb} failed")
 
     success = 0
+    skipped = 0
     failed = 0
     for sid, err in results:
         if err is None:
             console.print(f"  [green]✓[/green] {sid}: {success_verb}")
             success += 1
+        elif _is_noop_status_change(err):
+            # No-op: catalog already matches the desired state.  Surface
+            # as a skip (yellow ⊘) so the operator can still see it, but
+            # don't count toward the failure tally that drives ``exit
+            # 1`` — CI must stay green when reruns find nothing to do.
+            console.print(
+                f"  [yellow]⊘[/yellow] {sid}: skipped (no-op — content already matches an active service)"
+            )
+            skipped += 1
         else:
             console.print(f"  [red]✗[/red] {sid}: {err}")
             failed += 1
 
     if count > 1:
         console.print(f"\n[green]✓ Success:[/green] {success}/{count}")
+        if skipped:
+            console.print(f"[yellow]⊘ Skipped:[/yellow] {skipped}/{count}")
         if failed:
             console.print(f"[red]✗ Failed:[/red] {failed}/{count}")
             raise typer.Exit(code=1)

--- a/tests/test_services_noop_submit.py
+++ b/tests/test_services_noop_submit.py
@@ -1,0 +1,195 @@
+"""Tests for the no-op-submit silencer in ``services submit``.
+
+Covers:
+
+- ``_is_noop_status_change`` recognizes the specific backend 400s that
+  mean "this status change is a no-op" (catalog already matches
+  desired state) and ignores unrelated 400s / wrong status codes.
+- ``_bulk_status_change`` treats those 400s as ``skipped`` rather than
+  ``failed``, so CI re-runs that find nothing to do exit zero.
+
+The end-to-end ``services submit`` CLI path is covered by
+``test_services_local_ids.py``; this file targets the new branching
+in isolation so a future tweak to the bulk-helper UX can't silently
+re-introduce the CI-flap that motivated this change.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from unitysvc_sellers.commands.services import (
+    _bulk_status_change,
+    _is_noop_status_change,
+)
+from unitysvc_sellers.exceptions import APIError
+
+API_BASE = "http://test.local/v1"
+SID_A = "11111111-1111-1111-1111-111111111111"
+SID_B = "22222222-2222-2222-2222-222222222222"
+
+
+# ---------------------------------------------------------------------------
+# _is_noop_status_change
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        # Real text from backend services.py:834 (duplicate active service).
+        "API request failed with status 400: A service with identical "
+        "content already exists: d7c429fa-cb73-4efb-8260-d74e75659fce "
+        "(status: active). Please modify the service data before submitting.",
+        # Real text from services.py:831 (no-changes-on-revision path).
+        "API request failed with status 400: No changes detected. Please "
+        "modify the service before submitting for review.",
+    ],
+)
+def test_is_noop_recognizes_known_phrases(message: str) -> None:
+    exc = APIError(message, status_code=400)
+    assert _is_noop_status_change(exc) is True
+
+
+def test_is_noop_rejects_unrelated_400() -> None:
+    exc = APIError(
+        "API request failed with status 400: Cannot change status from "
+        "'active'. Contact admin for assistance.",
+        status_code=400,
+    )
+    assert _is_noop_status_change(exc) is False
+
+
+def test_is_noop_rejects_non_400_even_with_phrase() -> None:
+    # Defensive: if some future endpoint surfaces the same wording at
+    # 500 we don't want to silently swallow that.
+    exc = APIError(
+        "A service with identical content already exists in cache",
+        status_code=500,
+    )
+    assert _is_noop_status_change(exc) is False
+
+
+def test_is_noop_matches_phrase_when_no_status_code() -> None:
+    # Some wrapper paths raise plain ``Exception`` without a
+    # ``status_code`` attribute; phrase match alone is enough there.
+    exc = Exception(
+        "wrapped: API request failed with status 400: A service with "
+        "identical content already exists ..."
+    )
+    assert _is_noop_status_change(exc) is True
+
+
+# ---------------------------------------------------------------------------
+# _bulk_status_change behavior on no-op 400
+# ---------------------------------------------------------------------------
+
+
+def _noop_400_response() -> httpx.Response:
+    return httpx.Response(
+        400,
+        json={
+            "detail": (
+                f"A service with identical content already exists: {SID_B} "
+                "(status: active). Please modify the service data before "
+                "submitting."
+            )
+        },
+    )
+
+
+def _real_400_response() -> httpx.Response:
+    return httpx.Response(
+        400,
+        json={"detail": "Cannot change status from 'active'."},
+    )
+
+
+def _success_response() -> httpx.Response:
+    return httpx.Response(
+        200,
+        json={"id": SID_A, "status": "pending"},
+    )
+
+
+def test_bulk_status_change_counts_noop_as_skipped_and_exits_zero(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A run where every PATCH returns the no-op 400 must not raise
+    ``typer.Exit`` — CI needs to stay green on identical re-runs.
+    """
+    with respx.mock(base_url=API_BASE, assert_all_called=True) as mock:
+        mock.patch(f"/services/{SID_A}").mock(return_value=_noop_400_response())
+        # Should NOT raise typer.Exit.
+        _bulk_status_change(
+            api_key="test-key",
+            base_url=API_BASE,
+            service_ids=[SID_A],
+            status="pending",
+            success_verb="Submitted",
+            confirm_prompt="ignored",
+            yes=True,
+        )
+
+    out = capsys.readouterr().out
+    assert "skipped" in out.lower()
+    assert "no-op" in out.lower()
+    # Critical: no failure line for a noop-only run.
+    assert "Failed" not in out
+
+
+def test_bulk_status_change_still_exits_one_on_real_failure(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """An unrelated 400 must still count as a failure and exit non-zero
+    — this is the regression guard for the silencer ever growing too
+    permissive.
+    """
+    import typer
+
+    with respx.mock(base_url=API_BASE, assert_all_called=True) as mock:
+        mock.patch(f"/services/{SID_A}").mock(return_value=_success_response())
+        mock.patch(f"/services/{SID_B}").mock(return_value=_real_400_response())
+
+        with pytest.raises(typer.Exit) as exc_info:
+            _bulk_status_change(
+                api_key="test-key",
+                base_url=API_BASE,
+                service_ids=[SID_A, SID_B],
+                status="pending",
+                success_verb="Submitted",
+                confirm_prompt="ignored",
+                yes=True,
+            )
+
+    assert exc_info.value.exit_code == 1
+    out = capsys.readouterr().out
+    assert "Failed" in out
+
+
+def test_bulk_status_change_mixed_outcomes(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Mixed success + skip (no failures) — must still exit zero and
+    surface the skip line so the operator can see what was no-op'd.
+    """
+    with respx.mock(base_url=API_BASE, assert_all_called=True) as mock:
+        mock.patch(f"/services/{SID_A}").mock(return_value=_success_response())
+        mock.patch(f"/services/{SID_B}").mock(return_value=_noop_400_response())
+
+        _bulk_status_change(
+            api_key="test-key",
+            base_url=API_BASE,
+            service_ids=[SID_A, SID_B],
+            status="pending",
+            success_verb="Submitted",
+            confirm_prompt="ignored",
+            yes=True,
+        )
+
+    out = capsys.readouterr().out
+    assert "Success" in out and "1/2" in out
+    assert "Skipped" in out and "1/2" in out
+    assert "Failed" not in out


### PR DESCRIPTION
## Summary
- ``usvc_seller services submit`` no longer fails CI when the merged data is content-identical to the active catalog.
- Recognizes two specific backend 400 messages as no-ops (catalog already where the seller wanted it) and treats them as ``skipped`` instead of ``failed``.

## Why
CI workflows in every ``unitysvc-services-*`` data repo run:
1. ``usvc_seller data upload`` — POSTs services; the backend's ingest task already handles "content unchanged" gracefully (`backend/app/workers/ingest_tasks.py:873-879`, returns same service id with ``service_status="unchanged"``).
2. ``usvc_seller services submit --local-ids`` — PATCHes each service to ``status=pending``.

Step 2 hits a duplicate-content check (`backend/app/api/routes/seller/services.py:815-844`). When the submitting draft is content-identical to an existing active service owned by the same seller, the backend returns:

> 400: A service with identical content already exists: <id> (status: active). Please modify the service data before submitting.

That's the steady state for "no real changes" merges — the catalog is exactly where the seller wanted it — but the CLI was treating every 400 as a failure and `raise typer.Exit(code=1)`, so CI flapped red on every empty-change merge.

Concrete failure: https://github.com/unitysvc-labs/unitysvc-services-resp/actions/runs/26733386154/job/78852028611 — six identical "no-op" 400s from the submit step, exit 1.

## What changed
``commands/services.py``:
- New ``_NOOP_400_PHRASES`` constant and ``_is_noop_status_change(exc)`` helper. Matches the two known "no-op" wordings — the duplicate-active phrase and the "No changes detected" revision-path phrase — and guards on ``status_code == 400`` (when present) so unrelated 400s that happen to overlap on wording aren't silently swallowed.
- ``_bulk_status_change`` now buckets exceptions into ``success / skipped / failed``. Skipped runs print a yellow ``⊘ {sid}: skipped (no-op — content already matches an active service)`` line so the operator can still see them, but don't contribute to the non-zero exit code.

## Side-effect caveat (not in scope of this PR)
The backend still marks the draft as ``rejected`` with a ``status_message`` when this dup-check fires (services.py:838-841). So even with this silencer, each CI run leaves a "rejected-due-to-identical-content" ghost in the seller's catalog. The proper backend fix is to either leave the draft untouched OR delete it AND return 2xx — happy to open a follow-up for that. This PR just unbreaks CI in the meantime.

## Test plan
- [x] 8 new tests in ``tests/test_services_noop_submit.py``: known no-op phrases skip; unrelated 400s still fail; non-400s with matching wording aren't silenced; mixed success+skip exits zero; success+real-failure still exits non-zero.
- [x] Full suite green: 204 passed (was 196 baseline).
- [x] ``ruff check`` clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)