### PR TITLE
utils: drop dead re-export of find_file_by_schema_and_name

### DIFF
--- a/src/unitysvc_sellers/utils.py
+++ b/src/unitysvc_sellers/utils.py
@@ -34,7 +34,6 @@ from unitysvc_core.utils import (  # noqa: F401
     compute_file_hash,
     deep_merge_dicts,
     find_data_files,
-    find_file_by_schema_and_name,
     find_files_by_schema,
     generate_content_based_key,
     get_basename,


### PR DESCRIPTION
Companion to [unitysvc-core#33](https://github.com/unitysvc/unitysvc-core/pull/33). `find_file_by_schema_and_name` was re-exported from `unitysvc_sellers.utils` but never called anywhere; core is removing it. Drop the dead import. Works against both current and post-#33 core.

## Test plan
- [x] Full suite (199) passes; imports clean against core#33

🤖 Generated with [Claude Code](https://claude.com/claude-code)