### PR TITLE
Release 0.2.5 — restore compatibility with core 0.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "unitysvc-sellers"
-version = "0.2.4"
+version = "0.2.5"
 description = "Seller-facing tools for UnitySVC: HTTP SDK + usvc_seller CLI"
 readme = "README.md"
 authors = [{ name = "Bo Peng", email = "bo.peng@unitysvc.com" }]
@@ -17,7 +17,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-  "unitysvc-core>=0.2.0",
+  "unitysvc-core>=0.2.1",
   "unitysvc-data>=0.1.18",
   "typer",
   "rich",


### PR DESCRIPTION
## Summary
- Bump `unitysvc-sellers` to **0.2.5** and tighten the core pin to `unitysvc-core>=0.2.1`.
- **Why:** the released **0.2.4** still re-exported `find_file_by_schema_and_name` from `unitysvc_core.utils`, which **core 0.2.1** removed in the service_id refactor. With both released versions installed, `import unitysvc_sellers.cli` raises `ImportError` *before any command runs* — breaking every centralized-CI service repo (e.g. [unitysvc-services-resp#8](https://github.com/unitysvc-labs/unitysvc-services-resp/pull/8), http, and all ~20 `unitysvc-services-*`).
- The fix already landed as #92 (drop the dead re-export); this release ships it, plus #93–#95 (ServiceData identity round-trip via `service.json`, and the `params` list/show family operating on a `params/` folder).

## Verification
- `import unitysvc_sellers.cli` succeeds against the symbol-less installed core 0.2.1.
- `usvc_seller specs validate` in `unitysvc-services-resp` → `✓ All 6 service folder(s) are valid!`

## Release step
After merge: publish a `v0.2.5` GitHub Release → `publish.yml` (`on: release: published`) pushes to PyPI. Service-repo CIs go green on their next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
