### PR TITLE
docs: introduce the Service Templates concept

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,29 @@ API (`https://seller.unitysvc.com/v1`). This package provides:
 | **Python SDK** | [SDK Guide](https://unitysvc-sellers.readthedocs.io/en/latest/sdk-guide/) | [SDK Reference](https://unitysvc-sellers.readthedocs.io/en/latest/sdk-reference/) (auto-generated from docstrings) |
 | **CLI** | [CLI Guide](https://unitysvc-sellers.readthedocs.io/en/latest/cli-guide/) | [CLI Reference](https://unitysvc-sellers.readthedocs.io/en/latest/cli-reference/) (auto-generated from `typer`) |
 
+## Service templates
+
+A **service template** is a *parameterized* version of service data — the
+`offering.json` / `listing.json` you'd otherwise write by hand, with the parts
+that vary replaced by parameters plus the logic to fill them. Render it and you
+get back complete, schema-valid service data. Templates are the easy way to
+**offer a common service** and the scalable way to **populate a group of
+services**. There are three ways to use them:
+
+1. **Platform templates** *(easiest)* — the platform authors a template for a
+   common service type; you pick it in the dashboard's *Create from template*
+   flow, fill a short form, and it renders + uploads with its own bundled tests.
+2. **Capability pools** — a platform template carrying a *pool name*;
+   instantiating it joins `/p/<pool>` at the pool's uniform terms and price. You
+   provide only the upstream URL. (Opt-in; `usvc_seller data upload` cannot
+   create a pool service — only a pool template can.)
+3. **Your own templates** — author `.j2` templates + a populator script, then
+   `usvc_seller data populate` to generate many services from a source list.
+
+See **[Service Templates](https://unitysvc-sellers.readthedocs.io/en/latest/service-templates/)**
+for the full guide, and [Workflows → Automated Workflow](https://unitysvc-sellers.readthedocs.io/en/latest/workflows/#automated-workflow-template-based)
+for the populator walkthrough.
+
 ## Install
 
 ```bash

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,6 +11,8 @@ UnitySVC provides two complementary approaches:
 The [UnitySVC web platform](https://unitysvc.com) provides a user-friendly interface to:
 
 - Create, edit, and manage providers, offerings, and listings
+- **Create a service from a platform template** in a few clicks — the fastest
+  way to offer a common service type (see [Service Templates](service-templates.md))
 - Validate data with instant feedback
 - Preview how services appear to customers
 - Export data for use with the SDK

--- a/docs/index.md
+++ b/docs/index.md
@@ -74,6 +74,17 @@ This enables scenarios like:
 - One offering with multiple listings (e.g., basic/premium tiers)
 - Shared documentation across services
 
+## Service Templates
+
+A **service template** is a *parameterized* version of the service data above —
+the variable parts replaced by parameters, plus the logic to fill them. Render
+it and you get back complete, schema-valid service data. Templates make it easy
+to **offer a common service** (the platform authored the hard parts; you supply
+a few values) and to **populate a whole group of services** from a source list.
+See [Service Templates](service-templates.md) for the three ways to use them —
+platform templates, capability pools, and your own `usvc_seller data populate`
+generators.
+
 ## Key Features
 
 -   **Unified Upload** — Provider, offering, and listing uploaded together atomically

--- a/docs/service-templates.md
+++ b/docs/service-templates.md
@@ -1,0 +1,117 @@
+# Service Templates
+
+A **service template** is a *parameterized* version of service data: the
+`offering.json` / `listing.json` (and friends) you would otherwise write by
+hand, but with the parts that change from one service to the next replaced by
+**parameters** — and a small amount of logic that fills those parameters in.
+Render the template with a set of parameter values and you get back complete,
+schema-valid service data, ready to validate and upload.
+
+> **Is there a word for this?** The act is **parameterizing** (or
+> "templatizing") your service data; the result is a **parameterized service
+> definition**. Throughout the platform we just call it a *service template*.
+
+If a plain service is "one filled-in form", a service template is "the blank
+form plus instructions for filling it" — which is exactly what makes it good at
+two jobs:
+
+1. **Offer a common service with almost no effort** — the hard parts (pricing
+   shape, upstream config, tests) are authored once, by the template, and you
+   supply only a handful of values.
+2. **Populate a whole *group* of services at once** — point a template at a
+   list (your upstream's model catalog, a spreadsheet, an API) and generate one
+   service per item, consistently.
+
+## Three ways to use service templates
+
+The three uses sit on a spectrum from *least effort* to *most control*. Pick
+the row that matches what you're doing.
+
+| Use | Who authors the template | How you use it | Best for |
+|---|---|---|---|
+| **1. Platform templates** | The platform | Dashboard → *Create from template*, fill a short form | Offering a common service type with zero file authoring |
+| **2. Capability pools** | The platform (template carries a pool name) | Dashboard → instantiate a pool template; you provide only the upstream URL | Joining a fungible, uniformly-priced commodity pool |
+| **3. Your own templates** | You | Author `.j2` templates + a populator script, then `usvc_seller data populate` | Generating many services programmatically from a source list |
+
+### 1. Platform service templates — the easy path
+
+The platform publishes **curated templates** for the most common service types
+(e.g. an OpenAI-compatible LLM endpoint). This is the **easiest way to create
+and upload a service**: in the dashboard, choose *Create from template*, fill a
+short, typed form (model id, upstream URL, an API-key secret name, a price),
+and the platform renders the complete service spec, runs the bundled
+connectivity test, and submits it through the normal publish pipeline. No local
+files, no SDK, no test to write — the template ships its own.
+
+You manage the resulting service exactly like any other (it appears under your
+**Staging** list), and if you outgrow the template you can download the rendered
+files and refine them with this SDK.
+
+> Platform templates are a **dashboard** feature; there is no `usvc_seller`
+> command for them. Reach for use #3 below when you want to generate services
+> from local files.
+
+### 2. Capability pools — opt in with a pool name
+
+A **capability pool** (`/p/<capability>`) is a special platform template that
+carries a **pool name**. Every service instantiated from a pool template
+automatically joins `/p/<pool-name>`, where the gateway load-balances across all
+verified providers of that capability. Because the model, contract, **price, and
+terms are fixed by the template**, every member is fungible — you only provide
+your upstream URL (and a key secret, if your upstream needs one). Opting in is
+that simple: in the dashboard, instantiate the pool template.
+
+A few consequences worth knowing:
+
+- **Uniform price → performance routing.** Every member is billed at the pool's
+  single price, so the pool routes requests by performance (latency / quality /
+  health), not cost.
+- **Opt-in and non-exclusive.** Want a different price? Offer the same
+  capability as a **separate, standalone service** at your own price; pool
+  membership doesn't stop you.
+- **Membership comes only from a pool template.** A pool service can be created
+  *only* by instantiating a pool-named template — `usvc_seller data upload` of a
+  hand-authored spec always produces a plain standalone service, never a pool
+  member.
+
+### 3. Your own service templates — `usvc_seller data populate`
+
+When you offer *many* similar services — every model your upstream serves, a
+region per endpoint, a tier per plan — author the template **yourself** and let
+the SDK generate the catalog. This is the populator pattern, and it's the
+SDK-native way to **populate a group of services**:
+
+1. Author `offering.json.j2` / `listing.json.j2` (and any doc/test templates)
+   under `data/<provider>/templates/`, replacing the per-service values with
+   `{{ placeholders }}`.
+2. Write a **populator script** that yields one parameter dict per service
+   (typically by reading your upstream's model list).
+3. Declare it in `provider.toml` under `[services_populator]`.
+4. Run it:
+
+   ```bash
+   usvc_seller data populate           # render every service from the template
+   usvc_seller data populate --dry-run # preview without writing files
+   ```
+
+   The generated `services/<name>/offering.json` + `listing.json` are normal
+   service data — validate, test, and upload them like anything else. Re-running
+   `populate` keeps the catalog in sync with the source list (services that
+   disappear upstream are marked `deprecated`).
+
+The full, step-by-step guide — converting a working service into templates,
+writing the populator, filtering, and CI automation — lives in
+[Workflows → Automated Workflow (Template-Based)](workflows.md#automated-workflow-template-based).
+
+## Which one should I use?
+
+- **One common service, fastest path?** → Platform template (use #1).
+- **Joining a commodity pool at the platform's price?** → Capability pool
+  (use #2).
+- **Generating a catalog of many services from a source list?** → Your own
+  templates + `populate` (use #3).
+
+Uses #1 and #2 are about **ease** (the platform did the hard authoring for you);
+use #3 is about **scale** (you author once, generate many). They compose freely
+— a seller might join a capability pool for a commodity model *and* run a
+populator for their long tail of specialty endpoints.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -208,6 +208,12 @@ usvc_seller data upload --data-path ./data
 
 ## Automated Workflow (Template-Based)
 
+This is **use #3** of [Service Templates](service-templates.md): you author
+your own `.j2` templates and a populator script, then generate a whole group of
+services with `usvc_seller data populate`. (For the *platform-authored*
+templates and capability pools — the zero-authoring paths — see the
+[Service Templates](service-templates.md) overview.)
+
 Best for providers with:
 
 - Large service catalogs (> 20 services)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,6 +78,7 @@ nav:
       - Usage Overview: usage.md
       - Installation & Quick Start: getting-started.md
       - Service Types: service-types.md
+      - Service Templates: service-templates.md
       - Data Structure: data-structure.md
       - Workflows: workflows.md
       - Seller Lifecycle: seller-lifecycle.md


### PR DESCRIPTION
## Summary

Introduces **Service Templates** as a first-class concept in the seller docs: a
*parameterized* version of service data (the `offering.json` / `listing.json`
you'd otherwise write by hand, with the variable parts replaced by parameters
plus the logic to fill them). Templates are the **easy way to offer a common
service** and the **scalable way to populate a group of services**.

The SDK already shipped the populator mechanics (`.j2` templates +
`services_populator` + `usvc_seller data populate`), but the *concept* was never
named or tied together with the platform-side template flows. This PR fills that
gap.

## What's documented

A new **[Service Templates](docs/service-templates.md)** page presents the three
uses as an effort-vs-control spectrum:

| Use | Author | How | Best for |
|---|---|---|---|
| **Platform templates** | Platform | Dashboard → *Create from template* | Offer a common service, zero file authoring |
| **Capability pools** | Platform (pool-named) | Instantiate a pool template | Join `/p/<pool>` at uniform terms/price |
| **Your own templates** | You | `.j2` + populator + `usvc_seller data populate` | Generate many services from a source list |

It also answers the naming question — the act is *parameterizing* your service
data; the result is a *parameterized service definition* — and clarifies that
pool membership comes **only** from instantiating a pool template (`data upload`
of a hand-authored spec is always a plain standalone service).

## Changes

- **New** `docs/service-templates.md` — the canonical concept page.
- `mkdocs.yml` — adds it to the *Getting Started* nav.
- `index.md` — a *Service Templates* section under the data model.
- `getting-started.md` — notes "Create from template" as the fastest on-ramp.
- `workflows.md` — frames the existing template-based section as **use #3** and
  cross-links the concept page (no rewrite of the mechanics).
- `README.md` — a *Service templates* section with the three uses + doc links.

## Verification

- [x] `mkdocs build --strict` — builds clean, no broken internal links or anchors
- [x] Documents only existing behavior: `usvc_seller data populate` /
  `services_populator` / `.j2` (SDK) and the dashboard template/pool flows
  (platform); no invented CLI commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)
