### PR TITLE
Release 0.2.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "unitysvc-sellers"
-version = "0.2.3"
+version = "0.2.4"
 description = "Seller-facing tools for UnitySVC: HTTP SDK + usvc_seller CLI"
 readme = "README.md"
 authors = [{ name = "Bo Peng", email = "bo.peng@unitysvc.com" }]


### PR DESCRIPTION
Bump to 0.2.4. Ships local param-file rendering in `specs` (#90): `specs/<name>.json` param files rendered ephemerally through a local template, plus the design note (#89). Needed before `unitysvc-services-resp` can adopt the param format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)