### PR TITLE
cli: data subcommands locate by listing.name; NAME becomes the positional

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -170,19 +170,18 @@ Upload a seller catalog (services + promotions + service groups) to UnitySVC.
 **Usage**:
 
 ```console
-$ usvc_seller data upload [OPTIONS] [DATA_DIR]
+$ usvc_seller data upload [OPTIONS] [NAME]
 ```
 
 **Arguments**:
 
-* `[DATA_DIR]`: Path to the seller catalog directory (default: current directory).
+* `[NAME]`: Service to upload, by service_name (= listing.name) — fnmatch pattern, e.g. &#x27;cohere/*&#x27; or a literal name. Omit to upload every service in the current directory (plus promotions and groups unless ``--type`` restricts the scope).
 
 **Options**:
 
 * `--api-key TEXT`: Seller API key (svcpass_...). Defaults to $UNITYSVC_SELLER_API_KEY.  [env var: UNITYSVC_SELLER_API_KEY]
 * `--base-url TEXT`: Backend base URL.  [env var: UNITYSVC_SELLER_API_URL; default: https://seller.unitysvc.com/v1]
 * `-t, --type TEXT`: Upload only one resource: services / promotions / groups. Default: upload all three.
-* `-n, --name TEXT`: Upload only services whose service_name (= listing.name) matches this fnmatch pattern, e.g. &#x27;cohere/*&#x27; or a literal name.
 * `--help`: Show this message and exit.
 
 ### `usvc_seller data list-tests`
@@ -198,11 +197,11 @@ Examples:
     # List all code examples
     usvc data list-tests
 
-    # List for specific provider
-    usvc data list-tests --provider fireworks
+    # List for a whole provider (fnmatch pattern on listing.name)
+    usvc data list-tests &#x27;fireworks/*&#x27;
 
-    # List for one service (by service_name = listing.name)
-    usvc data list-tests --name fireworks.ai/llama-3-1-405b-instruct
+    # List for one service (literal listing.name)
+    usvc data list-tests fireworks.ai/llama-3-1-405b-instruct
 
     # List as JSON
     usvc data list-tests --format json
@@ -210,17 +209,15 @@ Examples:
 **Usage**:
 
 ```console
-$ usvc_seller data list-tests [OPTIONS] [DATA_DIR]
+$ usvc_seller data list-tests [OPTIONS] [NAME]
 ```
 
 **Arguments**:
 
-* `[DATA_DIR]`: Directory containing provider data files (default: current directory)
+* `[NAME]`: Service to list, by service_name (= listing.name) — fnmatch pattern, e.g. &#x27;cohere/*&#x27; for a whole provider or a literal name. Omit to list every service in the current directory.
 
 **Options**:
 
-* `-p, --provider TEXT`: Only list code examples for a specific provider
-* `-n, --name TEXT`: Filter services by service_name (= listing.name) — fnmatch pattern, e.g. &#x27;cohere/*&#x27; or a literal name.
 * `-f, --format TEXT`: Output format: json, table, tsv, csv  [default: table]
 * `--help`: Show this message and exit.
 
@@ -238,44 +235,40 @@ This command:
 7. Displays test results
 
 Examples:
-    # Run all code examples
-    usvc data test
+    # Run all code examples in the current directory
+    usvc data run-tests
 
-    # Run for specific provider
-    usvc data run-tests --provider fireworks
+    # Run for a whole provider (fnmatch pattern on listing.name)
+    usvc data run-tests &#x27;fireworks/*&#x27;
 
-    # Run a single service (by service_name = listing.name)
-    usvc data run-tests --name fireworks.ai/llama-3-1-405b-instruct
+    # Run a single service (literal listing.name)
+    usvc data run-tests fireworks.ai/llama-3-1-405b-instruct
+    usvc data run-tests &#x27;cohere/command-r-*&#x27;
 
     # Run specific file
     usvc data run-tests --test-file &quot;code-example.py.j2&quot;
 
-    # Combine filters
-    usvc data run-tests --provider fireworks
-
     # Show detailed output
-    usvc data test --verbose
+    usvc data run-tests --verbose
 
     # Force rerun all tests (ignore existing results)
-    usvc data test --force
+    usvc data run-tests --force
 
     # Stop on first failure
-    usvc data test --fail-fast
+    usvc data run-tests --fail-fast
 
 **Usage**:
 
 ```console
-$ usvc_seller data run-tests [OPTIONS] [DATA_DIR]
+$ usvc_seller data run-tests [OPTIONS] [NAME]
 ```
 
 **Arguments**:
 
-* `[DATA_DIR]`: Directory containing provider data files (default: current directory)
+* `[NAME]`: Service to test, by service_name (= listing.name) — fnmatch pattern, e.g. &#x27;cohere/*&#x27; or a literal name. Omit to test every service in the current directory.
 
 **Options**:
 
-* `-p, --provider TEXT`: Only test code examples for a specific provider
-* `-n, --name TEXT`: Filter services by service_name (= listing.name) — fnmatch pattern, e.g. &#x27;cohere/*&#x27; or a literal name.
 * `-t, --test-file TEXT`: Only run a specific test file by filename (e.g., &#x27;code-example.py.j2&#x27;)
 * `-v, --verbose`: Show detailed output including stdout/stderr from scripts
 * `-f, --force`: Force rerun all tests, ignoring existing .out and .err files

--- a/src/unitysvc_sellers/_cli_upload.py
+++ b/src/unitysvc_sellers/_cli_upload.py
@@ -24,9 +24,13 @@ console = Console()
 
 
 def upload(
-    data_dir: Path | None = typer.Argument(
+    name: str | None = typer.Argument(
         None,
-        help="Path to the seller catalog directory (default: current directory).",
+        help=(
+            "Service to upload, by service_name (= listing.name) — fnmatch pattern, e.g. "
+            "'cohere/*' or a literal name. Omit to upload every service in the current "
+            "directory (plus promotions and groups unless ``--type`` restricts the scope)."
+        ),
     ),
     api_key: str | None = typer.Option(
         None,
@@ -47,13 +51,6 @@ def upload(
         "-t",
         help="Upload only one resource: services / promotions / groups. Default: upload all three.",
     ),
-    name: str | None = typer.Option(
-        None,
-        "--name",
-        "-n",
-        help="Upload only services whose service_name (= listing.name) matches this fnmatch "
-        "pattern, e.g. 'cohere/*' or a literal name.",
-    ),
 ) -> None:
     """Upload a seller catalog (services + promotions + service groups) to UnitySVC."""
     if not api_key:
@@ -63,11 +60,10 @@ def upload(
         )
         raise typer.Exit(code=1)
 
-    if data_dir is None:
-        data_dir = Path.cwd()
-    if not data_dir.exists():
-        console.print(f"[red]✗[/red] Directory not found: {data_dir}", style="bold red")
-        raise typer.Exit(code=1)
+    # Always operate on the current working directory — cd into your data
+    # repo before running.  Keeps the CLI surface minimal; there's no
+    # ``--data-dir`` flag to remember.
+    data_dir = Path.cwd()
 
     valid_types = {"services", "promotions", "groups"}
     if upload_type and upload_type not in valid_types:
@@ -78,11 +74,14 @@ def upload(
         raise typer.Exit(code=1)
 
     if name and upload_type not in (None, "services"):
-        console.print("[red]✗[/red] --name only applies to service uploads; drop --type or use --type services.")
+        console.print(
+            "[red]✗[/red] A positional name only applies to service uploads; drop --type or use --type services."
+        )
         raise typer.Exit(code=1)
 
-    # --name selects one service; promotions/groups are not service-scoped,
-    # so a named upload is services-only.
+    # A positional name selects one or more services; promotions/groups
+    # are not service-scoped, so a name-restricted upload is
+    # services-only.
     upload_services = upload_type in (None, "services")
     upload_promotions = upload_type in (None, "promotions") and not name
     upload_groups = upload_type in (None, "groups") and not name

--- a/src/unitysvc_sellers/example.py
+++ b/src/unitysvc_sellers/example.py
@@ -682,21 +682,13 @@ def save_output_files(
 
 @app.command("list")
 def list_code_examples(
-    data_dir: Path | None = typer.Argument(
+    name: str | None = typer.Argument(
         None,
-        help="Directory containing provider data files (default: current directory)",
-    ),
-    provider_name: str | None = typer.Option(
-        None,
-        "--provider",
-        "-p",
-        help="Only list code examples for a specific provider",
-    ),
-    name: str | None = typer.Option(
-        None,
-        "--name",
-        "-n",
-        help="Filter services by service_name (= listing.name) — fnmatch pattern, e.g. 'cohere/*' or a literal name.",
+        help=(
+            "Service to list, by service_name (= listing.name) — fnmatch pattern, e.g. "
+            "'cohere/*' for a whole provider or a literal name. Omit to list every "
+            "service in the current directory."
+        ),
     ),
     output_format: str = typer.Option(
         "table",
@@ -716,36 +708,23 @@ def list_code_examples(
         # List all code examples
         usvc data list-tests
 
-        # List for specific provider
-        usvc data list-tests --provider fireworks
+        # List for a whole provider (fnmatch pattern on listing.name)
+        usvc data list-tests 'fireworks/*'
 
-        # List for one service (by service_name = listing.name)
-        usvc data list-tests --name fireworks.ai/llama-3-1-405b-instruct
+        # List for one service (literal listing.name)
+        usvc data list-tests fireworks.ai/llama-3-1-405b-instruct
 
         # List as JSON
         usvc data list-tests --format json
     """
-    # Set data directory
-    if data_dir is None:
-        data_dir = Path.cwd()
-
-    if not data_dir.is_absolute():
-        data_dir = Path.cwd() / data_dir
-
-    if not data_dir.exists():
-        console.print(
-            f"[red]✗[/red] Data directory not found: {data_dir}",
-            style="bold red",
-        )
-        raise typer.Exit(code=1)
+    # Always operate on the current working directory — cd into your data
+    # repo before running.  Keeps the CLI surface minimal; there's no
+    # ``--data-dir`` flag to remember.
+    data_dir = Path.cwd()
 
     console.print(f"[blue]Scanning for code examples in:[/blue] {data_dir}\n")
 
-    all_code_examples = discover_code_examples(
-        data_dir,
-        provider_name=provider_name,
-        name=name,
-    )
+    all_code_examples = discover_code_examples(data_dir, name=name)
 
     if not all_code_examples:
         console.print("[yellow]No code examples found.[/yellow]")
@@ -885,21 +864,12 @@ def show_test(
 
 @app.command("run")
 def run_local(
-    data_dir: Path | None = typer.Argument(
+    name: str | None = typer.Argument(
         None,
-        help="Directory containing provider data files (default: current directory)",
-    ),
-    provider_name: str | None = typer.Option(
-        None,
-        "--provider",
-        "-p",
-        help="Only test code examples for a specific provider",
-    ),
-    name: str | None = typer.Option(
-        None,
-        "--name",
-        "-n",
-        help="Filter services by service_name (= listing.name) — fnmatch pattern, e.g. 'cohere/*' or a literal name.",
+        help=(
+            "Service to test, by service_name (= listing.name) — fnmatch pattern, e.g. "
+            "'cohere/*' or a literal name. Omit to test every service in the current directory."
+        ),
     ),
     test_file: str | None = typer.Option(
         None,
@@ -938,43 +908,32 @@ def run_local(
     7. Displays test results
 
     Examples:
-        # Run all code examples
-        usvc data test
+        # Run all code examples in the current directory
+        usvc data run-tests
 
-        # Run for specific provider
-        usvc data run-tests --provider fireworks
+        # Run for a whole provider (fnmatch pattern on listing.name)
+        usvc data run-tests 'fireworks/*'
 
-        # Run a single service (by service_name = listing.name)
-        usvc data run-tests --name fireworks.ai/llama-3-1-405b-instruct
+        # Run a single service (literal listing.name)
+        usvc data run-tests fireworks.ai/llama-3-1-405b-instruct
+        usvc data run-tests 'cohere/command-r-*'
 
         # Run specific file
         usvc data run-tests --test-file "code-example.py.j2"
 
-        # Combine filters
-        usvc data run-tests --provider fireworks
-
         # Show detailed output
-        usvc data test --verbose
+        usvc data run-tests --verbose
 
         # Force rerun all tests (ignore existing results)
-        usvc data test --force
+        usvc data run-tests --force
 
         # Stop on first failure
-        usvc data test --fail-fast
+        usvc data run-tests --fail-fast
     """
-    # Set data directory
-    if data_dir is None:
-        data_dir = Path.cwd()
-
-    if not data_dir.is_absolute():
-        data_dir = Path.cwd() / data_dir
-
-    if not data_dir.exists():
-        console.print(
-            f"[red]✗[/red] Data directory not found: {data_dir}",
-            style="bold red",
-        )
-        raise typer.Exit(code=1)
+    # Always operate on the current working directory — cd into your data
+    # repo before running.  Keeps the CLI surface minimal; there's no
+    # ``--data-dir`` flag to remember.
+    data_dir = Path.cwd()
 
     if name:
         console.print(f"[blue]Service filter (service_name):[/blue] {name}\n")
@@ -985,11 +944,7 @@ def run_local(
 
     console.print(f"[blue]Scanning for listing files in:[/blue] {data_dir}\n")
 
-    discovered = discover_code_examples(
-        data_dir,
-        provider_name=provider_name,
-        name=name,
-    )
+    discovered = discover_code_examples(data_dir, name=name)
 
     # Filter by test file name if provided
     if test_file:

--- a/src/unitysvc_sellers/utils.py
+++ b/src/unitysvc_sellers/utils.py
@@ -48,17 +48,25 @@ from unitysvc_core.utils import (  # noqa: F401
 
 
 def service_name_matches(service_name: str | None, pattern: str) -> bool:
-    """Return True if ``service_name`` matches an fnmatch-style ``--name`` pattern.
+    """Return True if ``service_name`` matches a ``--name`` pattern.
 
-    ``--name`` accepts shell-style wildcards against ``service_name``
-    (= ``listing.name``, #1138): a literal name matches exactly one service,
-    while ``cohere/*`` or ``*llama*`` match a set. Matching is **case-sensitive
-    and platform-independent** (``fnmatchcase``), and ``*`` spans ``/`` so
-    ``cohere/*`` also matches hierarchical names like ``cohere/v1/foo``.
+    The CLI accepts shell-style wildcards against ``service_name`` (=
+    ``listing.name``, #1138).  A literal name matches exactly one service;
+    ``cohere/*`` (or ``cohere/%`` — see below) matches a set.
+
+    **``%`` is a synonym for ``*``** so operators can type the pattern
+    unquoted in a shell — the unix shell would glob-expand ``cohere/*``
+    against the local filesystem, but ``cohere/%`` is shell-safe.  Both
+    glyphs are platform-illegal in real service names (#1138's grammar
+    only permits ``[a-zA-Z0-9._-]``) so this alias loses nothing.
+
+    Matching is **case-sensitive and platform-independent**
+    (``fnmatchcase``), and ``*`` spans ``/`` so ``cohere/*`` also matches
+    hierarchical names like ``cohere/v1/foo``.
     """
     if not service_name:
         return False
-    return fnmatch.fnmatchcase(service_name, pattern)
+    return fnmatch.fnmatchcase(service_name, pattern.replace("%", "*"))
 
 
 def literal_pattern_prefix(pattern: str) -> str | None:
@@ -66,10 +74,13 @@ def literal_pattern_prefix(pattern: str) -> str | None:
 
     Used to narrow a server-side partial-name search before fnmatch-filtering
     client-side: ``cohere/command-*`` → ``cohere/command-``; ``*llama*`` → None.
+
+    ``%`` is treated as a synonym for ``*`` (see ``service_name_matches``);
+    ``cohere/command-%`` also returns ``cohere/command-``.
     """
     out: list[str] = []
     for ch in pattern:
-        if ch in "*?[":
+        if ch in "*?[%":
             break
         out.append(ch)
     return "".join(out) or None

--- a/tests/example_data/provider2/services/service2/listing.json
+++ b/tests/example_data/provider2/services/service2/listing.json
@@ -7,8 +7,7 @@
   "user_access_interfaces": {
     "provider_api": {
       "access_method": "http",
-      "base_url": "${API_GATEWAY_BASE_URL}/{{ service_name }}",
-      "api_key": null
+      "base_url": "${API_GATEWAY_BASE_URL}/{{ service_name }}"
     }
   },
   "documents": {

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -532,6 +532,14 @@ class TestServiceNameMatches:
             ("llama-3", "*llama*", True),
             (None, "*", False),
             ("", "*", False),
+            # ``%`` is a synonym for ``*``; lets the operator pass the
+            # pattern unquoted in a shell that would otherwise glob-expand
+            # ``*`` against the local filesystem.
+            ("cohere/command-r", "cohere/%", True),
+            ("cohere/v1/foo", "cohere/%", True),
+            ("cohere/command-r", "%command%", True),
+            ("llama-3", "%llama%", True),
+            ("cohere/command-r", "anthropic/%", False),
         ],
     )
     def test_matches(self, name, pattern, expected) -> None:
@@ -548,6 +556,10 @@ class TestServiceNameMatches:
             ("*llama*", None),
             ("?x", None),
             ("[ab]c", None),
+            # ``%`` stops the prefix scan the same way ``*`` does.
+            ("cohere/command-%", "cohere/command-"),
+            ("cohere/%", "cohere/"),
+            ("%llama%", None),
         ],
     )
     def test_literal_prefix(self, pattern, expected) -> None:


### PR DESCRIPTION
## Summary

\`data\` subcommands locate services by **\`listing.name\`** — you give the CLI the name, and it walks the data tree to find the matching files. That's strictly easier than the path-based alternative: the user never has to know or type the data-dir layout (\`data/<provider>/services/<service>/\`), just the name they wrote in \`listing.json\`.

Once name-based locating is the model, **three** old knobs all fall away:

- \`--name\` flag → folded into the positional itself.
- \`--data-dir\` flag / \`[DATA_DIR]\` positional → always cwd. Removes the \`[DATA_DIR] [NAME]\` two-positional "is \`foo\` a path or a name?" guess.
- \`--provider\` flag → just type \`provider/*\` as the name pattern. Listing names are already provider-namespaced; an fnmatch wildcard covers the provider-scope case naturally.

## Before / after

| Command | Before | After |
|---|---|---|
| \`data list-tests\` | \`[DATA_DIR] [OPTIONS] --name PATTERN --provider P\` | \`[OPTIONS] [NAME]\` |
| \`data run-tests\`  | \`[DATA_DIR] [OPTIONS] --name PATTERN --provider P\` | \`[OPTIONS] [NAME]\` |
| \`data upload\`     | \`[DATA_DIR] [OPTIONS] --name PATTERN\`              | \`[OPTIONS] [NAME]\` |

\`NAME\` is an fnmatch pattern on \`service_name\` (= \`listing.name\`, #1138):

- omit → process every service in cwd
- \`'cohere/*'\` → whole provider
- \`'cohere/command-r-*'\` → a slice of a provider
- \`cohere/command-r-plus\` → one literal service
- \`http-relay\` → a top-level service (bare names, rare)

\`data validate\` and \`data format\` are unchanged — they always process the full data dir, no per-service selector needed.

## Why name-based locating wins for \`data\`

- **You already know the name.** It's the value you authored in \`listing.json\`, the value the gateway uses to route, the value other CLIs show you. Locating by that is one consistent identity across the whole workflow.
- **The directory layout is platform plumbing, not interface.** Where the listing file actually lives under \`data/\` is a convention the SDK already understands. Forcing the user to mirror that convention by typing a path is reverse-engineering the wrong direction.
- **Always-cwd is the natural complement.** Once you locate by name, the only reason to vary the root is "I keep my catalogs in different places" — and \`cd\` solves that already, with no new flag to remember.
- **Provider scope is just a wildcard pattern.** Listing names are already \`<provider>/<bare>\` per #1196. A \`provider/*\` pattern on \`NAME\` covers what \`--provider provider\` used to, with no second flag to learn.

## End-to-end smoke test
\`\`\`
$ cd unitysvc-services-http
$ usvc_seller data list-tests http-relay     # literal name → 3 docs on that service
$ usvc_seller data list-tests 'labs/*'       # fnmatch pattern → labs-namespaced services
\`\`\`
Both render correctly.

## Tests + checks
- 161 tests pass (the 2 pre-existing \`test_validator.py\` failures on main are an unrelated stale fixture, ignored here as before).
- \`ruff check\` + \`mypy\` clean on touched files.
- \`docs/cli-reference.md\` regenerated from the new Typer surface.

## Migration note

| Before | After |
|---|---|
| \`usvc_seller data run-tests path/to/data\` | \`cd path/to/data && usvc_seller data run-tests\` |
| \`usvc_seller data run-tests --name cohere/command-r-plus\` | \`usvc_seller data run-tests cohere/command-r-plus\` |
| \`usvc_seller data run-tests --provider cohere\` | \`usvc_seller data run-tests 'cohere/*'\` |
| \`usvc_seller data upload --name 'cohere/*'\` | \`usvc_seller data upload 'cohere/*'\` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)