### PR TITLE
fix(cli): paginate resolve_service_id fallback (422 on services show --id)

### DIFF
--- a/src/unitysvc_sellers/commands/_helpers.py
+++ b/src/unitysvc_sellers/commands/_helpers.py
@@ -151,12 +151,18 @@ async def resolve_promotion(client: AsyncClient, name_or_id: str) -> dict[str, A
 # Service id resolution
 # ---------------------------------------------------------------------------
 async def resolve_service_id(client: AsyncClient, partial_id: str) -> str:
-    """Resolve a partial service id (≥8 chars) to a full UUID.
+    """Resolve a partial service id to a full UUID.
 
-    The new ``services_get`` endpoint accepts the raw path segment and
-    leaves resolution to the backend, but for bulk operations we still
-    need a list-and-prefix-match step. Returns the full id as a string,
-    or raises ``typer.Exit(1)`` on miss / ambiguous.
+    For an id of at least 8 chars the ``services_get`` endpoint resolves the
+    partial id **server-side**, so the happy path never lists — ``get`` returns
+    the service directly. Only when ``get`` *fails* (or for a short prefix it
+    won't accept) do we fall back to a list-and-prefix-match.
+
+    That fallback is cursor-paginated: the backend caps page size at 200
+    (``seller/_pagination.LimitParam``), so the previous single ``limit=1000``
+    request raised a 422 — which, on a plain not-found, surfaced as a confusing
+    "limit must be <= 200" instead of "service not found". Returns the full id
+    as a string, or raises ``typer.Exit(1)`` on miss / ambiguous.
     """
     if len(partial_id) >= 8:
         # Try to fetch directly first — backend handles partial ids.
@@ -168,9 +174,12 @@ async def resolve_service_id(client: AsyncClient, partial_id: str) -> str:
         except SellerSDKError:
             pass
 
-    # Fall back to listing and prefix match.
-    services = model_list(await client.services.list(limit=1000))
-    matches = [s for s in services if str(s.get("id", "")).startswith(partial_id)]
+    # Fall back to a cursor-paginated list-and-prefix-match.
+    matches: list[dict[str, Any]] = []
+    async for svc in client.services.iter_all(limit=200):
+        detail = model_to_dict(svc)
+        if str(detail.get("id", "")).startswith(partial_id):
+            matches.append(detail)
     if len(matches) == 1:
         return str(matches[0]["id"])
     if len(matches) > 1:

--- a/tests/test_aclient.py
+++ b/tests/test_aclient.py
@@ -237,7 +237,7 @@ class TestServicesCommands:
         # ``--id`` resolution falls back to listing on a 404; mock an
         # empty list so the helper reports "not found" rather than
         # "ambiguous".
-        respx.get(f"{BASE_URL}/services").mock(
+        list_route = respx.get(f"{BASE_URL}/services").mock(
             return_value=httpx.Response(
                 200, json={"data": [], "has_more": False, "count": 0}
             )
@@ -247,6 +247,11 @@ class TestServicesCommands:
         assert result.exit_code == 1
         # ``resolve_service_id`` reports a not-found via the list fallback.
         assert "not found" in result.stdout.lower() or "Failed to resolve" in result.stdout
+        # Regression: the fallback must page within the backend's limit cap
+        # (<= 200), not request limit=1000 (which raised a confusing 422).
+        assert list_route.called
+        limit = int(list_route.calls.last.request.url.params["limit"])
+        assert limit <= 200, f"resolve fallback requested limit={limit} (> 200 cap)"
 
     @respx.mock
     def test_deprecate_calls_set_status(self, runner: CliRunner, env: None) -> None:


### PR DESCRIPTION
## What

Fix the confusing **422 on `usvc_seller services show --id <prefix>`** (and any other path through `resolve_service_id`):

```
✗ Failed to resolve --id: API request failed with status 422:
  [{'loc': ['query','limit'], 'msg': 'Input should be less than or equal to 200', 'input': '1000', ...}]
```

## Why

`resolve_service_id` tries `services.get(partial_id)` first — the backend resolves partial ids server-side — and only falls back to a list-and-prefix-match when `get()` fails (or for a short prefix). That fallback used `services.list(limit=1000)`, but the seller list endpoint caps page size at **200** (`seller/_pagination.LimitParam`), so it raised a 422. On a plain not-found (e.g. the id no longer exists), the user saw "limit must be ≤ 200" instead of "service not found" — the real error was masked behind the cap.

`fetch_service_ids_by_status` already paginates at `PAGE_SIZE=200` and documents this exact cap; `resolve_service_id` was the lone holdout still requesting `limit=1000`.

## How

- Page the fallback via `services.iter_all(limit=200)` (cursor pagination) instead of `list(limit=1000)`.
- Happy path unchanged: for a sufficiently-specific id, `get()` returns directly and **never lists**; the scan only runs as a defensive fallback (e.g. `get()` 404/transient error, or a `<8`-char prefix). With the scan now actually running, a genuine miss reports a clean **"Service '<id>' not found"**.
- Regression test asserts the fallback requests `limit ≤ 200`.

`ruff` / `mypy` clean; full suite (212 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
