### PR TITLE
release: v0.1.16 — positional NAME selectors; bump unitysvc-core to 0.1.17

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "unitysvc-sellers"
-version = "0.1.15"
+version = "0.1.16"
 description = "Seller-facing tools for UnitySVC: HTTP SDK + usvc_seller CLI"
 readme = "README.md"
 authors = [{ name = "Bo Peng", email = "bo.peng@unitysvc.com" }]
@@ -17,7 +17,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-  "unitysvc-core>=0.1.15",
+  "unitysvc-core>=0.1.17",
   "unitysvc-data>=0.1.18",
   "typer",
   "rich",

--- a/tests/example_data/provider2/services/service2/listing.json
+++ b/tests/example_data/provider2/services/service2/listing.json
@@ -7,8 +7,7 @@
   "user_access_interfaces": {
     "provider_api": {
       "access_method": "http",
-      "base_url": "${API_GATEWAY_BASE_URL}/{{ service_name }}",
-      "api_key": null
+      "base_url": "${API_GATEWAY_BASE_URL}/{{ service_name }}"
     }
   },
   "documents": {


### PR DESCRIPTION
## Summary
- Bumps `unitysvc-sellers` to **v0.1.16**.
- Bumps `unitysvc-core` dep from `>=0.1.15` → `>=0.1.17` to pick up the latest validator + schema.
- Release umbrella for the two feature PRs landing this cycle:
  - **#66** — services CLI unified on positional `NAME` (fnmatch / strict glob; `%` as a shell-safe alias for `*`) + `--id <prefix>` for disambiguation.
  - **#67** — data CLI simplified to positional `NAME` only (drops `--name`, `--data-dir`, `--provider`; cwd is implicit).

Also includes the stale-fixture fix on `provider2/service2/listing.json` (drops a now-rejected `api_key: null` field) so this branch's tests pass against `main` ahead of the feature PRs merging. Once #66 / #67 merge, that bit of the diff drops out cleanly.

## Test plan
- [x] `uv run pytest -x -q` — 216 passed.
- [x] `uv lock` — resolves `unitysvc-core 0.1.17` from PyPI; `unitysvc-sellers` now at `0.1.16`.
- [ ] Merge after #66 and #67 land (rebase if needed).
- [ ] Tag `v0.1.16` after merge and let release CI publish to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)