### PR TITLE
run-tests: fix specs provider column + add -l/--local-ids to services run-tests

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -794,6 +794,8 @@ $ usvc_seller services run-tests [OPTIONS] [NAME]
 **Options**:
 
 * `--id TEXT`: Service ID (full or partial, ≥8 chars).  Use this when a name matches multiple rows (e.g. an active service plus its pending revision) and you need to pin one specific row.
+* `-l, --local-ids`: Run tests for every service whose backend id is recorded in a service.json under --data-dir (the local specs/ catalog). Mutually exclusive with NAME and --id.
+* `--data-dir DIRECTORY`: Data directory for --local-ids (default: current directory).  [default: .]
 * `-d, --document-id TEXT`: Run a single document instead of every executable doc on the service.
 * `--force`: Re-execute documents whose previous per-iface result was &#x27;success&#x27;.
 * `--poll-interval FLOAT`: Seconds between task-status polls while waiting for the diagnostic.  [default: 2.0]

--- a/src/unitysvc_sellers/commands/services.py
+++ b/src/unitysvc_sellers/commands/services.py
@@ -494,17 +494,14 @@ def _bulk_visibility_change(
 
 
 def _read_ids_from_data_dir(data_dir: Path) -> list[str]:
-    """Collect service_ids from every service folder's service.json under data_dir."""
-    from unitysvc_core.utils import find_files_by_schema
+    """Collect service_ids from every service folder's service.json under data_dir.
 
-    from ..utils import read_service_id
+    Thin wrapper over the shared :func:`unitysvc_sellers.utils.read_local_service_ids`
+    utility (kept for the module-internal callers and existing tests).
+    """
+    from ..utils import read_local_service_ids
 
-    ids: list[str] = []
-    for listing_path, _fmt, _data in find_files_by_schema(data_dir, "listing_v1"):
-        sid = read_service_id(listing_path.parent)
-        if sid:
-            ids.append(sid)
-    return ids
+    return read_local_service_ids(data_dir)
 
 
 async def _filter_ids_by_state(
@@ -669,24 +666,9 @@ def _resolve_or_fetch_ids(
 
     # --- --local-ids: local listing_v1 files ---
     if use_local_ids:
-        ids = _read_ids_from_data_dir(data_dir)
-        if provider:
-            from unitysvc_core.utils import find_files_by_schema
+        from ..utils import read_local_service_ids
 
-            from ..utils import read_service_id
-
-            provider_lower = provider.lower()
-            allowed: set[str] = set()
-            for listing_path, _, _ in find_files_by_schema(data_dir, "listing_v1"):
-                sid = read_service_id(listing_path.parent)
-                if not sid:
-                    continue
-                # The provider lives beside the listing in the flat layout.
-                prov = find_files_by_schema(listing_path.parent, "provider_v1")
-                prov_name = (prov[0][2].get("name") or "") if prov else ""
-                if provider_lower in prov_name.lower():
-                    allowed.add(sid)
-            ids = [i for i in ids if i in allowed]
+        ids = read_local_service_ids(data_dir, provider)
         if not ids:
             console.print("[yellow]No service IDs found in listing_v1 files under the given directory.[/yellow]")
             raise typer.Exit(code=0)

--- a/src/unitysvc_sellers/commands/tests.py
+++ b/src/unitysvc_sellers/commands/tests.py
@@ -18,6 +18,7 @@ keeps working.
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import Any
 
 import typer
@@ -26,6 +27,7 @@ from rich.table import Table
 
 from .._http import unwrap as _unwrap_response
 from ..exceptions import NotFoundError
+from ..utils import read_local_service_ids
 from ._helpers import (
     api_key_option,
     async_client,
@@ -125,6 +127,7 @@ def list_tests(
     # Single-target semantics — multi-match name errors with a --id hint.
     if name is not None or service_id is not None:
         from .services import _resolve_single_target_id
+
         service_id = _resolve_single_target_id(api_key, base_url, name=name, service_id=service_id)
 
     async def _impl() -> list[dict[str, Any]]:
@@ -382,6 +385,24 @@ def run_tests(
             "need to pin one specific row."
         ),
     ),
+    local_ids: bool = typer.Option(
+        False,
+        "--local-ids",
+        "-l",
+        help=(
+            "Run tests for every service whose backend id is recorded in a "
+            "service.json under --data-dir (the local specs/ catalog). Mutually "
+            "exclusive with NAME and --id."
+        ),
+    ),
+    data_dir: Path = typer.Option(
+        Path("."),
+        "--data-dir",
+        help="Data directory for --local-ids (default: current directory).",
+        exists=True,
+        file_okay=False,
+        dir_okay=True,
+    ),
     document_id: str | None = typer.Option(
         None,
         "--document-id",
@@ -427,8 +448,9 @@ def run_tests(
         usvc_seller services run-tests 'cohere/*' --force
         usvc_seller services run-tests --id 6c55d6d9          # disambiguate
     """
-    if (name is None) == (service_id is None):
-        console.print("[red]Error:[/red] provide exactly one of a positional NAME or ``--id``.")
+    modes = sum([name is not None, service_id is not None, local_ids])
+    if modes != 1:
+        console.print("[red]Error:[/red] provide exactly one of: positional NAME, ``--id``, or ``--local-ids``.")
         raise typer.Exit(code=1)
 
     if name is not None:
@@ -440,6 +462,16 @@ def run_tests(
             console.print(f"[yellow]No services match '{name}'.[/yellow]")
             raise typer.Exit(code=0)
         console.print(f"[green]Found {len(targets)} service(s) matching '{name}'[/green]\n")
+    elif local_ids:
+        # Read backend ids from the local specs/ catalog; the diagnostic runs
+        # per id with no status filter (mirrors ``--id`` — the operator pointed
+        # at these services explicitly).
+        ids = read_local_service_ids(data_dir)
+        if not ids:
+            console.print("[yellow]No service IDs found in service.json files under the given directory.[/yellow]")
+            raise typer.Exit(code=0)
+        console.print(f"[cyan]Found {len(ids)} service ID(s) from {data_dir}[/cyan]\n")
+        targets = [(sid, None) for sid in ids]
     else:
         # service_id is non-None — the mutex check above guarantees it.
         assert service_id is not None

--- a/src/unitysvc_sellers/example.py
+++ b/src/unitysvc_sellers/example.py
@@ -25,6 +25,7 @@ from .utils import (
     find_files_by_schema,
     load_data_file,
     render_template_file,
+    resolve_provider_name,
     service_name_matches,
 )
 
@@ -224,15 +225,16 @@ def discover_code_examples(
     results: list[tuple[dict[str, Any], str]] = []
 
     for listing_file, _format, listing_data in listing_results:
-        # Determine provider from directory structure
-        parts = listing_file.parts
-        prov_name = "unknown"
-        try:
-            services_idx = parts.index("services")
-            if services_idx > 0:
-                prov_name = parts[services_idx - 1]
-        except (ValueError, IndexError):
-            pass
+        # Resolve provider from the sibling provider file (flat specs/ layout).
+        # Fall back to the legacy data/<provider>/services/... directory shape.
+        prov_name = resolve_provider_name(listing_file)
+        if not prov_name:
+            parts = listing_file.parts
+            try:
+                services_idx = parts.index("services")
+                prov_name = parts[services_idx - 1] if services_idx > 0 else "unknown"
+            except (ValueError, IndexError):
+                prov_name = "unknown"
 
         # Filter by provider
         if provider_name and prov_name != provider_name:
@@ -1259,7 +1261,6 @@ def run_local(
     console.print(f"\n[green]✓ Passed: {passed}/{total_tests}[/green]")
     if skipped > 0:
         console.print(f"[yellow]⊘ Skipped: {skipped}/{total_tests}[/yellow]")
-    console.print(f"[red]✗ Failed: {failed}/{total_tests}[/red]")
-
     if failed > 0:
+        console.print(f"[red]✗ Failed: {failed}/{total_tests}[/red]")
         raise typer.Exit(code=1)

--- a/src/unitysvc_sellers/utils.py
+++ b/src/unitysvc_sellers/utils.py
@@ -173,6 +173,35 @@ def write_service_id(service_dir: Path, service_id: str) -> None:
     service_file.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n")
 
 
+def read_local_service_ids(data_dir: Path, provider: str | None = None) -> list[str]:
+    """Collect backend ``service_id``s for the local services under ``data_dir``.
+
+    The shared ``-l`` / ``--local-ids`` resolution used across the ``services``
+    command family: walk every ``listing_v1`` file beneath ``data_dir`` and read
+    the backend-assigned id from the sibling ``service.json`` (the flat
+    ``specs/`` layout keeps the id as provenance beside the spec files). Folders
+    without a recorded id are skipped.
+
+    With ``provider`` set, keep only services whose sibling ``provider_v1``
+    ``name`` contains the given substring (case-insensitive) — matching the
+    filter the bulk ``services`` commands apply in ``--local-ids`` mode.
+    """
+    provider_lower = provider.lower() if provider else None
+    ids: list[str] = []
+    for listing_path, _fmt, _data in find_files_by_schema(data_dir, "listing_v1"):
+        sid = read_service_id(listing_path.parent)
+        if not sid:
+            continue
+        if provider_lower is not None:
+            # The provider lives beside the listing in the flat layout.
+            prov = find_files_by_schema(listing_path.parent, "provider_v1")
+            prov_name = (prov[0][2].get("name") or "") if prov else ""
+            if provider_lower not in prov_name.lower():
+                continue
+        ids.append(sid)
+    return ids
+
+
 def convert_convenience_fields_to_documents(
     data: dict[str, Any],
     base_path: Path,

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -5,7 +5,14 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from unitysvc_sellers.example import build_upstream_template_context, execute_code_example, expand_template_strings
+from unitysvc_sellers.example import (
+    build_upstream_template_context,
+    discover_code_examples,
+    execute_code_example,
+    expand_template_strings,
+)
+
+EXAMPLE_DATA = Path(__file__).parent / "example_data"
 
 
 def test_build_upstream_template_context_renames_base_url() -> None:
@@ -20,9 +27,7 @@ def test_build_upstream_template_context_drops_api_key() -> None:
     Templates read ``UNITYSVC_API_KEY`` from the environment instead, so the
     key must not leak into the Jinja2 namespace.
     """
-    ctx = build_upstream_template_context(
-        {"base_url": "https://api.example.com", "api_key": "sk-secret"}
-    )
+    ctx = build_upstream_template_context({"base_url": "https://api.example.com", "api_key": "sk-secret"})
     assert "api_key" not in ctx
     assert ctx == {"service_base_url": "https://api.example.com"}
 
@@ -55,6 +60,7 @@ def test_build_upstream_template_context_empty() -> None:
 # ---------------------------------------------------------------------------
 # expand_template_strings
 # ---------------------------------------------------------------------------
+
 
 def test_expand_template_strings_expands_top_level_strings() -> None:
     result = expand_template_strings(
@@ -174,3 +180,13 @@ def test_execute_code_example_uses_resolved_credentials_for_template_context(
     # Sanity: the script ran cleanly and printed the resolved URL.
     assert result["exit_code"] == 0, result.get("stderr")
     assert "URL=https://upstream.test" in (result.get("stdout") or "")
+
+
+def test_discover_code_examples_resolves_provider_from_sibling_file() -> None:
+    """Provider comes from the sibling provider_v1 file (flat ``specs/`` layout),
+    not the directory name — regression for the ``unknown`` provider column when
+    there is no ``services/`` path component."""
+    results = discover_code_examples(EXAMPLE_DATA)
+    providers = {prov_name for _example, prov_name in results}
+    assert providers == {"provider1", "provider2"}
+    assert "unknown" not in providers

--- a/tests/test_services_local_ids.py
+++ b/tests/test_services_local_ids.py
@@ -21,6 +21,7 @@ from typer.testing import CliRunner
 
 from unitysvc_sellers.cli import app as _cli_app
 from unitysvc_sellers.commands.services import _read_ids_from_data_dir, _resolve_or_fetch_ids
+from unitysvc_sellers.utils import read_local_service_ids
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -472,3 +473,33 @@ class TestListLocalIds:
         assert result.exit_code == 0, result.stdout
         rendered = _json.loads(result.stdout)
         assert {svc["name"] for svc in rendered} == {"alpha"}
+
+
+# ---------------------------------------------------------------------------
+# read_local_service_ids — the shared -l / --local-ids resolution utility
+# ---------------------------------------------------------------------------
+
+
+def test_read_local_service_ids_collects_from_service_json(tmp_path: Path) -> None:
+    _write_listing(tmp_path / "a" / "listing.json", {"service_id": _UUID_A})
+    _write_listing(tmp_path / "b" / "listing.json", {"service_id": _UUID_B})
+    _write_listing(tmp_path / "c" / "listing.json")  # no service.json → skipped
+
+    ids = read_local_service_ids(tmp_path)
+    assert sorted(ids) == sorted([_UUID_A, _UUID_B])
+
+
+def test_read_local_service_ids_filters_by_provider(tmp_path: Path) -> None:
+    _write_listing(tmp_path / "a" / "listing.json", {"service_id": _UUID_A, "provider_name": "acme"})
+    _write_listing(tmp_path / "b" / "listing.json", {"service_id": _UUID_B, "provider_name": "globex"})
+
+    assert read_local_service_ids(tmp_path, provider="acme") == [_UUID_A]
+    assert read_local_service_ids(tmp_path, provider="globex") == [_UUID_B]
+    # Substring, case-insensitive — mirrors the existing services-command filter.
+    assert sorted(read_local_service_ids(tmp_path, provider="")) == sorted([_UUID_A, _UUID_B])
+
+
+def test_read_ids_from_data_dir_delegates_to_utility(tmp_path: Path) -> None:
+    """The private services-module reader stays as a thin wrapper."""
+    _write_listing(tmp_path / "a" / "listing.json", {"service_id": _UUID_A})
+    assert _read_ids_from_data_dir(tmp_path) == [_UUID_A]

--- a/tests/test_services_run_tests_name.py
+++ b/tests/test_services_run_tests_name.py
@@ -172,3 +172,67 @@ def test_name_with_no_matches_exits_zero(env):
     assert result.exit_code == 0, result.output
     services.run_tests.assert_not_awaited()
     assert "No services match" in result.output
+
+
+# ---------------------------------------------------------------------------
+# --local-ids / -l selector
+# ---------------------------------------------------------------------------
+
+
+def _write_local_service(data_dir, sid: str, name: str = "svc") -> None:
+    """Create a flat-layout service folder carrying ``sid`` in service.json."""
+    import json
+    from pathlib import Path
+
+    folder = Path(data_dir) / name
+    folder.mkdir(parents=True, exist_ok=True)
+    (folder / "listing.json").write_text(json.dumps({"schema": "listing_v1", "name": name, "status": "ready"}))
+    (folder / "service.json").write_text(json.dumps({"service_id": sid}))
+
+
+def test_local_ids_runs_tests_for_each_local_service(env, tmp_path):
+    """``run-tests -l`` resolves every service_id under --data-dir and runs the
+    diagnostic once per id — no positional NAME, no backend list call."""
+    _write_local_service(tmp_path, SID_A, "svc-a")
+    _write_local_service(tmp_path, SID_B, "svc-b")
+    services, factory = _mock_clients(
+        list_returns=_services_page([]),
+        run_tests_returns=[_diag_ok(), _diag_ok()],
+    )
+
+    with patch("unitysvc_sellers.commands.tests.async_client", factory):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli_app,
+            ["services", "run-tests", "-l", "--data-dir", str(tmp_path)],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert services.run_tests.await_count == 2
+    called_ids = sorted(call.args[0] for call in services.run_tests.await_args_list)
+    assert called_ids == sorted([SID_A, SID_B])
+    services.list.assert_not_awaited()
+
+
+def test_local_ids_with_no_local_services_exits_zero(env, tmp_path):
+    """An empty data dir → graceful exit 0, nothing dispatched."""
+    services, factory = _mock_clients(list_returns=_services_page([]), run_tests_returns=[])
+    with patch("unitysvc_sellers.commands.tests.async_client", factory):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli_app,
+            ["services", "run-tests", "-l", "--data-dir", str(tmp_path)],
+        )
+    assert result.exit_code == 0, result.output
+    services.run_tests.assert_not_awaited()
+
+
+def test_local_ids_mutually_exclusive_with_name(env, tmp_path):
+    """``run-tests <NAME> -l`` is an error — exactly one selector."""
+    _write_local_service(tmp_path, SID_A, "svc-a")
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_app,
+        ["services", "run-tests", "cohere/x", "-l", "--data-dir", str(tmp_path)],
+    )
+    assert result.exit_code != 0


### PR DESCRIPTION
## Summary

Two related improvements to `usvc_seller` `run-tests`, surfaced while testing the demo catalog:

1. **`specs run-tests` provider column showed `unknown`** for the flat `specs/` layout. `discover_code_examples` derived the provider from a `services/` path component (the legacy `data/<provider>/services/...` shape), which the flat layout lacks, so it fell through to `"unknown"`. Now resolved via the existing `resolve_provider_name()` helper (the sibling `provider_v1` file), with the directory heuristic kept as a legacy fallback.
2. **`specs run-tests` printed `✗ Failed: 0/N`** even when nothing failed — now folded into the existing failure guard, so the line only appears when there are failures.
3. **`services run-tests` gained `-l`/`--local-ids` + `--data-dir`.** The other bulk `services` commands (`list/submit/withdraw/deprecate/set-visibility/delete`) already accept `-l` to target services by the ids recorded in local `service.json` files; `run-tests` did not. The local-id resolution is now a shared utility `read_local_service_ids(data_dir, provider=None)` (consolidating the previously private `_read_ids_from_data_dir` + the inline provider filter in `_resolve_or_fetch_ids`), and `run-tests -l` runs the server-side diagnostic per local id with no status filter (mirroring `--id`).

```bash
usvc_seller services run-tests -l                    # all services in the local catalog
usvc_seller services run-tests -l --data-dir specs   # explicit dir
```

## Test plan
- [x] `ruff check src tests` — all checks passed
- [x] `ruff format --check` on all touched files — already formatted
- [x] `pytest` — 191 passed
- [x] New coverage: provider-resolution regression test (`test_example.py`); `read_local_service_ids` collect/provider-filter/delegation tests; `run-tests -l` per-id dispatch / empty-dir / mutex tests
- [x] End-to-end: `read_local_service_ids` resolves 17 ids in the demo repo; `discover_code_examples` now reports the real provider instead of `unknown`

Note: a few unrelated files in the repo are flagged by `ruff format --check` (pre-existing drift, not touched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
