### PR TITLE
Release 0.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "unitysvc-sellers"
-version = "0.2.0"
+version = "0.2.1"
 description = "Seller-facing tools for UnitySVC: HTTP SDK + usvc_seller CLI"
 readme = "README.md"
 authors = [{ name = "Bo Peng", email = "bo.peng@unitysvc.com" }]


### PR DESCRIPTION
Bump version to 0.2.1.

Ships `populate` reading `services_populator` from `templates/config.json` (#78), so the populate workflow can drive the flat specs/ layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)