### PR TITLE
fix(params_render): omit provider_name for top-level (bare) service names

### DIFF
--- a/src/unitysvc_sellers/params_render.py
+++ b/src/unitysvc_sellers/params_render.py
@@ -167,12 +167,17 @@ def materialized_param_specs(root: Path) -> Iterator[list[Path]]:
                     f"'{_service_name_for(pf)}' — a service is one or the other."
                 )
             service_name = _service_name_for(pf)
-            ctx = {
+            ctx: dict[str, Any] = {
                 "name": service_name,  # name_field → folder path under output_dir
                 "service_name": service_name,
-                "provider_name": service_name.split("/")[0],
-                **(data.get("parameters") or {}),
             }
+            # provider_name only applies to a namespaced (provider/service)
+            # name; a top-level service (a bare name like ``resp200``) has no
+            # provider segment, so it's omitted rather than set to the whole
+            # name. Templates for top-level services hardcode their provider.
+            if "/" in service_name:
+                ctx["provider_name"] = service_name.split("/")[0]
+            ctx.update(data.get("parameters") or {})
             groups.setdefault(tdir, []).append((pf, ctx))
 
         for tdir, items in groups.items():

--- a/tests/test_params_render.py
+++ b/tests/test_params_render.py
@@ -97,6 +97,39 @@ def test_renders_self_contained_folder_then_cleans_up(tmp_path: Path) -> None:
     assert (root / "specs" / "unitysvc" / "resp200.json").exists()
 
 
+def test_top_level_name_omits_provider_name(tmp_path: Path) -> None:
+    """A bare top-level name (directly under ``specs/``) renders a bare
+    ``service_name`` and does NOT inject ``provider_name`` (= the whole name);
+    a namespaced name still derives ``provider_name`` from the first segment.
+    """
+    tdir = tmp_path / "templates" / "t"
+    tdir.mkdir(parents=True)
+    (tdir / "provider.json").write_text(PROVIDER + "\n")
+    # Echo provider_name into the offering (materialized_param_specs does not
+    # validate, so an extra field is fine for the assertion).
+    (tdir / "offering.json.j2").write_text(
+        '{"name": "{{ service_name }}", "x_provider": "{{ provider_name | default(\'<none>\') }}"}\n'
+    )
+    (tdir / "listing.json.j2").write_text('{"name": "{{ service_name }}"}\n')
+
+    specs = tmp_path / "specs"
+    (specs / "labs").mkdir(parents=True)
+    (specs / "resp200.json").write_text(  # bare, top-level
+        json.dumps({"template": "t", "parameters": {}}) + "\n"
+    )
+    (specs / "labs" / "svc.json").write_text(  # namespaced
+        json.dumps({"template": "t", "parameters": {}}) + "\n"
+    )
+
+    with materialized_param_specs(tmp_path):
+        bare = json.loads((specs / "resp200" / "offering.json").read_text())
+        namespaced = json.loads((specs / "labs" / "svc" / "offering.json").read_text())
+        assert bare["name"] == "resp200"
+        assert bare["x_provider"] == "<none>"  # provider_name not set for a bare name
+        assert namespaced["name"] == "labs/svc"
+        assert namespaced["x_provider"] == "labs"  # first segment
+
+
 def test_service_id_sidecar_roundtrip(tmp_path: Path) -> None:
     root = _make_repo(tmp_path)
     sidecar = root / "specs" / "unitysvc" / "resp200.service.json"


### PR DESCRIPTION
The param-file render context set \`provider_name = service_name.split(\"/\")[0]\`, which for a **bare top-level name** like \`resp200\` produced a bogus \`provider_name = \"resp200\"\` (the whole name, not a provider).

\`provider_name\` only applies to a **namespaced** \`provider/service\` name; a top-level service has no provider segment, so it is now **omitted** for bare names. Templates for top-level services hardcode their provider (e.g. resp's static \`provider.json\`).

This surfaced while making the resp services bare top-level handles (\`resp200\` instead of \`unitysvc/resp200\`) — their static provider.json masked the bug, but any top-level template referencing \`{{ provider_name }}\` would have rendered the service name as the provider.

## Test plan
- [x] New \`test_top_level_name_omits_provider_name\`: bare name → \`provider_name\` absent; namespaced → first segment.
- [x] \`ruff\` + \`mypy src\` clean (207 files); \`pytest\` — 206 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)