### PR TITLE
feat(specs): render local param files via templates (ephemeral specs)

### DIFF
--- a/src/unitysvc_sellers/data.py
+++ b/src/unitysvc_sellers/data.py
@@ -12,10 +12,34 @@ from rich.table import Table
 from . import _cli_upload as upload_cmd
 from . import example, format_data, populate, specs
 from . import list as list_cmd
+from .params_render import ParamRenderError, materialized_param_specs
 from .utils import find_files_by_schema, load_data_file, read_service_id
 
 app = typer.Typer(help="Local operations on the flat specs/ layout (validate, format, populate, upload, test, etc.)")
 console = Console()
+
+
+@app.callback()
+def _expand_params(ctx: typer.Context) -> None:
+    """Reading service files is the same whether they're written directly or
+    expanded from a template.
+
+    Before any *read* command runs, render the repo's local param files
+    (``specs/<name>.json`` → ``{ template, parameters }``) into ephemeral service
+    folders so the rest of the pipeline treats them exactly like hand-authored
+    folders. The folders are removed — and any backend-assigned ``service_id``
+    synced to the committed ``<name>.service.json`` sidecar — when the command
+    finishes. ``format`` and ``populate`` are skipped: they operate on the
+    committed files themselves, not the expanded view.
+    """
+    sub = ctx.invoked_subcommand
+    if not sub or sub in {"format", "populate"}:
+        return
+    try:
+        ctx.with_resource(materialized_param_specs(Path.cwd()))
+    except ParamRenderError as exc:
+        console.print(f"[red]✗[/red] Param render error: {exc}")
+        raise typer.Exit(1) from exc
 
 
 # ---------------------------------------------------------------------------

