### PR TITLE
specs: add 'usvc_seller specs validate' for the flat specs/ layout

### DIFF
--- a/src/unitysvc_sellers/cli.py
+++ b/src/unitysvc_sellers/cli.py
@@ -7,6 +7,7 @@ import importlib.metadata
 import typer
 
 from . import data
+from . import specs as specs_cmd
 from .commands import groups as groups_cmd
 from .commands import params as params_cmd
 from .commands import promotions as promotions_cmd
@@ -52,6 +53,7 @@ def main(
 
 # Local catalog tools
 app.add_typer(data.app, name="data")
+app.add_typer(specs_cmd.app, name="specs")
 
 # Remote API command groups (use AsyncClient under the hood)
 app.add_typer(services_cmd.app, name="services")

--- a/src/unitysvc_sellers/specs.py
+++ b/src/unitysvc_sellers/specs.py
@@ -1,0 +1,206 @@
+"""``specs`` command group — local operations on the flat ``specs/`` layout.
+
+The flat layout (unitysvc#1263) replaces the nested
+``data/<provider>/services/<svc>/`` tree with one self-contained folder per
+Service, named by the (namespaced) service name::
+
+    specs/<provider>/<name...>/
+        provider.json      # the provider that owns this service
+        offering.json      # (or offering.toml) — the offering
+        listing.json       # (or listing.toml)  — the single listing
+        service.json       # optional: service_id + upload provenance
+
+Key differences from the legacy ``data/`` layout, all enforced here:
+
+- **No ``schema`` field.** The *filename* is the type discriminator, so spec
+  files must not carry a ``schema`` key.
+- **No directory traversal for information.** Every folder is self-contained;
+  the provider lives beside the offering and listing rather than two levels up.
+- **The folder path is the service name.** ``listing.name`` must equal the
+  folder's path relative to ``specs/`` (e.g. ``parasail/deepseek-ai/DeepSeek``).
+- **Three required files** per folder: ``provider``, ``offering``, ``listing``
+  (``.json`` or ``.toml``). ``service.json`` is optional provenance written by
+  ``upload``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+import unitysvc_core
+from rich.console import Console
+from unitysvc_core.validator import DataValidator
+
+app = typer.Typer(help="Local operations on the flat specs/ layout")
+console = Console()
+
+# Filename stem → core schema name. The filename is the discriminator now.
+FILENAME_TO_SCHEMA: dict[str, str] = {
+    "provider": "provider_v1",
+    "offering": "offering_v1",
+    "listing": "listing_v1",
+}
+
+# Spec files that must exist in every service folder (service.json is optional).
+REQUIRED_KINDS: tuple[str, ...] = ("provider", "offering", "listing")
+
+_DATA_SUFFIXES = (".json", ".toml")
+
+
+def resolve_specs_root(start: Path) -> Path:
+    """Resolve the ``specs/`` root from a user-supplied path.
+
+    Accepts the repo root (with a ``specs/`` subdir), the ``specs/`` dir
+    itself, or any subtree of it.
+    """
+    candidate = start / "specs"
+    if candidate.is_dir():
+        return candidate
+    return start
+
+
+def _find_kind_file(folder: Path, kind: str) -> tuple[Path | None, list[Path]]:
+    """Return ``(the single <kind>.{json,toml}, all_matches)`` in *folder*."""
+    matches = [folder / f"{kind}{suffix}" for suffix in _DATA_SUFFIXES]
+    present = [p for p in matches if p.is_file()]
+    return (present[0] if len(present) == 1 else None), present
+
+
+def find_service_folders(root: Path) -> list[Path]:
+    """Every folder under *root* that contains a ``listing.{json,toml}``."""
+    folders: set[Path] = set()
+    for suffix in _DATA_SUFFIXES:
+        for listing in root.rglob(f"listing{suffix}"):
+            if any(part.startswith(".") for part in listing.parts):
+                continue
+            folders.add(listing.parent)
+    return sorted(folders)
+
+
+def validate_service_folder(validator: DataValidator, root: Path, folder: Path) -> list[str]:
+    """Validate a single ``specs/`` service folder; return error strings."""
+    errors: list[str] = []
+    rel_folder = folder.relative_to(root).as_posix()
+
+    # Stale override files were folded into service.json by the migration.
+    for override in sorted(folder.glob("*.override.*")):
+        errors.append(
+            f"{override.relative_to(root)}: legacy override file — fold it into "
+            f"service.json (the flat layout stores service_id there)"
+        )
+
+    # Required spec files present, exactly one format each.
+    kind_files: dict[str, Path] = {}
+    for kind in REQUIRED_KINDS:
+        single, present = _find_kind_file(folder, kind)
+        if not present:
+            errors.append(f"{rel_folder}: missing required {kind} file ({kind}.json or {kind}.toml)")
+        elif len(present) > 1:
+            names = ", ".join(p.name for p in present)
+            errors.append(f"{rel_folder}: multiple {kind} files ({names}) — keep exactly one")
+        else:
+            kind_files[kind] = single  # type: ignore[assignment]
+
+    # Per-file validation, keyed by filename rather than a ``schema`` field.
+    for kind, path in kind_files.items():
+        data, load_errors = validator.load_data_file(path)
+        if load_errors or data is None:
+            errors.extend(f"{path.relative_to(root)}: {e}" for e in (load_errors or ["failed to load"]))
+            continue
+        if "schema" in data:
+            errors.append(
+                f"{path.relative_to(root)}: remove the 'schema' field — the filename is the "
+                f"discriminator in the specs/ layout"
+            )
+        try:
+            ok, file_errors = validator.validate_data_file(
+                path, schema_name=FILENAME_TO_SCHEMA[kind], check_name_consistency=False
+            )
+        except Exception as exc:  # noqa: BLE001 — surface, don't crash the run
+            ok, file_errors = False, [f"validation raised {type(exc).__name__}: {exc}"]
+        if not ok:
+            errors.extend(f"{path.relative_to(root)}: {e}" for e in file_errors)
+
+    # The folder path under specs/ must equal the listing (service) name.
+    if "listing" in kind_files:
+        data, load_errors = validator.load_data_file(kind_files["listing"])
+        if not load_errors and isinstance(data, dict):
+            listing_name = data.get("name")
+            if listing_name != rel_folder:
+                errors.append(
+                    f"{rel_folder}: listing name {listing_name!r} does not match the folder path "
+                    f"{rel_folder!r} — the folder under specs/ must be the service name"
+                )
+
+    # Optional service.json: if present, must be a JSON object.
+    service_file = folder / "service.json"
+    if service_file.is_file():
+        data, load_errors = validator.load_data_file(service_file)
+        if load_errors or not isinstance(data, dict):
+            errors.append(f"{service_file.relative_to(root)}: not a valid JSON object")
+        elif "schema" in data:
+            errors.append(f"{service_file.relative_to(root)}: remove the 'schema' field")
+
+    return errors
+
+
+@app.command()
+def validate(
+    specs_dir: Path | None = typer.Argument(
+        None,
+        help="Repo root or specs/ directory to validate (default: current directory)",
+    ),
+    has_service_id: bool = typer.Option(
+        False,
+        "--has-service-id",
+        help="Also require each service folder to have a service.json with a service_id",
+    ),
+) -> None:
+    """Validate a repository in the flat ``specs/`` layout.
+
+    For every service folder (one containing a ``listing.{json,toml}``):
+
+    1. the three spec files (provider, offering, listing) are present, one
+       format each, and carry no ``schema`` field;
+    2. each validates against its core schema (routed by filename);
+    3. ``listing.name`` equals the folder's path relative to ``specs/``.
+    """
+    start = (specs_dir or Path.cwd()).resolve()
+    if not start.exists():
+        console.print(f"[red]✗[/red] Path not found: {start}")
+        raise typer.Exit(1)
+
+    root = resolve_specs_root(start)
+    console.print(f"[cyan]Validating specs in:[/cyan] {root}")
+    console.print()
+
+    schema_dir = Path(unitysvc_core.__file__).parent / "schema"
+    validator = DataValidator(root, schema_dir)
+
+    folders = find_service_folders(root)
+    if not folders:
+        console.print(f"[red]✗[/red] No service folders (containing a listing.json) found under {root}")
+        raise typer.Exit(1)
+
+    validation_errors: list[str] = []
+    for folder in folders:
+        validation_errors.extend(validate_service_folder(validator, root, folder))
+
+        if has_service_id:
+            service_file = folder / "service.json"
+            data, _ = validator.load_data_file(service_file) if service_file.is_file() else (None, [])
+            if not isinstance(data, dict) or not data.get("service_id"):
+                rel = folder.relative_to(root).as_posix()
+                validation_errors.append(
+                    f"{rel}: missing service_id in service.json (run 'usvc_seller specs upload' first)"
+                )
+
+    if validation_errors:
+        console.print(f"[red]✗ Validation failed with {len(validation_errors)} error(s):[/red]")
+        console.print()
+        for i, error in enumerate(validation_errors, 1):
+            console.print(f"[red]{i}.[/red] {error}")
+        raise typer.Exit(1)
+
+    console.print(f"[green]✓ All {len(folders)} service folder(s) are valid![/green]")

--- a/src/unitysvc_sellers/utils.py
+++ b/src/unitysvc_sellers/utils.py
@@ -115,14 +115,13 @@ def resolve_provider_name(file_path: Path) -> str | None:
             # Get the full path to the provider directory
             provider_path = Path(*parts[:services_idx])
 
-            # Look for provider data file to validate and get the actual provider name
+            # Look for the provider file (by filename) and return its name.
             for data_file in find_data_files(provider_path):
                 try:
                     # Only check files in the provider directory itself, not subdirectories
-                    if data_file.parent == provider_path:
+                    if data_file.parent == provider_path and data_file.stem == "provider":
                         data, _file_format = load_data_file(data_file)
-                        if data.get("schema") == "provider_v1":
-                            return data.get("name")
+                        return data.get("name")
                 except Exception:
                     continue
 
@@ -151,12 +150,13 @@ def resolve_service_name_for_listing(listing_file: Path, listing_data: dict[str,
     """
     listing_dir = listing_file.parent
 
-    # Find the service offering file in the same directory
+    # Find the service offering file (by filename) in the same directory.
     for data_file in find_data_files(listing_dir):
+        if data_file.stem != "offering":
+            continue
         try:
             data, _file_format = load_data_file(data_file)
-            if data.get("schema") == "offering_v1":
-                return data.get("name")
+            return data.get("name")
         except Exception:
             continue
 

--- a/src/unitysvc_sellers/validator.py
+++ b/src/unitysvc_sellers/validator.py
@@ -98,16 +98,17 @@ class DataValidator(CoreDataValidator):
         listings: list[Path] = []
 
         for file_path in data_files:
+            # File TYPE is the filename now, not an in-file ``schema`` field.
+            if file_path.stem not in ("offering", "listing"):
+                continue
             try:
                 data, load_errors = self.load_data_file(file_path)
                 if load_errors or data is None:
                     continue
 
-                schema = data.get("schema")
-
-                if schema == "offering_v1":
+                if file_path.stem == "offering":
                     offerings.append((file_path, data))
-                elif schema == "listing_v1":
+                else:
                     listings.append(file_path)
 
             except Exception as e:
@@ -139,21 +140,11 @@ class DataValidator(CoreDataValidator):
 
         directories_to_validate: set[Path] = set()
 
-        for pattern in ["*.json", "*.toml"]:
+        for pattern in ["offering.json", "offering.toml", "listing.json", "listing.toml"]:
             for file_path in data_dir.rglob(pattern):
                 if any(part.startswith(".") for part in file_path.parts):
                     continue
-
-                try:
-                    data, load_errors = self.load_data_file(file_path)
-                    if load_errors or data is None:
-                        continue
-
-                    schema = data.get("schema")
-                    if schema in ["offering_v1", "listing_v1"]:
-                        directories_to_validate.add(file_path.parent)
-                except Exception:
-                    continue
+                directories_to_validate.add(file_path.parent)
 
         for directory in sorted(directories_to_validate):
             try:

--- a/tests/example_data/provider1/provider.toml
+++ b/tests/example_data/provider1/provider.toml
@@ -1,4 +1,3 @@
-schema = "provider_v1"
 time_created = "2025-08-17T10:55:04.976433Z"
 name = "provider1"
 terms_of_service = "https://fireworks.ai/terms-of-service"

--- a/tests/example_data/provider1/services/service1/listing.toml
+++ b/tests/example_data/provider1/services/service1/listing.toml
@@ -1,4 +1,3 @@
-schema = "listing_v1"
 status = "ready"
 name = "provider1/service1"
 display_name = "Service 1 Listing"

--- a/tests/example_data/provider1/services/service1/offering.toml
+++ b/tests/example_data/provider1/services/service1/offering.toml
@@ -1,4 +1,3 @@
-schema = "offering_v1"
 time_created = "2024-02-29T05:52:38.739683Z"
 name = "service1"
 service_type = "llm"

--- a/tests/example_data/provider2/provider.json
+++ b/tests/example_data/provider2/provider.json
@@ -2,7 +2,6 @@
   "contact_email": "support@openai.com",
   "homepage": "https://openai.com/",
   "name": "provider2",
-  "schema": "provider_v1",
   "secondary_contact_email": "enterprise@openai.com",
   "services_populator": {
     "command": "scripts/update_openai_services.py --force",

--- a/tests/example_data/provider2/services/service2/listing.json
+++ b/tests/example_data/provider2/services/service2/listing.json
@@ -1,6 +1,5 @@
 {
   "status": "ready",
-  "schema": "listing_v1",
   "name": "provider2/service2",
   "display_name": "Service 2 Listing",
   "time_created": "2024-02-29T05:52:38.739683Z",

--- a/tests/example_data/provider2/services/service2/offering.json
+++ b/tests/example_data/provider2/services/service2/offering.json
@@ -8,13 +8,20 @@
     "maxResolution": "2048x2048",
     "modelType": "diffusion",
     "parameterCount": "12000000000",
-    "supportedFormats": ["PNG", "JPEG", "WEBP"],
-    "supportedSchedulers": ["DDIM", "DDPM", "DPMSolverMultistep"],
+    "supportedFormats": [
+      "PNG",
+      "JPEG",
+      "WEBP"
+    ],
+    "supportedSchedulers": [
+      "DDIM",
+      "DDPM",
+      "DPMSolverMultistep"
+    ],
     "supportsImageInput": false,
     "supportsTools": false
   },
   "name": "service2",
-  "schema": "offering_v1",
   "service_type": "image_generation",
   "time_created": "2024-03-15T10:30:00.000Z",
   "upstream_access_config": {

--- a/tests/test_specs.py
+++ b/tests/test_specs.py
@@ -1,0 +1,125 @@
+"""Tests for ``usvc_seller specs validate`` (the flat ``specs/`` layout)."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from unitysvc_sellers.specs import app
+
+EXAMPLE_DATA = Path(__file__).parent / "example_data"
+runner = CliRunner()
+
+
+def _strip_schema(path: Path) -> None:
+    data = json.loads(path.read_text())
+    data.pop("schema", None)
+    path.write_text(json.dumps(data, indent=2) + "\n")
+
+
+@pytest.fixture
+def specs_repo(tmp_path: Path) -> Path:
+    """Build a valid one-service ``specs/`` repo from the preset-free
+    ``provider2/service2`` example fixture.
+
+    Layout::
+
+        <tmp>/specs/provider2/service2/{provider,offering,listing}.json
+    """
+    folder = tmp_path / "specs" / "provider2" / "service2"
+    folder.mkdir(parents=True)
+
+    src = EXAMPLE_DATA / "provider2" / "services" / "service2"
+    for f in src.iterdir():
+        if f.is_file():
+            shutil.copy2(f, folder / f.name)
+    shutil.copy2(EXAMPLE_DATA / "provider2" / "provider.json", folder / "provider.json")
+
+    for name in ("provider.json", "offering.json", "listing.json"):
+        _strip_schema(folder / name)
+
+    # listing.name is already "provider2/service2" == folder path under specs/.
+    return tmp_path
+
+
+def _run(target: Path, *args: str):
+    # ``app`` has a single command, so it is invoked without a command name.
+    return runner.invoke(app, [str(target), *args])
+
+
+def _norm(output: str) -> str:
+    """Collapse whitespace so assertions survive rich's line wrapping."""
+    return " ".join(output.split())
+
+
+def test_valid_specs_repo_passes(specs_repo: Path) -> None:
+    result = _run(specs_repo)
+    assert result.exit_code == 0, result.output
+    assert "valid" in result.output.lower()
+
+
+def test_resolves_specs_subdir_or_root(specs_repo: Path) -> None:
+    # Pointing at the repo root and at specs/ directly both work.
+    assert _run(specs_repo).exit_code == 0
+    assert _run(specs_repo / "specs").exit_code == 0
+
+
+def test_schema_field_is_rejected(specs_repo: Path) -> None:
+    listing = specs_repo / "specs" / "provider2" / "service2" / "listing.json"
+    data = json.loads(listing.read_text())
+    data["schema"] = "listing_v1"
+    listing.write_text(json.dumps(data, indent=2) + "\n")
+
+    result = _run(specs_repo)
+    assert result.exit_code == 1
+    assert "remove the 'schema' field" in _norm(result.output)
+
+
+def test_missing_required_file_is_rejected(specs_repo: Path) -> None:
+    (specs_repo / "specs" / "provider2" / "service2" / "offering.json").unlink()
+    result = _run(specs_repo)
+    assert result.exit_code == 1
+    assert "missing required offering file" in _norm(result.output)
+
+
+def test_name_must_match_folder_path(specs_repo: Path) -> None:
+    folder = specs_repo / "specs" / "provider2" / "service2"
+    renamed = folder.parent / "renamed"
+    folder.rename(renamed)  # folder path now provider2/renamed, name still provider2/service2
+
+    result = _run(specs_repo)
+    assert result.exit_code == 1
+    assert "does not match the folder path" in _norm(result.output)
+
+
+def test_legacy_override_file_is_rejected(specs_repo: Path) -> None:
+    folder = specs_repo / "specs" / "provider2" / "service2"
+    (folder / "listing.override.json").write_text('{"service_id": "x"}\n')
+
+    result = _run(specs_repo)
+    assert result.exit_code == 1
+    assert "legacy override file" in _norm(result.output)
+
+
+def test_no_service_folders_errors(tmp_path: Path) -> None:
+    (tmp_path / "specs").mkdir()
+    result = _run(tmp_path)
+    assert result.exit_code == 1
+    assert "no service folders" in _norm(result.output).lower()
+
+
+def test_has_service_id_flag(specs_repo: Path) -> None:
+    folder = specs_repo / "specs" / "provider2" / "service2"
+    # Without service.json, --has-service-id fails.
+    result = _run(specs_repo, "--has-service-id")
+    assert result.exit_code == 1
+    assert "missing service_id" in _norm(result.output)
+
+    # With a service.json carrying a service_id, it passes.
+    (folder / "service.json").write_text('{"service_id": "abc-123"}\n')
+    result = _run(specs_repo, "--has-service-id")
+    assert result.exit_code == 0, result.output


### PR DESCRIPTION
## Summary
Add `usvc_seller specs validate` for the flat `specs/` layout ([unitysvc#1263](https://github.com/unitysvc/unitysvc/issues/1263)), and complete the **schema-field cutover** in the `data` toolchain — file TYPE is the **filename** now, not an in-file `schema` field.

### New `specs validate`
Validates a migrated repo. Per service folder (one containing `listing.{json,toml}`):
1. the three spec files (`provider`/`offering`/`listing`) are present, one format each, and carry **no `schema` field**;
2. each validates against its core schema, routed by filename (no directory traversal — every folder is self-contained);
3. `listing.name` equals the folder path under `specs/`;
4. leftover `schema` fields / stale `*.override.*` files are flagged. `service.json` is optional provenance (`--has-service-id` requires it).

### `data` toolchain updated to filename routing
- `validator`: classify offering/listing files by filename stem.
- `utils`: `resolve_provider_name` / `resolve_service_name_for_listing` match the provider/offering file by name, not `data["schema"]`.
- `find_files_by_schema` keeps its signature (core maps schema→filename internally) — the ~25 discovery call sites are unchanged.
- Stripped the now-invalid `schema` field from `tests/example_data` fixtures.

## ⚠️ Depends on unitysvc-core 0.1.19
Requires the schema-less core ([unitysvc-core#28](https://github.com/unitysvc/unitysvc-core/pull/28)). **Merge + release core 0.1.19 first**, then bump the `unitysvc-core` pin here to `>=0.1.19` and relock — CI goes green at that point. Pin left at `>=0.1.18` to keep the lockfile consistent until then.

## Test plan
- [x] Full suite — 237 passed (8 new `specs` tests; legacy `data validate` (56) unaffected)
- [x] `ruff` / `mypy src` clean
- [x] Manual: `usvc_seller specs validate` on the migrated demo repo — **19/19 folders valid**
- [ ] Bump `unitysvc-core>=0.1.19` + `uv lock` after core release (CI green gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
