### PR TITLE
Release 0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "unitysvc-sellers"
-version = "0.1.16"
+version = "0.2.0"
 description = "Seller-facing tools for UnitySVC: HTTP SDK + usvc_seller CLI"
 readme = "README.md"
 authors = [{ name = "Bo Peng", email = "bo.peng@unitysvc.com" }]


### PR DESCRIPTION
## Summary
Version bump `0.1.16` → **`0.2.0`** for the flat `specs/` layout cutover (#76), aligned with **unitysvc-core 0.2.0**.

- `usvc_seller data …` renamed to `usvc_seller specs …`
- toolchain ported to the flat `specs/<namespaced-name>/` layout; `service_id` round-trips through `service.json` (override files retired)
- requires `unitysvc-core>=0.2.0`

Verified end-to-end against the migrated demo (staging upload 19/19; validate/format/list/run-tests all green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
