### PR TITLE
docs: document enrollment.code + /e/<code>; remove enrollment_code()

### DIFF
--- a/docs/file-schemas.md
+++ b/docs/file-schemas.md
@@ -156,7 +156,7 @@ Service files define the service offering from the upstream provider's perspecti
 | `schema`                     | string                      | Must be `"offering_v1"`                                                                                                                                                           |
 | `name`                       | string                      | Service identifier (must match directory name, allows slashes for hierarchy)                                                                                                      |
 | `service_type`               | enum                        | Service category (see [ServiceTypeEnum values](#servicetype-enum-values))                                                                                                         |
-| `upstream_access_config` | dict of AccessInterfaceData | How to access upstream services, keyed by interface name. Supports Jinja2 templates (e.g. `{{ enrollment_code(6) }}`); expanded at gateway routing time using enrollment context. |
+| `upstream_access_config` | dict of AccessInterfaceData | How to access upstream services, keyed by interface name. Supports Jinja2 templates (e.g. `{{ enrollment.code }}`); expanded at gateway routing time using enrollment context. |
 | `time_created`               | datetime (ISO 8601)         | Timestamp when offering was created                                                                                                                                               |
 
 ### Optional Fields
@@ -280,22 +280,22 @@ The `service_options` field configures backend behavior for service listings. Al
 
 **Enrollment Variables (`enrollment_vars`):**
 
-The `enrollment_vars` field defines per-enrollment variables that are rendered and passed to code examples and test scripts during both local testing (`usvc_seller data run-tests`) and gateway testing (`usvc_seller services run-tests`). Values support Jinja2 template syntax with access to enrollment context functions.
+The `enrollment_vars` field defines per-enrollment variables that are rendered and passed to code examples and test scripts during both local testing (`usvc_seller data run-tests`) and gateway testing (`usvc_seller services run-tests`). Values support Jinja2 template syntax with access to the enrollment context.
 
 ```json
 {
     "service_options": {
         "enrollment_vars": {
-            "user_id": "{{ enrollment_code(6) }}",
+            "user_id": "{{ enrollment.code }}",
             "region": "us-east-1"
         }
     }
 }
 ```
 
-Template functions available in `enrollment_vars` values:
+Enrollment context available in `enrollment_vars` values:
 
-- `{{ enrollment_code(N) }}` — Returns the enrollment's unique code (N = length). The code is stable per enrollment.
+- `{{ enrollment.code }}` — the enrollment's unique 4-character code, stable per enrollment (also reachable at `/e/<code>`).
 
 Variable names should be lowercase. They are available directly in access interface templates as `{{ var_name }}`.
 
@@ -316,7 +316,7 @@ Variable names should be lowercase. They are available directly in access interf
             "region": "us-east-1"
         },
         "enrollment_vars": {
-            "USER_ID": "{{ enrollment_code(6) }}"
+            "USER_ID": "{{ enrollment.code }}"
         },
         "enrollment_limit": 100,
         "enrollment_limit_per_customer": 5,
@@ -338,7 +338,7 @@ api_key = "${ secrets.SERVICE_API_KEY }"
 region = "us-east-1"
 
 [service_options.enrollment_vars]
-user_id = "{{ enrollment_code(6) }}"
+user_id = "{{ enrollment.code }}"
 ```
 
 ### Listing Name Field
@@ -693,19 +693,16 @@ String values in `user_access_interfaces` and `upstream_access_config` can use *
 
 **Template context variables:**
 
-| Variable                 | Type   | Description               |
-| ------------------------ | ------ | ------------------------- |
-| `enrollment.id`          | string | Enrollment UUID           |
-| `enrollment.customer_id` | string | Customer UUID             |
-| `enrollment.parameters`  | dict   | All enrollment parameters |
+| Variable                 | Type   | Description                                          |
+| ------------------------ | ------ | --------------------------------------------------- |
+| `enrollment.code`        | string | The enrollment's unique **4-character** reference code |
+| `enrollment.id`          | string | Enrollment UUID                                     |
+| `enrollment.customer_id` | string | Customer UUID                                       |
+| `enrollment.parameters`  | dict   | All enrollment parameters                           |
 
-**Template functions:**
+Every enrollment has a unique, stable **4-character code** (Crockford base32, e.g. `CEFF`), available as `{{ enrollment.code }}` and identical across `user_access_interfaces` and `upstream_access_config`. The same code is a built-in routing handle: **every enrollment is reachable at `/e/<code>`** regardless of its `base_url`. `/e/` is reserved — do not use it in `base_url`.
 
-| Function                    | Returns | Description                                                    |
-| --------------------------- | ------- | -------------------------------------------------------------- |
-| `enrollment_code(length=6)` | string  | Create or retrieve a random code tied to a specific enrollment |
-
-The `enrollment_code` function is idempotent — calling it multiple times for the same enrollment returns the same code. The code is persisted in the `action_code` table and can be referenced from both `user_access_interfaces` and `upstream_access_config` templates.
+> **Migration:** `enrollment.code` replaces the old `enrollment_code()` function. Use `{{ enrollment.code }}` instead of `{{ enrollment_code(6) }}` (the length argument is gone — the code is always 4 characters).
 
 **Behavior:**
 
@@ -719,7 +716,7 @@ The `enrollment_code` function is idempotent — calling it multiple times for t
 ```toml
 [user_access_interfaces.ntfy-gateway]
 access_method = "http"
-base_url = "${API_GATEWAY_BASE_URL}/ntfy/{{ enrollment_code(6) }}"
+base_url = "${API_GATEWAY_BASE_URL}/ntfy/{{ enrollment.code }}"
 description = "Your ntfy notification endpoint"
 ```
 
@@ -730,7 +727,7 @@ description = "Your ntfy notification endpoint"
     "user_access_interfaces": {
         "ntfy-gateway": {
             "access_method": "http",
-            "base_url": "${API_GATEWAY_BASE_URL}/ntfy/{{ enrollment_code(6) }}",
+            "base_url": "${API_GATEWAY_BASE_URL}/ntfy/{{ enrollment.code }}",
             "description": "Your ntfy notification endpoint"
         }
     }
@@ -741,21 +738,21 @@ After enrollment, the `base_url` is rendered with the generated code (e.g., `${A
 
 **Example — upstream access interface with template:**
 
-The corresponding upstream interface in the offering can reference the same `enrollment_code()` to route requests to the correct upstream target:
+The corresponding upstream interface in the offering can reference the same `{{ enrollment.code }}` to route requests to the correct upstream target:
 
 ```json
 {
     "upstream_access_config": {
         "ntfy-upstream": {
             "access_method": "http",
-            "base_url": "https://ntfy.svcpass.com/{{ enrollment_code(6) }}",
+            "base_url": "https://ntfy.svcpass.com/{{ enrollment.code }}",
             "description": "Private ntfy instance"
         }
     }
 }
 ```
 
-Unlike user interfaces, upstream templates are **not** materialized at enrollment time. They are rendered at gateway routing time — the gateway identifies the enrollment from the inbound request, then expands the upstream template with the enrollment's `enrollment_code()` to determine the final upstream URL.
+Unlike user interfaces, upstream templates are **not** materialized at enrollment time. They are rendered at gateway routing time — the gateway identifies the enrollment from the inbound request, then expands the upstream template with the enrollment's `enrollment.code` to determine the final upstream URL.
 
 #### Routing Key
 

--- a/docs/service-types.md
+++ b/docs/service-types.md
@@ -148,7 +148,7 @@ When per-enrollment values are needed in URLs (e.g., unique topic codes):
 
 ```toml
 [service_options.enrollment_vars]
-topic = "{{ enrollment_code(6) }}"
+topic = "{{ enrollment.code }}"
 
 [user_access_interfaces.gateway]
 access_method = "http"
@@ -156,8 +156,10 @@ base_url = "${API_GATEWAY_BASE_URL}/ntfy/{{ topic }}"
 ```
 
 Rendering happens in two phases:
-1. `enrollment_vars` rendered first — `{{ enrollment_code(6) }}` → `VTXBNM`
-2. Access interface URL rendered — `{{ topic }}` → `VTXBNM`
+1. `enrollment_vars` rendered first — `{{ enrollment.code }}` → `CEFF` (every enrollment's unique 4-character code)
+2. Access interface URL rendered — `{{ topic }}` → `CEFF`
+
+Every enrollment is also reachable directly at `/e/CEFF` regardless of `base_url` — see [User Access Interface Templates](tech-notes/user-access-interface-template.md).
 
 See [User Access Interface Templates](tech-notes/user-access-interface-template.md) for details.
 

--- a/docs/tech-notes/user-access-interface-template.md
+++ b/docs/tech-notes/user-access-interface-template.md
@@ -15,22 +15,24 @@ Interfaces containing template syntax (`{{` or `{%`) are rendered per-enrollment
 
 Templates are rendered with these variables:
 
-| Variable                     | Type   | Description                     |
-| ---------------------------- | ------ | ------------------------------- |
-| `enrollment.id`              | string | Enrollment UUID                 |
-| `enrollment.customer_id`     | string | Customer UUID                   |
-| `enrollment.parameters`      | dict   | All enrollment parameters       |
+| Variable                     | Type   | Description                                          |
+| ---------------------------- | ------ | --------------------------------------------------- |
+| `enrollment.code`            | string | The enrollment's unique **4-character** reference code |
+| `enrollment.id`              | string | Enrollment UUID                                     |
+| `enrollment.customer_id`     | string | Customer UUID                                       |
+| `enrollment.parameters`      | dict   | All enrollment parameters                           |
 
-## Template Functions
+## `enrollment.code` and the `/e/<code>` primitive
 
-### `enrollment_code(length=6)`
+**Every enrollment is assigned a unique, stable 4-character code** (Crockford base32, e.g. `CEFF`) at creation. Reference it in any template with `{{ enrollment.code }}` — both `user_access_interfaces` and `upstream_access_config` see the same value for a given enrollment.
 
-Creates or retrieves a random code tied to a specific enrollment. The function is **idempotent** — repeated calls for the same enrollment return the same code (looked up by `entity_id` and `code_type=enrollment` in the `action_code` table). This allows both `user_access_interfaces` and `upstream_access_config` to reference the same enrollment-specific code.
+The code is also a built-in routing handle: **every enrollment is reachable at `/e/<code>`** (e.g. `${API_GATEWAY_BASE_URL}/e/CEFF`), which the gateway resolves to that enrollment's endpoint — regardless of the `base_url` you define. You don't build `/e/...` yourself, and `/e/` is **reserved** (you cannot use it in `base_url`); it is always available for free, as a short, unique handle to the enrollment.
 
 ```jinja2
-{{ enrollment_code() }}      {# 6-character uppercase token, e.g. VTXBNM #}
-{{ enrollment_code(8) }}     {# 8-character token #}
+{{ enrollment.code }}      {# 4-character code, e.g. CEFF #}
 ```
+
+> **Migration:** `enrollment.code` replaces the old `enrollment_code()` template function. Use `{{ enrollment.code }}` instead of `{{ enrollment_code(6) }}`. The code is now a fixed 4 characters — the length argument is gone.
 
 ## Example: ntfy Service
 
@@ -42,7 +44,7 @@ The ntfy service exposes a notification gateway where each enrollment gets a uni
 # listing.toml — user-facing endpoint with per-enrollment topic
 [user_access_interfaces.ntfy-gateway]
 access_method = "http"
-base_url = "${API_GATEWAY_BASE_URL}/ntfy/{{ enrollment_code(6) }}"
+base_url = "${API_GATEWAY_BASE_URL}/ntfy/{{ enrollment.code }}"
 description = "Your ntfy notification endpoint"
 ```
 
@@ -50,18 +52,18 @@ description = "Your ntfy notification endpoint"
 # offering.toml — upstream endpoint with same enrollment code
 [upstream_access_config.ntfy-upstream]
 access_method = "http"
-base_url = "https://ntfy.svcpass.com/{{ enrollment_code(6) }}"
+base_url = "https://ntfy.svcpass.com/{{ enrollment.code }}"
 description = "Private ntfy instance"
 ```
 
-Both templates call `enrollment_code(6)` and resolve to the same code (e.g. `VTXBNM`) for a given enrollment.
+Both templates reference `{{ enrollment.code }}` and resolve to the same code (e.g. `CEFF`) for a given enrollment.
 
 ### After Enrollment
 
-- Topic code `VTXBNM` is generated and persisted in the `action_code` table
-- An enrollment-scoped `AccessInterface` is created with `base_url = "${API_GATEWAY_BASE_URL}/ntfy/VTXBNM"`
+- The enrollment's code (e.g. `CEFF`) is generated at enrollment creation
+- An enrollment-scoped `AccessInterface` is created with `base_url = "${API_GATEWAY_BASE_URL}/ntfy/CEFF"`
 - The user sees their complete, personalized endpoint
-- At gateway routing time, the upstream template resolves to `https://ntfy.svcpass.com/VTXBNM`
+- At gateway routing time, the upstream template resolves to `https://ntfy.svcpass.com/CEFF`
 - Gateway forwards the request to the correct upstream topic
 
 ### Access Control
@@ -82,14 +84,14 @@ Enrollment-scoped `AccessInterface` records are only visible to the enrollment t
 2. Each interface is classified:
    - **Template** (contains `{{` or `{%`): rendered per-enrollment, creates enrollment-scoped `AccessInterface`
    - **Static** (no template syntax): shared listing-scoped `AccessInterface` (idempotent)
-3. Template rendering uses `jinja2.Environment(enable_async=True)` with `render_async()`, which auto-awaits async functions like `enrollment_code()`
+3. Template rendering substitutes `{{ enrollment.code }}` (and the other `enrollment.*` context values) with the enrollment's data
 4. Rendered values are validated as `AccessInterfaceData` and persisted via upsert
 
 ### Upstream access interfaces (gateway routing time)
 
 1. When a request arrives, the gateway identifies the enrollment from the user access interface match
 2. If the offering's `upstream_access_config` contain template syntax, they are rendered using the enrollment context
-3. `enrollment_code()` resolves to the same code that was created at enrollment time (idempotent lookup)
+3. `{{ enrollment.code }}` resolves to the enrollment's 4-character code (assigned at enrollment creation)
 4. The resolved upstream URL is used to forward the request — no upstream `AccessInterface` records are created per enrollment
 
 ## Consistency with Service Groups

--- a/src/unitysvc_sellers/example.py
+++ b/src/unitysvc_sellers/example.py
@@ -10,7 +10,6 @@ making it easy to track results in version control.
 import os
 import random
 import re
-import string
 from pathlib import Path
 from typing import Any
 
@@ -34,15 +33,22 @@ console = Console()
 
 _jinja_env = jinja2.Environment()
 
+# Crockford base32 alphabet (no I/L/O/U) — matches the real enrollment code.
+_CROCKFORD = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+
 # Fixed test code reused across a single run so all templates resolve consistently
 _test_enrollment_code: str | None = None
 
 
-def _get_test_enrollment_code(length: int = 6) -> str:
-    """Return a fixed random code for local testing (no real enrollment)."""
+def _get_test_enrollment_code(length: int = 4) -> str:
+    """Return a fixed random 4-character code for local testing (no real enrollment).
+
+    Mirrors the platform's intrinsic ``enrollment.code`` (a fixed 4-character
+    Crockford base32 code assigned to every enrollment).
+    """
     global _test_enrollment_code
     if _test_enrollment_code is None:
-        _test_enrollment_code = "".join(random.choices(string.ascii_uppercase, k=length))
+        _test_enrollment_code = "".join(random.choices(_CROCKFORD, k=length))
     return _test_enrollment_code
 
 
@@ -52,7 +58,7 @@ def expand_template_strings(
 ) -> dict[str, Any]:
     """Expand Jinja2 template syntax in string values of a dict (recursively).
 
-    Uses a fake enrollment_code() for local testing. Only processes
+    Provides a fake ``enrollment.code`` for local testing. Only processes
     string values that contain {{ or {%; nested dicts are expanded
     recursively so that ``routing_key.model = "{{ params.model }}"`` is
     resolved before the value is placed into the template render context.
@@ -61,9 +67,14 @@ def expand_template_strings(
         data: Dict whose string values may contain Jinja2 templates.
         extra_context: Additional template variables (e.g. rendered enrollment_vars).
     """
-    ctx: dict[str, Any] = {"enrollment_code": _get_test_enrollment_code}
+    ctx: dict[str, Any] = {}
     if extra_context:
         ctx.update(extra_context)
+    # Ensure {{ enrollment.code }} resolves for local testing, without
+    # clobbering any enrollment context the caller already supplied.
+    enrollment_ctx = dict(ctx.get("enrollment") or {})
+    enrollment_ctx.setdefault("code", _get_test_enrollment_code())
+    ctx["enrollment"] = enrollment_ctx
     result = {}
     for key, value in data.items():
         if isinstance(value, str) and ("{{" in value or "{%" in value):
@@ -76,8 +87,6 @@ def expand_template_strings(
             value = expand_template_strings(value, extra_context)
         result[key] = value
     return result
-
-
 
 
 def extract_code_examples_from_listing(listing_data: dict[str, Any], listing_file: Path) -> list[dict[str, Any]]:

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -657,7 +657,7 @@ class TestServiceOptionsValidation:
         data = {
             "schema": "listing_v1",
             "service_options": {
-                "enrollment_vars": {"user_id": "{{ enrollment_code(6) }}"},
+                "enrollment_vars": {"user_id": "{{ enrollment.code }}"},
             },
         }
         errors = validator.validate_service_options_keys(data, "listing_v1")
@@ -697,10 +697,9 @@ class TestServiceOptionsValidation:
         data = {
             "schema": "listing_v1",
             "service_options": {
-                "enrollment_vars": {"topic": "{{ enrollment_code() }}"},
+                "enrollment_vars": {"topic": "{{ enrollment.code }}"},
                 "enrollment_limit_per_customer": 5,
             },
         }
         errors = validator.validate_service_options_keys(data, "listing_v1")
         assert errors == []
-


### PR DESCRIPTION
## Summary

Document the intrinsic **`enrollment.code`** and the **`/e/<code>`** routing primitive, and remove the old `enrollment_code()` Jinja function from seller-facing docs and tooling.

Every enrollment now has a stable, unique **4-character code** (Crockford base32, e.g. `CEFF`):
- Reference it in templates with `{{ enrollment.code }}` (same value in `user_access_interfaces` and `upstream_access_config`).
- Every enrollment is reachable at **`/e/<code>`** regardless of its `base_url`. `/e/` is **reserved** — sellers cannot use it in `base_url`.

## Changes

- **`docs/tech-notes/user-access-interface-template.md`** — replaced the `enrollment_code(length=6)` "Template Functions" section with `enrollment.code` in the template-context table + a dedicated `/e/<code>` section; updated the ntfy examples and "How It Works"; added a migration note.
- **`docs/file-schemas.md`** — same: `enrollment.code` in the context table, `/e/<code>` note, migration note; updated all `{{ enrollment_code(6) }}` examples.
- **`docs/service-types.md`** — enrollment-vars example uses `{{ enrollment.code }}`; notes `/e/<code>` reachability.
- **`src/unitysvc_sellers/example.py`** — local-test renderer now supplies a fake **4-char** `enrollment.code` (Crockford alphabet) instead of an `enrollment_code()` function.
- **`tests/test_validator.py`** — fixtures updated to `{{ enrollment.code }}`.

## Test plan

- [x] `ruff check` + `ruff format --check` clean
- [x] `pytest tests/test_validator.py tests/test_example.py` — 64 passed

Relates to unitysvc/unitysvc#1202 (the `/e/` primitive; `enrollment_code()` was removed in unitysvc#1204).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
