### PR TITLE
Release 0.2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "unitysvc-sellers"
-version = "0.2.1"
+version = "0.2.2"
 description = "Seller-facing tools for UnitySVC: HTTP SDK + usvc_seller CLI"
 readme = "README.md"
 authors = [{ name = "Bo Peng", email = "bo.peng@unitysvc.com" }]


### PR DESCRIPTION
Bump to 0.2.2.

Ships the flat nested specs layout in `populate_from_iterator` (#80): preserves `/` nesting, copies `templates/provider.json` into each service folder, recursive deprecation. Unblocks the SDK-based provider repos' populate workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)