### PR TITLE
release: v0.1.15 (#1138 service_name = listing.name + --name selectors)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "unitysvc-sellers"
-version = "0.1.14"
+version = "0.1.15"
 description = "Seller-facing tools for UnitySVC: HTTP SDK + usvc_seller CLI"
 readme = "README.md"
 authors = [{ name = "Bo Peng", email = "bo.peng@unitysvc.com" }]


### PR DESCRIPTION
Bumps package version 0.1.14 → 0.1.15 for the #1138 release (merged in #63): service_name = listing.name, `--name` fnmatch selectors across data/services/upload, override cleanup; requires unitysvc-core >=0.1.15.

After merge, a `v0.1.15` GitHub release publishes to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)