### PR TITLE
feat(params): add list/show; operate on a params/ folder of system-template params

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -30,7 +30,7 @@ $ usvc_seller [OPTIONS] COMMAND [ARGS]...
 * `groups`: Remote service group operations (list,...
 * `secrets`: Remote secret operations (list, show, set,...
 * `templates`: Browse the platform service-template...
-* `params`: Create services from templates +...
+* `params`: System-template param files under params/...
 
 ## `usvc_seller specs`
 
@@ -1216,7 +1216,7 @@ $ usvc_seller templates show [OPTIONS] NAME_OR_ID
 
 ## `usvc_seller params`
 
-Create services from templates + parameters (instantiate).
+System-template param files under params/ (list, show, instantiate).
 
 **Usage**:
 
@@ -1230,32 +1230,75 @@ $ usvc_seller params [OPTIONS] COMMAND [ARGS]...
 
 **Commands**:
 
-* `instantiate`: Instantiate a template + parameters into a...
+* `list`: List the system-template param files under...
+* `show`: Show one param file&#x27;s template,...
+* `instantiate`: Instantiate system-template param files...
 
-### `usvc_seller params instantiate`
+### `usvc_seller params list`
 
-Instantiate a template + parameters into a service (the params-kind
-analog of ``specs upload``).
-
-Examples:
-    usvc_seller params instantiate openai-compatible-llm \
-        -P api_base_url=https://ollama.example.com/v1 -P input_price=1.00
+List the system-template param files under ``params/`` (offline).
 
 **Usage**:
 
 ```console
-$ usvc_seller params instantiate [OPTIONS] TEMPLATE
+$ usvc_seller params list [OPTIONS] [NAME]
 ```
 
 **Arguments**:
 
-* `TEMPLATE`: Template name or partial UUID.  [required]
+* `[NAME]`: Filter by name (fnmatch, e.g. &#x27;acme/*&#x27; or &#x27;acme/%&#x27;).
 
 **Options**:
 
-* `-P, --param TEXT`: A template parameter as key=value (repeatable). Secret-typed params take the secret NAME, not the value.
-* `--name TEXT`: Optional label for the service (defaults to template).
-* `--submit / --no-submit`: Submit the rendered service for review (default), or leave it a draft.  [default: submit]
+* `-d, --data-dir PATH`: Repo root or params/ directory (default: current directory).
+* `-f, --format TEXT`: Output format: table | json.  [default: table]
+* `--help`: Show this message and exit.
+
+### `usvc_seller params show`
+
+Show one param file&#x27;s template, parameters, and recorded service_id.
+
+**Usage**:
+
+```console
+$ usvc_seller params show [OPTIONS] NAME
+```
+
+**Arguments**:
+
+* `NAME`: Service name of the param file (first column of `params list`).  [required]
+
+**Options**:
+
+* `-d, --data-dir PATH`: Repo root or params/ directory (default: current directory).
+* `-f, --format TEXT`: Output format: table | json.  [default: table]
+* `--help`: Show this message and exit.
+
+### `usvc_seller params instantiate`
+
+Instantiate system-template param files into services — all, or those
+matching ``NAME``.
+
+Each param file&#x27;s ``template`` (a system template — see ``usvc_seller
+templates``) is rendered with its ``parameters`` into a backend service. The
+returned ``service_id`` is written to a committed ``&lt;name&gt;.service.json``
+sidecar; an entry that already has one is skipped (re-instantiating to update
+the same service needs backend support, unitysvc/unitysvc#1273).
+
+**Usage**:
+
+```console
+$ usvc_seller params instantiate [OPTIONS] [NAME]
+```
+
+**Arguments**:
+
+* `[NAME]`: Param-file selector (fnmatch; omit = all under params/).
+
+**Options**:
+
+* `--submit / --no-submit`: Submit each rendered service for review (default), or leave a draft.  [default: submit]
+* `-d, --data-dir PATH`: Repo root or params/ directory (default: current directory).
 * `--api-key TEXT`: Seller API key (svcpass_...). Defaults to $UNITYSVC_SELLER_API_KEY.  [env var: UNITYSVC_SELLER_API_KEY]
 * `--base-url TEXT`: Backend base URL.  [env var: UNITYSVC_SELLER_API_URL; default: https://seller.unitysvc.com/v1]
 * `--help`: Show this message and exit.

--- a/docs/guides/create-from-template.md
+++ b/docs/guides/create-from-template.md
@@ -1,53 +1,109 @@
 # Create from a Template
 
-The fastest way to publish a common service type is to **instantiate a platform
-template** — you author no files at all. You provide a handful of parameters and
-the platform renders the complete service, runs the template's bundled test, and
-submits it. This is the `params` route from
-[Services → Two ways to create a service](../services.md#two-ways-to-create-a-service);
-for the bigger picture (capability pools, authoring your own templates) see the
+The fastest way to publish a common service type is to **instantiate a system
+template** — a template the platform publishes (e.g. an OpenAI-compatible LLM
+endpoint). You author no spec files: you pick a template, supply a handful of
+parameters in a small **param file** under `params/`, and the platform renders
+the complete service, runs the template's bundled test, and submits it.
+
+This is the `params` route — the system-template mirror of `specs/`. Two
+commands work together:
+
+| Command | Role |
+|---|---|
+| **`usvc_seller templates`** | **Browse** the catalog — `list` the system templates, `show` one's parameters. Read-only. |
+| **`usvc_seller params`** | **Use** them — author `params/` files, `list` / `show` them, and `instantiate` them into services. |
+
+For the bigger picture (capability pools, authoring your *own* templates) see the
 [Service Templates](../service-templates.md) concept page.
 
-## Browse the catalog
+## 1. Browse the catalog — `templates`
 
 ```bash
-usvc_seller templates list                        # active platform templates
-usvc_seller templates show openai-compatible-llm  # parameters, types, and which are required
+usvc_seller templates list                        # active system templates
+usvc_seller templates show openai-compatible-llm  # its parameters: name, type, required?
 ```
 
 `templates show` lists each parameter's name, type, and whether it's required —
-your checklist for the next step.
+your checklist for the param file you write next.
 
-## Instantiate
+## 2. Author a param file under `params/`
 
-`params instantiate` is the template analog of `specs upload`: it renders the
-template into a service and (by default) submits it for review.
+A param file is `params/<name>.json` = `{ "template", "parameters" }`: the
+**system template name** (from `templates list`) plus the values to render it
+with. Its path under `params/` becomes the service name.
+
+```
+params/
+└── acme/
+    ├── gpt.json            # { template, parameters }
+    └── gpt.service.json    # identity sidecar (service_id) — written on instantiate, committed
+```
+
+```jsonc
+// params/acme/gpt.json
+{
+  "template": "openai-compatible-llm",
+  "parameters": {
+    "api_base_url": "https://api.acme.ai/v1",
+    "api_key_secret_name": "UPSTREAM_API_KEY",
+    "input_price": 1.00
+  }
+}
+```
+
+> **`params/` (system templates) vs `specs/` (local).** A param file under
+> `params/` names a **system** template, rendered server-side by `instantiate`.
+> A param file under `specs/` whose `template` is a **local** `templates/`
+> directory is instead rendered on your machine by the `specs` commands. Same
+> file shape, different folder, different command — see
+> [Service Templates](../service-templates.md).
+
+## 3. Inspect what you've authored — `params list` / `show`
+
+Offline, no API call:
 
 ```bash
-usvc_seller params instantiate openai-compatible-llm \
-    -P api_base_url=https://api.example.com/v1 \
-    -P api_key_secret_name=UPSTREAM_API_KEY \
-    -P input_price=1.00
+usvc_seller params list                 # every param file under params/ (Service · Template · Service ID)
+usvc_seller params show acme/gpt        # one file's template, parameters, and recorded service_id
+```
+
+## 4. Instantiate — `params instantiate`
+
+`params instantiate` is the params-kind analog of `specs upload`: it renders each
+param file's system template with its parameters into a backend service and (by
+default) submits it for review.
+
+```bash
+usvc_seller params instantiate           # all param files under params/
+usvc_seller params instantiate acme/gpt  # just this one (NAME is an fnmatch selector)
+usvc_seller params instantiate 'acme/*'  # everything under acme/
 ```
 
 | Option | Meaning |
 |---|---|
-| `-P key=value` | A template parameter (repeatable) |
-| `--name` | Optional label for the service (defaults to the template name) |
-| `--submit` / `--no-submit` | Submit for review (default), or leave a draft to submit later |
+| `[NAME]` | Param-file selector (fnmatch); omit = all under `params/` |
+| `--submit` / `--no-submit` | Submit each for review (default), or leave a draft |
 
-With `--no-submit` you get a reviewable draft; submit it later with
-`usvc_seller services submit <service_name>`.
+**Identity round-trips through the sidecar.** On a successful instantiate the
+backend-assigned `service_id` is written to `params/<name>.service.json` (commit
+it). An entry that already has a `service_id` is skipped — re-instantiating to
+*update* the same service needs backend support
+([unitysvc/unitysvc#1273](https://github.com/unitysvc/unitysvc/issues/1273)).
 
 ## Secret-typed parameters
 
 A secret-typed parameter (e.g. an upstream API key) takes the **name of a
-secret**, never the raw value. Create the secret first, then reference it by
-name:
+secret**, never the raw value. Create the secret first, then reference it by name
+in the param file:
 
 ```bash
-usvc_seller secrets set UPSTREAM_API_KEY            # stores the value securely
-usvc_seller params instantiate openai-compatible-llm -P api_key_secret_name=UPSTREAM_API_KEY …
+usvc_seller secrets set UPSTREAM_API_KEY   # stores the value securely
+```
+
+```jsonc
+// then in the param file:
+"parameters": { "api_key_secret_name": "UPSTREAM_API_KEY", … }
 ```
 
 See [Promotions, Groups & Secrets](catalog-extras.md#secrets) for managing
@@ -61,11 +117,11 @@ secrets.
 from unitysvc_sellers import Client
 
 with Client() as client:
-    client.templates.list()                       # available templates
+    client.templates.list()                       # available system templates
     result = client.instances.create(
         "openai-compatible-llm",
         parameters={
-            "api_base_url": "https://api.example.com/v1",
+            "api_base_url": "https://api.acme.ai/v1",
             "api_key_secret_name": "UPSTREAM_API_KEY",
             "input_price": 1.00,
         },

--- a/src/unitysvc_sellers/commands/params.py
+++ b/src/unitysvc_sellers/commands/params.py
@@ -1,23 +1,34 @@
-"""``usvc_seller params`` — create services from templates + parameters.
+"""``usvc_seller params`` — system-template param files under ``params/``.
 
-A *params* entry is just a template reference + parameter values (local, like a
-spec) — inert until you **`instantiate`** it, at which point it produces a
-backend service (an *instance of a template*). `instantiate` is the params-kind
-analog of `specs upload`. Browse what you can instantiate with
-`usvc_seller templates`; see the services it produced with `usvc_seller services`.
+A **param file** (``params/<name>.json`` = ``{ "template", "parameters" }``) is a
+compact, declarative service definition: a **system template** name (browse the
+catalog with ``usvc_seller templates``) plus the values to render it with. The
+``params/`` folder is the system-template mirror of ``specs/`` (which holds local
+spec folders and local-template param files):
 
-Capability pools opt in the same way: `instantiate` a pool-named template and
-the resulting service joins ``/p/<pool>`` at the pool's uniform terms.
+- **`list`** / **`show`** — inspect the param files in ``params/`` (offline).
+- **`instantiate`** — render the system template + parameters into a backend
+  service (the params-kind analog of ``specs upload``), for all param files or a
+  selected subset. The backend-assigned ``service_id`` round-trips through a
+  committed ``<name>.service.json`` sidecar.
+
+A param file whose ``template`` is a pool-named system template produces a
+service that joins ``/p/<pool>`` at the pool's uniform terms.
 """
 
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import Any
 
+import json5
 import typer
 from rich.console import Console
+from rich.table import Table
 
+from ..params_render import is_param_file
+from ..utils import service_name_matches
 from ._helpers import (
     api_key_option,
     async_client,
@@ -30,78 +41,242 @@ from .templates import _resolve_template
 console = Console()
 
 app = typer.Typer(
-    help="Create services from templates + parameters (instantiate).",
+    help="System-template param files under params/ (list, show, instantiate).",
 )
 
 
-def _coerce(value: str) -> Any:
-    """Best-effort scalar coercion for ``-P key=value`` (JSON, else str)."""
+# --- params/ discovery + identity sidecar (local, no network) --------------
+
+
+def _params_root(data_dir: Path | None) -> Path:
+    """The ``params/`` directory, resolved from a repo root or the dir itself."""
+    start = (data_dir or Path.cwd()).resolve()
+    candidate = start / "params"
+    return candidate if candidate.is_dir() else start
+
+
+def _sidecar(param_file: Path) -> Path:
+    return param_file.with_name(param_file.stem + ".service.json")
+
+
+def _read_service_id(param_file: Path) -> str | None:
+    sidecar = _sidecar(param_file)
+    if not sidecar.is_file():
+        return None
     try:
-        return json.loads(value)
-    except (json.JSONDecodeError, ValueError):
-        return value
+        data = json.loads(sidecar.read_text())
+    except Exception:
+        return None
+    sid = data.get("service_id") if isinstance(data, dict) else None
+    return str(sid) if sid else None
 
 
-def _parse_params(params: list[str]) -> dict[str, Any]:
-    out: dict[str, Any] = {}
-    for item in params:
-        if "=" not in item:
-            console.print(f"[red]Error:[/red] --param expects key=value, got '{item}'")
-            raise typer.Exit(code=1)
-        key, value = item.split("=", 1)
-        out[key.strip()] = _coerce(value)
-    return out
+def _write_service_id(param_file: Path, service_id: str) -> None:
+    sidecar = _sidecar(param_file)
+    data: dict[str, Any] = {}
+    if sidecar.is_file():
+        try:
+            loaded = json.loads(sidecar.read_text())
+            if isinstance(loaded, dict):
+                data = loaded
+        except Exception:
+            data = {}
+    data["service_id"] = str(service_id)
+    sidecar.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n")
+
+
+def _entries(data_dir: Path | None, name_filter: str | None = None) -> list[dict[str, Any]]:
+    """Param files under ``params/`` as ``{service_name, template, parameters,
+    service_id, path}``, optionally fnmatch-filtered by name, sorted by name."""
+    root = _params_root(data_dir)
+    out: list[dict[str, Any]] = []
+    for path in sorted(p for p in root.rglob("*.json") if is_param_file(p)):
+        name = path.relative_to(root).with_suffix("").as_posix()
+        if name_filter and not service_name_matches(name, name_filter):
+            continue
+        data = json5.loads(path.read_text())
+        out.append(
+            {
+                "service_name": name,
+                "template": data.get("template"),
+                "parameters": data.get("parameters") or {},
+                "service_id": _read_service_id(path),
+                "path": path,
+            }
+        )
+    return sorted(out, key=lambda e: e["service_name"])
+
+
+def _extract_service_id(result: dict[str, Any]) -> str | None:
+    """Pull a ``service_id`` from an ingest task result — the flat ServiceData
+    record, or the pre-flatten ``{"service": {...}}`` shape."""
+    if not isinstance(result, dict):
+        return None
+    sid = result.get("service_id")
+    if not sid:
+        service = result.get("service")
+        if isinstance(service, dict):
+            sid = service.get("service_id") or service.get("id")
+    return str(sid) if sid else None
+
+
+# --- commands --------------------------------------------------------------
+
+
+@app.command("list")
+def list_params(
+    name: str | None = typer.Argument(None, help="Filter by name (fnmatch, e.g. 'acme/*' or 'acme/%')."),
+    data_dir: Path | None = typer.Option(
+        None,
+        "--data-dir",
+        "-d",
+        help="Repo root or params/ directory (default: current directory).",
+    ),
+    output_format: str = typer.Option("table", "--format", "-f", help="Output format: table | json."),
+) -> None:
+    """List the system-template param files under ``params/`` (offline)."""
+    entries = _entries(data_dir, name)
+    if not entries:
+        console.print("[dim]No param files found under params/[/dim]")
+        return
+    if output_format == "json":
+        console.print(
+            json.dumps(
+                [{k: v for k, v in e.items() if k != "path"} for e in entries],
+                indent=2,
+                default=str,
+            )
+        )
+        return
+    table = Table(title="Param Files (params/)")
+    table.add_column("Service", style="bold")
+    table.add_column("Template")
+    table.add_column("Service ID", style="dim")
+    for e in entries:
+        table.add_row(
+            e["service_name"],
+            e["template"] or "[red](missing)[/red]",
+            (e["service_id"] or "")[:8],
+        )
+    console.print(table)
+
+
+@app.command("show")
+def show_param(
+    name: str = typer.Argument(..., help="Service name of the param file (first column of `params list`)."),
+    data_dir: Path | None = typer.Option(
+        None,
+        "--data-dir",
+        "-d",
+        help="Repo root or params/ directory (default: current directory).",
+    ),
+    output_format: str = typer.Option("table", "--format", "-f", help="Output format: table | json."),
+) -> None:
+    """Show one param file's template, parameters, and recorded service_id."""
+    matches = [e for e in _entries(data_dir) if e["service_name"] == name]
+    if not matches:
+        console.print(
+            f"[red]Error:[/red] No param file for '{name}' under params/. Run [cyan]usvc_seller params list[/cyan]."
+        )
+        raise typer.Exit(code=1)
+    entry = matches[0]
+    if output_format == "json":
+        console.print(json.dumps({k: v for k, v in entry.items() if k != "path"}, indent=2, default=str))
+        return
+
+    console.print(f"\n[bold]{entry['service_name']}[/bold]")
+    meta = Table(show_header=False, box=None, padding=(0, 2))
+    meta.add_column("Field", style="cyan")
+    meta.add_column("Value")
+    meta.add_row(
+        "template",
+        entry["template"] or "[red](missing — system template name required)[/red]",
+    )
+    if entry["service_id"]:
+        meta.add_row("service_id", entry["service_id"])
+    console.print(meta)
+
+    params = entry["parameters"]
+    if params:
+        console.print("\n[bold]Parameters[/bold]")
+        ptable = Table()
+        ptable.add_column("Key", style="bold")
+        ptable.add_column("Value")
+        for key, value in params.items():
+            ptable.add_row(key, value if isinstance(value, str) else json.dumps(value, default=str))
+        console.print(ptable)
+    console.print("\n[dim]Instantiate with[/dim] [cyan]usvc_seller params instantiate[/cyan][dim].[/dim]")
 
 
 @app.command("instantiate")
 def instantiate(
-    template: str = typer.Argument(..., help="Template name or partial UUID."),
-    param: list[str] = typer.Option(
-        [],
-        "--param",
-        "-P",
-        help="A template parameter as key=value (repeatable). Secret-typed params take the secret NAME, not the value.",
-    ),
-    name: str | None = typer.Option(
-        None, "--name", help="Optional label for the service (defaults to template)."
-    ),
+    name: str | None = typer.Argument(None, help="Param-file selector (fnmatch; omit = all under params/)."),
     submit: bool = typer.Option(
         True,
         "--submit/--no-submit",
-        help="Submit the rendered service for review (default), or leave it a draft.",
+        help="Submit each rendered service for review (default), or leave a draft.",
+    ),
+    data_dir: Path | None = typer.Option(
+        None,
+        "--data-dir",
+        "-d",
+        help="Repo root or params/ directory (default: current directory).",
     ),
     api_key: str | None = api_key_option(),
     base_url: str = base_url_option(),
 ) -> None:
-    """Instantiate a template + parameters into a service (the params-kind
-    analog of ``specs upload``).
+    """Instantiate system-template param files into services — all, or those
+    matching ``NAME``.
 
-    Examples:
-        usvc_seller params instantiate openai-compatible-llm \\
-            -P api_base_url=https://ollama.example.com/v1 -P input_price=1.00
+    Each param file's ``template`` (a system template — see ``usvc_seller
+    templates``) is rendered with its ``parameters`` into a backend service. The
+    returned ``service_id`` is written to a committed ``<name>.service.json``
+    sidecar; an entry that already has one is skipped (re-instantiating to update
+    the same service needs backend support, unitysvc/unitysvc#1273).
     """
-    parameters = _parse_params(param)
+    entries = _entries(data_dir, name)
+    if not entries:
+        where = f" matching '{name}'" if name else " under params/"
+        console.print(f"[yellow]No param files{where}[/yellow]")
+        raise typer.Exit(code=1)
 
-    async def _impl():
+    async def _impl() -> None:
         async with async_client(api_key, base_url) as client:
-            stub = await _resolve_template(client, template)
-            return model_to_dict(
-                await client.instances.create(
-                    stub["id"], parameters=parameters, name=name, submit=submit
-                )
-            )
+            for entry in entries:
+                label = entry["service_name"]
+                if entry["service_id"]:
+                    console.print(f"[dim]• {label}: already instantiated ({entry['service_id'][:8]}) — skipping[/dim]")
+                    continue
+                if not entry["template"]:
+                    console.print(f"[red]✗ {label}: no 'template' (system template name required)[/red]")
+                    continue
+                try:
+                    stub = await _resolve_template(client, entry["template"])
+                    queued = model_to_dict(
+                        await client.instances.create(
+                            stub["id"],
+                            parameters=entry["parameters"],
+                            name=label,
+                            submit=submit,
+                        )
+                    )
+                except Exception as exc:  # noqa: BLE001 — report and continue
+                    console.print(f"[red]✗ {label}: {exc}[/red]")
+                    continue
 
-    result = run_async(_impl(), error_prefix="Failed to instantiate template")
-    verb = "Submitted for review" if submit else "Created as a draft"
-    console.print(f"[green]✓[/green] {verb}")
-    console.print(f"  instance_id: {result.get('instance_id')}")
-    console.print(f"  task_id: {result.get('task_id')}")
-    tail = (
-        "submit it later with [cyan]usvc_seller services submit[/cyan]"
-        if not submit
-        else "track it in your staging list"
-    )
-    console.print(
-        f"\n[dim]The service will appear under your staging list once ingest "
-        f"completes — {tail}.[/dim]"
-    )
+                task_id = queued.get("task_id")
+                service_id = None
+                if task_id:
+                    statuses = await client.tasks.wait(str(task_id))
+                    status = statuses.get(str(task_id), {})
+                    if status.get("status") == "completed":
+                        service_id = _extract_service_id(status.get("result") or {})
+                if service_id:
+                    _write_service_id(entry["path"], service_id)
+                    console.print(f"[green]✓[/green] {label}: service_id={service_id}")
+                else:
+                    detail = f"task_id={task_id}" if task_id else "queued"
+                    console.print(f"[green]✓[/green] {label}: submitted ({detail})")
+
+    run_async(_impl(), error_prefix="Failed to instantiate param files")
+    console.print("\n[dim]Services appear under your staging list once ingest completes.[/dim]")

--- a/tests/test_params_cli.py
+++ b/tests/test_params_cli.py
@@ -1,0 +1,86 @@
+"""Tests for ``usvc_seller params list`` / ``show`` over the ``params/`` folder.
+
+These are the offline commands (no backend). ``instantiate`` needs a live
+backend with system templates and is exercised by integration coverage.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from unitysvc_sellers.commands.params import app
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def params_repo(tmp_path: Path) -> Path:
+    """A repo with a ``params/`` folder: two param files, one with a sidecar."""
+    acme = tmp_path / "params" / "acme"
+    acme.mkdir(parents=True)
+    (acme / "gpt.json").write_text(
+        json.dumps(
+            {
+                "template": "openai-compatible-llm",
+                "parameters": {"api_base_url": "https://acme.ai/v1", "input_price": 1.0},
+            }
+        )
+        + "\n"
+    )
+    (acme / "gpt.service.json").write_text(json.dumps({"service_id": "abc12345-0000-0000-0000-000000000000"}) + "\n")
+    (acme / "gpt2.json").write_text(
+        json.dumps({"template": "openai-compatible-llm", "parameters": {"api_base_url": "https://acme.ai/v2"}}) + "\n"
+    )
+    return tmp_path
+
+
+def test_list_shows_all_param_files(params_repo: Path) -> None:
+    result = runner.invoke(app, ["list", "-d", str(params_repo)])
+    assert result.exit_code == 0, result.output
+    assert "acme/gpt" in result.output
+    assert "acme/gpt2" in result.output
+    assert "openai-compatible-llm" in result.output
+    # the sidecar service_id surfaces (truncated)
+    assert "abc12345" in result.output
+
+
+def test_list_json_and_name_filter(params_repo: Path) -> None:
+    result = runner.invoke(app, ["list", "acme/gpt2", "-d", str(params_repo), "-f", "json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert [e["service_name"] for e in payload] == ["acme/gpt2"]
+    assert payload[0]["service_id"] is None
+    assert "path" not in payload[0]
+
+
+def test_list_empty_when_no_params_folder(tmp_path: Path) -> None:
+    result = runner.invoke(app, ["list", "-d", str(tmp_path)])
+    assert result.exit_code == 0
+    assert "No param files" in result.output
+
+
+def test_show_one_param(params_repo: Path) -> None:
+    result = runner.invoke(app, ["show", "acme/gpt", "-d", str(params_repo)])
+    assert result.exit_code == 0, result.output
+    assert "openai-compatible-llm" in result.output
+    assert "abc12345-0000-0000-0000-000000000000" in result.output
+    assert "api_base_url" in result.output
+
+
+def test_show_json(params_repo: Path) -> None:
+    result = runner.invoke(app, ["show", "acme/gpt2", "-d", str(params_repo), "-f", "json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["service_name"] == "acme/gpt2"
+    assert payload["template"] == "openai-compatible-llm"
+    assert payload["service_id"] is None
+
+
+def test_show_missing_errors(params_repo: Path) -> None:
+    result = runner.invoke(app, ["show", "acme/nope", "-d", str(params_repo)])
+    assert result.exit_code == 1
+    assert "No param file" in result.output


### PR DESCRIPTION
\`usvc_seller params\` only had \`instantiate\`. This gives it the \`list\` / \`show\` subcommands the other families have, and scopes the whole \`params\` family to a **\`params/\` folder** of system-template param files — the system-template mirror of \`specs/\` (which keeps local spec folders and local-template param files).

## Commands
- **\`params list [NAME]\`** — list the param files under \`params/\` (offline). Columns: Service / Template / Service ID; \`--format json\`; fnmatch NAME filter.
- **\`params show NAME\`** — one file's template, parameters, and recorded service_id.
- **\`params instantiate [NAME]\`** — now **file-based**: all param files under \`params/\`, or those matching NAME (the params-kind analog of \`specs upload\`). Each file's system \`template\` is rendered with its \`parameters\`; the returned \`service_id\` round-trips through a \`<name>.service.json\` sidecar. An entry that already has a service_id is skipped (re-instantiate-to-update needs backend [unitysvc#1273](https://github.com/unitysvc/unitysvc/issues/1273)).

The param-file format is unchanged: \`{ \"template\", \"parameters\" }\`.

## Note
The old inline \`params instantiate <template> -P key=value\` form is removed (superseded by param files). Docs that show it (and the \"no params/ directory\" framing) need a follow-up reconciliation — params/ (system templates) is now distinct from specs/ (local).

## Test plan
- [x] \`ruff\` + \`mypy src\` clean (207 files)
- [x] \`pytest\` — 205 passed (new \`test_params_cli.py\`: list/show table+json, name filter, empty, not-found)
- [x] Smoke-tested list/show against a temp \`params/\` fixture

🤖 Generated with [Claude Code](https://claude.com/claude-code)