--- a/src/unitysvc_sellers/params_render.py
+++ b/src/unitysvc_sellers/params_render.py
@@ -1,0 +1,219 @@
+"""Render local *param files* into ephemeral service folders.
+
+A **param file** is a compact way to author a service: ``specs/<provider>/<name>.json``
+containing ``{ "template": <name>?, "parameters": {...} }``. At validate / upload
+/ run-tests time it is rendered through a **local template directory** into a
+self-contained service folder (``specs/<provider>/<name>/``) that the normal
+``specs`` pipeline then handles. The generated folder is **ephemeral** — only the
+param file and its ``<name>.service.json`` sidecar are committed.
+
+Rendering reuses :func:`unitysvc_sellers.template_populate.populate_from_iterator`
+(the same engine the populator uses); this module only adds param-file discovery,
+template resolution, bundling of the template's extra files, and the
+``service.json`` ↔ sidecar round-trip — wrapped in :func:`materialized_param_specs`,
+a context manager the commands enter so the rendered folders exist for the
+duration of the walk and are cleaned up afterwards.
+
+A param file whose ``template`` does not resolve to a local directory is a
+**remote** template — handled by ``usvc_seller params instantiate``, not here.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import shutil
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+import json5
+
+from .template_populate import populate_from_iterator
+
+
+class ParamRenderError(ValueError):
+    """A param file could not be resolved or rendered (bad template, name clash, …)."""
+
+
+# Filenames that are never param files (they're the spec/aux files themselves).
+_RESERVED_STEMS = {"provider", "offering", "listing", "service", "promotion", "service_group", "config"}
+# Template-dir files that must NOT be copied verbatim into a rendered folder:
+# the two rendered templates and the populator's config.
+_NON_BUNDLED = {"offering.json.j2", "listing.json.j2", "config.json"}
+
+
+def _load_json(path: Path) -> Any:
+    return json5.loads(path.read_text())
+
+
+def is_param_file(path: Path) -> bool:
+    """True if ``path`` looks like a param file: a ``<name>.json`` under ``specs/``
+    that is not a reserved spec/aux file and carries a ``parameters`` key."""
+    if path.suffix != ".json" or path.name.endswith(".service.json"):
+        return False
+    if path.stem in _RESERVED_STEMS:
+        return False
+    try:
+        data = _load_json(path)
+    except Exception:
+        return False
+    return isinstance(data, dict) and "parameters" in data
+
+
+def discover_param_files(root: Path) -> list[Path]:
+    """All param files under ``root`` (recursively), sorted."""
+    return sorted(p for p in root.rglob("*.json") if is_param_file(p))
+
+
+def _repo_root_for(param_file: Path) -> Path:
+    """The nearest ancestor that contains a ``templates/`` directory."""
+    for parent in param_file.parents:
+        if (parent / "templates").is_dir():
+            return parent
+    raise ParamRenderError(f"no 'templates/' directory found above param file {param_file}")
+
+
+def _specs_root_for(param_file: Path) -> Path:
+    """The ``specs/`` directory the param file lives under (for path → name)."""
+    for parent in param_file.parents:
+        if parent.name == "specs":
+            return parent
+    # Fallback: assume specs/ is a sibling of templates/.
+    return _repo_root_for(param_file) / "specs"
+
+
+def _resolve_template_dir(param_file: Path, template_name: str | None) -> Path:
+    """Resolve a param file's ``template`` to a local template directory.
+
+    ``None`` → ``templates/``; ``"resp"`` → ``templates/resp/``. Raises if the
+    directory doesn't exist (a non-local template is a remote one — use
+    ``params instantiate``).
+    """
+    templates = _repo_root_for(param_file) / "templates"
+    tdir = templates / template_name if template_name else templates
+    if not tdir.is_dir():
+        ref = template_name or "(default templates/)"
+        raise ParamRenderError(
+            f"local template '{ref}' not found at {tdir} for {param_file.name}. "
+            f"Remote/system templates are created with `usvc_seller params instantiate`."
+        )
+    return tdir
+
+
+def _service_name_for(param_file: Path) -> str:
+    """Service name = the param file's path under ``specs/``, sans ``.json``."""
+    return param_file.relative_to(_specs_root_for(param_file)).with_suffix("").as_posix()
+
+
+def _sidecar_for(param_file: Path) -> Path:
+    return param_file.with_name(param_file.stem + ".service.json")
+
+
+def _read_service_id(sidecar: Path) -> str | None:
+    if not sidecar.is_file():
+        return None
+    try:
+        data = json.loads(sidecar.read_text())
+    except Exception:
+        return None
+    sid = data.get("service_id") if isinstance(data, dict) else None
+    return str(sid) if sid else None
+
+
+def _write_service_id(sidecar: Path, service_id: str) -> None:
+    data: dict[str, Any] = {}
+    if sidecar.is_file():
+        try:
+            loaded = json.loads(sidecar.read_text())
+            if isinstance(loaded, dict):
+                data = loaded
+        except Exception:
+            data = {}
+    data["service_id"] = str(service_id)
+    sidecar.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n")
+
+
+@contextmanager
+def materialized_param_specs(root: Path) -> Iterator[list[Path]]:
+    """Render every param file under ``root`` into a sibling service folder for
+    the duration of the ``with`` block, then clean up.
+
+    Each ``specs/<provider>/<name>.json`` becomes ``specs/<provider>/<name>/``
+    (offering + listing + provider + bundled docs). On exit the
+    backend-assigned ``service_id`` written into the folder's ``service.json`` is
+    copied back to the committed ``<name>.service.json`` sidecar, and the folder
+    is removed. Yields the list of rendered folders.
+
+    Local templates only: a param file whose ``template`` is not a local dir
+    raises (it belongs to ``params instantiate``).
+    """
+    param_files = discover_param_files(root)
+    rendered: list[tuple[Path, Path]] = []  # (folder, sidecar)
+
+    try:
+        # Group by resolved template dir so one populate call renders all params
+        # that share a template (and so a repo can mix templates).
+        groups: dict[Path, list[tuple[Path, dict[str, Any]]]] = {}
+        for pf in param_files:
+            data = _load_json(pf)
+            tdir = _resolve_template_dir(pf, data.get("template"))
+            folder = pf.with_suffix("")
+            if folder.exists():
+                raise ParamRenderError(
+                    f"both {pf.name} and folder {folder.name}/ exist for service "
+                    f"'{_service_name_for(pf)}' — a service is one or the other."
+                )
+            service_name = _service_name_for(pf)
+            ctx = {
+                "name": service_name,  # name_field → folder path under output_dir
+                "service_name": service_name,
+                "provider_name": service_name.split("/")[0],
+                **(data.get("parameters") or {}),
+            }
+            groups.setdefault(tdir, []).append((pf, ctx))
+
+        for tdir, items in groups.items():
+            specs_root = _specs_root_for(items[0][0])
+            # Reuse the populator's render engine; silence its progress output
+            # (this is an internal expansion, not a user-facing populate).
+            with contextlib.redirect_stdout(io.StringIO()):
+                populate_from_iterator(
+                    iter([ctx for _pf, ctx in items]),
+                    templates_dir=tdir,
+                    output_dir=specs_root,
+                    deprecate_missing=False,
+                )
+            extras = [f for f in tdir.iterdir() if f.is_file() and f.name not in (_NON_BUNDLED | {"provider.json"})]
+            for pf, ctx in items:
+                folder = specs_root / ctx["name"]
+                # Bundle the template's other files (e.g. connectivity.sh.j2)
+                # so the folder is self-contained (provider.json already copied).
+                for f in extras:
+                    shutil.copyfile(f, folder / f.name)
+                # Seed service.json from the committed sidecar so the upload
+                # updates the same service.
+                sidecar = _sidecar_for(pf)
+                sid = _read_service_id(sidecar)
+                if sid:
+                    (folder / "service.json").write_text(
+                        json.dumps({"service_id": sid}, indent=2, sort_keys=True) + "\n"
+                    )
+                rendered.append((folder, sidecar))
+
+        yield [folder for folder, _ in rendered]
+
+    finally:
+        for folder, sidecar in rendered:
+            # Round-trip any backend-assigned service_id back to the sidecar.
+            service_json = folder / "service.json"
+            if service_json.is_file():
+                try:
+                    sid = json.loads(service_json.read_text()).get("service_id")
+                except Exception:
+                    sid = None
+                if sid:
+                    _write_service_id(sidecar, str(sid))
+            shutil.rmtree(folder, ignore_errors=True)

--- a/tests/test_params_render.py
+++ b/tests/test_params_render.py
@@ -1,0 +1,146 @@
+"""Tests for local param-file rendering (``params_render``).
+
+A param file ``specs/<provider>/<name>.json`` ({template, parameters}) is
+rendered, via a local template directory, into an ephemeral service folder that
+the normal ``specs`` pipeline consumes; the folder is cleaned up afterwards and
+any backend ``service_id`` is synced to the ``<name>.service.json`` sidecar.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from unitysvc_sellers.params_render import ParamRenderError, materialized_param_specs
+
+PROVIDER = json.dumps(
+    {
+        "name": "unitysvc",
+        "display_name": "UnitySVC",
+        "homepage": "https://unitysvc.com/",
+        "contact_email": "service@unitysvc.com",
+        "status": "ready",
+        "time_created": "2026-05-31T00:00:00Z",
+    }
+)
+OFFERING_J2 = """{
+  "name": "resp{{ status }}",
+  "service_type": "gateway",
+  "capabilities": ["http_relay"],
+  "description": "Returns HTTP {{ status }} ({{ label }}).",
+  "status": "ready",
+  "tags": ["gateway", "test"],
+  "time_created": "2026-05-31T00:00:00Z",
+  "upstream_access_config": {"direct_response": {"access_method": "http", "base_url": "resp://{{ status }}"}}
+}
+"""
+LISTING_J2 = """{
+  "name": "{{ service_name }}",
+  "display_name": "Direct Response {{ status }}",
+  "currency": "USD",
+  "status": "ready",
+  "list_price": {"type": "constant", "price": "0", "description": "Free"},
+  "user_access_interfaces": {
+    "direct_response": {
+      "access_method": "http",
+      "base_url": "${API_GATEWAY_BASE_URL}/{{ service_name }}"
+    }
+  },
+  "documents": {
+    "Connectivity test": {
+      "category": "connectivity_test",
+      "description": "x",
+      "file_path": "connectivity.sh.j2",
+      "is_active": true,
+      "is_public": false,
+      "meta": {"output_contains": "ok"},
+      "mime_type": "bash"
+    }
+  }
+}
+"""
+
+
+def _make_repo(tmp_path: Path, *, params: dict[str, dict] | None = None) -> Path:
+    """Build a repo with a `resp` template and the given param files; return root."""
+    tdir = tmp_path / "templates" / "resp"
+    tdir.mkdir(parents=True)
+    (tdir / "provider.json").write_text(PROVIDER + "\n")
+    (tdir / "offering.json.j2").write_text(OFFERING_J2)
+    (tdir / "listing.json.j2").write_text(LISTING_J2)
+    (tdir / "connectivity.sh.j2").write_text("echo ok\n")
+    specs = tmp_path / "specs" / "unitysvc"
+    specs.mkdir(parents=True)
+    for name, params_dict in (params or {"resp200": {"status": 200, "label": "OK"}}).items():
+        (specs / f"{name}.json").write_text(json.dumps({"template": "resp", "parameters": params_dict}) + "\n")
+    return tmp_path
+
+
+def test_renders_self_contained_folder_then_cleans_up(tmp_path: Path) -> None:
+    root = _make_repo(tmp_path, params={"resp200": {"status": 200, "label": "OK"}})
+    folder = root / "specs" / "unitysvc" / "resp200"
+
+    with materialized_param_specs(root) as rendered:
+        assert rendered == [folder]
+        # self-contained: offering + listing + provider + bundled connectivity
+        for f in ("offering.json", "listing.json", "provider.json", "connectivity.sh.j2"):
+            assert (folder / f).exists(), f
+        offering = json.loads((folder / "offering.json").read_text())
+        listing = json.loads((folder / "listing.json").read_text())
+        assert offering["name"] == "resp200"
+        assert offering["upstream_access_config"]["direct_response"]["base_url"] == "resp://200"
+        # listing.name == folder path under specs/ (from {{ service_name }})
+        assert listing["name"] == "unitysvc/resp200"
+
+    # ephemeral: folder gone, param file untouched
+    assert not folder.exists()
+    assert (root / "specs" / "unitysvc" / "resp200.json").exists()
+
+
+def test_service_id_sidecar_roundtrip(tmp_path: Path) -> None:
+    root = _make_repo(tmp_path)
+    sidecar = root / "specs" / "unitysvc" / "resp200.service.json"
+    sidecar.write_text(json.dumps({"service_id": "existing-id"}) + "\n")
+
+    with materialized_param_specs(root):
+        folder = root / "specs" / "unitysvc" / "resp200"
+        # seeded from the committed sidecar so the upload updates the same service
+        assert json.loads((folder / "service.json").read_text())["service_id"] == "existing-id"
+        # simulate the backend assigning/refreshing the id during upload
+        (folder / "service.json").write_text(json.dumps({"service_id": "new-id"}) + "\n")
+
+    # synced back to the committed sidecar; folder cleaned up
+    assert json.loads(sidecar.read_text())["service_id"] == "new-id"
+    assert not (root / "specs" / "unitysvc" / "resp200").exists()
+
+
+def test_bad_template_raises(tmp_path: Path) -> None:
+    root = _make_repo(tmp_path)
+    (root / "specs" / "unitysvc" / "bad.json").write_text(json.dumps({"template": "nope", "parameters": {}}))
+    with pytest.raises(ParamRenderError, match="local template 'nope' not found"):
+        with materialized_param_specs(root):
+            pass
+
+
+def test_folder_and_param_file_conflict_raises(tmp_path: Path) -> None:
+    root = _make_repo(tmp_path)
+    (root / "specs" / "unitysvc" / "resp200").mkdir()  # a folder at the same path
+    with pytest.raises(ParamRenderError, match="a service is one or the other"):
+        with materialized_param_specs(root):
+            pass
+
+
+def test_validate_command_accepts_param_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    root = _make_repo(
+        tmp_path, params={"resp200": {"status": 200, "label": "OK"}, "resp404": {"status": 404, "label": "NF"}}
+    )
+    monkeypatch.chdir(root)
+    from typer.testing import CliRunner
+
+    from unitysvc_sellers.cli import app
+
+    result = CliRunner().invoke(app, ["specs", "validate"])
+    assert result.exit_code == 0, result.output
+    assert "2 service folder(s) are valid" in result.output
+    # no rendered folders left behind
+    assert not (root / "specs" / "unitysvc" / "resp200").exists()


### PR DESCRIPTION
## Summary

Implements **Path B** of the file-based params design ([#89](https://github.com/unitysvc/unitysvc-sellers/pull/89)): a service can be authored as a compact **param file** rendered through a **local template**, instead of full spec folders — with the generated specs kept **ephemeral** (only the param file + its `service.json` sidecar are committed).

Per review feedback, this isn't wired command-by-command. The feature is "**how you read service files — directly or via template expansion**", so it lives at the **single discovery seam**: one group callback on the `specs` app renders param files into ephemeral folders before any *read* command (`validate` / `upload` / `run-tests` / `list` / `show`) and cleans them up after. `format`/`populate` are skipped (they act on the committed files).

## How it works

- `specs/<provider>/<name>.json` = `{ "template"?: "<bare name>", "parameters": {…} }`. Service name comes from the path; `template` resolves to `templates/<name>/` (or `templates/`), else it's a remote template → errors toward `params instantiate`.
- Rendering **reuses `populate_from_iterator`** (the populator engine) for the `.j2` → offering/listing + `provider.json` + `time_created`; the param path only adds: bundling the template's extra files (e.g. `connectivity.sh.j2`) and the `service_id` ↔ `<name>.service.json` sidecar round-trip.
- All under `materialized_param_specs`, a context manager that renders, yields, then syncs the sidecar and removes the ephemeral folders. Existing repos (no param files) are unaffected — it's a no-op.

## Test plan
- [x] New `tests/test_params_render.py` (5): self-contained render + cleanup, `service_id` sidecar round-trip, bad-template error, folder/file conflict, end-to-end `specs validate` via CliRunner
- [x] Full suite 199 passed; ruff + mypy clean on changed files
- [x] Manual e2e on a resp-shaped repo: `specs validate` (2 valid), `specs run-tests` (2/2 pass), folders cleaned up, bad-template message is clean

## Follow-ups
- Convert `unitysvc-services-resp` to `templates/resp/` + `specs/unitysvc/resp*.json` (separate repo PR)
- Remote path (`params instantiate` from files) once [unitysvc/unitysvc#1273](https://github.com/unitysvc/unitysvc/issues/1273) lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)
