### PR TITLE
feat(services): surface multi-channel info in CLI (run-tests + show)

### DIFF
--- a/src/unitysvc_sellers/commands/services.py
+++ b/src/unitysvc_sellers/commands/services.py
@@ -383,6 +383,36 @@ def show_service(
             )
         console.print(doc_table)
 
+    # Upstream channels (#1281/#1297): the offering's upstream_access_config,
+    # one entry per channel, with the per-channel type + customer secrets the
+    # backend stamps at ingest (#1305). Orthogonal to the user-facing access
+    # interfaces below: a channel is *how the service reaches upstream*, an
+    # interface is *how a customer reaches the service*.
+    offering = service.get("offering")
+    offering_dict = model_to_dict(offering) if offering and not isinstance(offering, dict) else (offering or {})
+    channels = offering_dict.get("upstream_access_config") if isinstance(offering_dict, dict) else None
+    if isinstance(channels, dict) and channels:
+        console.print(f"\n[bold]Upstream Channels[/bold] ({len(channels)})")
+        for ch_name, cfg in channels.items():
+            if not isinstance(cfg, dict):
+                continue
+            ch_type = cfg.get("type")
+            # The enrollable channel is the one that hosts enrollment.
+            marker = "  [yellow](enrollment channel)[/yellow]" if ch_type == "enrollable" else ""
+            type_label = f" [dim]({ch_type})[/dim]" if ch_type else ""
+            console.print(f"  • [cyan]{ch_name}[/cyan]{type_label}{marker}")
+            if cfg.get("access_method"):
+                console.print(f"      access_method: {cfg['access_method']}")
+            required = cfg.get("customer_secrets_required")
+            if required:
+                console.print(f"      customer_secrets_required: {', '.join(required)}")
+            optional = cfg.get("customer_secrets_optional")
+            if optional:
+                names = ", ".join(
+                    str(o.get("name")) if isinstance(o, dict) else str(o) for o in optional
+                )
+                console.print(f"      customer_secrets_optional: {names}")
+
     # Interfaces
     interfaces = service.get("interfaces") or []
     if interfaces:

--- a/src/unitysvc_sellers/commands/tests.py
+++ b/src/unitysvc_sellers/commands/tests.py
@@ -318,6 +318,28 @@ def show_test(
             console.print("\n[bold]rendered script (executed):[/bold]")
             console.print(_truncate_for_display(str(test["rendered_script"])))
 
+        # Per-channel upstream probe results (#1281/#1297). A multi-channel
+        # service is probed once per upstream access channel; the enrollment
+        # channel is probed via its ops enrollment. ``upstream`` (singleton,
+        # representative) is shown only when the per-channel map is absent.
+        upstream_channels = test.get("upstream_channels")
+        if isinstance(upstream_channels, dict) and upstream_channels:
+            console.print("\n[bold]Per-channel upstream results[/bold]")
+            for ch_name, rec in upstream_channels.items():
+                if not isinstance(rec, dict):
+                    continue
+                console.print(f"  • [cyan]{ch_name}[/cyan]")
+                for k in ("status", "exit_code", "stdout", "stderr", "error"):
+                    v = rec.get(k)
+                    if v not in (None, ""):
+                        console.print(f"      {k}: {v}")
+        elif isinstance(test.get("upstream"), dict) and test["upstream"]:
+            console.print("\n[bold]Upstream result[/bold]")
+            for k in ("status", "exit_code", "stdout", "stderr", "error"):
+                v = test["upstream"].get(k)
+                if v not in (None, ""):
+                    console.print(f"      {k}: {v}")
+
     console.print()
 
 
@@ -585,7 +607,22 @@ def _render_iface_row(row: Any, *, prefix: str) -> None:
     console.print(f"  [red]✗[/red] {prefix}: {detail}")
     # When upstream fallback ran, show how it landed too — that's the
     # signal that distinguishes "platform broke" from "upstream broke".
-    if row.upstream:
+    # Multi-channel services (#1281/#1297) probe each upstream channel; show
+    # one line per channel when the per-channel breakdown is present, else
+    # fall back to the singleton representative probe.
+    channels = getattr(row, "upstream_channels", None)
+    if channels:
+        for ch_name, rec in channels.items():
+            ustatus = (rec or {}).get("status")
+            if ustatus == "success":
+                console.print(
+                    f"      [dim]↳ upstream[{ch_name}]: success (platform fault)[/dim]"
+                )
+            elif ustatus:
+                console.print(
+                    f"      [dim]↳ upstream[{ch_name}]: {ustatus} (upstream fault)[/dim]"
+                )
+    elif row.upstream:
         ustatus = row.upstream.get("status")
         if ustatus == "success":
             console.print("      [dim]↳ upstream: success (platform fault)[/dim]")

--- a/src/unitysvc_sellers/services.py
+++ b/src/unitysvc_sellers/services.py
@@ -66,8 +66,14 @@ class RunTestsIfaceResult:
     outcome: str | None = None
     # ``"success"`` | ``"script_failed"`` | … — the gateway-mode result string.
     gateway: str | None = None
-    # When upstream fallback ran, this carries the upstream-mode probe summary.
+    # When upstream fallback ran, this carries the upstream-mode probe summary
+    # (the representative channel — a passing one if any).
     upstream: dict[str, Any] | None = None
+    # Per upstream-access-channel probe summaries, keyed by channel name
+    # (#1281/#1297).  A multi-channel service is probed once per channel; the
+    # enrollment channel is probed via its ops enrollment.  ``upstream`` above
+    # stays for back-compat; this carries the full per-channel breakdown.
+    upstream_channels: dict[str, Any] | None = None
 
 
 @dataclass(frozen=True)
@@ -139,6 +145,7 @@ def _parse_run_tests_payload(task_id: str, payload: dict[str, Any]) -> RunTestsR
             outcome=row.get("outcome"),
             gateway=row.get("gateway"),
             upstream=row.get("upstream"),
+            upstream_channels=row.get("upstream_channels"),
         )
         for row in (body.get("results") or [])
     ]

--- a/tests/test_services_run_tests_payload.py
+++ b/tests/test_services_run_tests_payload.py
@@ -1,0 +1,60 @@
+"""Tests for ``_parse_run_tests_payload`` — the task-payload → typed-result coercion.
+
+Pins the per-channel breakdown (#1281/#1297): the diagnostic probes each
+upstream access channel, so a failing row carries ``upstream_channels`` keyed
+by channel name alongside the back-compat singleton ``upstream``.
+"""
+
+from __future__ import annotations
+
+from unitysvc_sellers.services import _parse_run_tests_payload
+
+
+def test_parses_upstream_channels_per_row() -> None:
+    payload = {
+        "status": "success",
+        "result": {
+            "service_id": "svc-1",
+            "status": "failure",
+            "success_count": 0,
+            "fail_count": 1,
+            "skipped_count": 0,
+            "results": [
+                {
+                    "document_id": "doc-1",
+                    "interface_name": "default",
+                    "status": "script_failed",
+                    "outcome": "upstream_fault",
+                    "upstream": {"status": "script_failed"},
+                    "upstream_channels": {
+                        "http_relay": {"status": "success"},
+                        "plus": {"status": "script_failed"},
+                    },
+                }
+            ],
+        },
+    }
+
+    result = _parse_run_tests_payload("task-1", payload)
+
+    assert len(result.results) == 1
+    row = result.results[0]
+    assert row.upstream == {"status": "script_failed"}
+    assert row.upstream_channels == {
+        "http_relay": {"status": "success"},
+        "plus": {"status": "script_failed"},
+    }
+
+
+def test_upstream_channels_absent_is_none() -> None:
+    payload = {
+        "status": "success",
+        "result": {
+            "service_id": "svc-1",
+            "status": "success",
+            "results": [{"document_id": "doc-1", "status": "success"}],
+        },
+    }
+
+    row = _parse_run_tests_payload("task-1", payload).results[0]
+    assert row.upstream_channels is None

--- a/tests/test_services_show_channels.py
+++ b/tests/test_services_show_channels.py
@@ -1,0 +1,99 @@
+"""``usvc_seller services show`` renders the upstream channels (#1281/#1297).
+
+The offering's ``upstream_access_config`` carries one entry per upstream
+access channel with the per-channel ``type`` + customer secrets stamped at
+ingest (#1305).  ``show`` must surface the channel *names* and types — they
+were previously invisible (only the user-facing access interfaces showed).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from unitysvc_sellers.cli import app as cli_app
+
+SID = "198eaef8-d924-4df2-801c-f3fb7c0bc9f5"
+
+
+@pytest.fixture
+def env(monkeypatch):
+    monkeypatch.setenv("UNITYSVC_SELLER_API_KEY", "test-key")
+    monkeypatch.setenv("UNITYSVC_SELLER_API_URL", "http://test.local/v1")
+
+
+def _detail() -> dict:
+    return {
+        "service_id": SID,
+        "service_name": "http-relay",
+        "status": "active",
+        "offering": {
+            "upstream_access_config": {
+                "http_relay": {
+                    "access_method": "http",
+                    "type": "byok",
+                    "customer_secrets_required": ["HTTP_RELAY_BASE_URL"],
+                    "customer_secrets_optional": [
+                        {"name": "HTTP_RELAY_API_KEY", "default": ""}
+                    ],
+                },
+                "plus": {
+                    "access_method": "http",
+                    "type": "enrollable",
+                },
+            }
+        },
+        "documents": [],
+        "interfaces": [],
+    }
+
+
+def _factory(detail: dict):
+    client = SimpleNamespace(
+        services=SimpleNamespace(get=_AsyncReturn(detail)),
+    )
+
+    class _Ctx:
+        async def __aenter__(self):
+            return client
+
+        async def __aexit__(self, *exc):
+            return False
+
+    return lambda *a, **kw: _Ctx()
+
+
+class _AsyncReturn:
+    def __init__(self, value):
+        self._value = value
+
+    async def __call__(self, *a, **kw):
+        return self._value
+
+
+def test_show_renders_upstream_channels(env):
+    runner = CliRunner()
+    with (
+        patch(
+            "unitysvc_sellers.commands.services._resolve_single_target_id",
+            return_value=SID,
+        ),
+        patch("unitysvc_sellers.commands.services.async_client", _factory(_detail())),
+    ):
+        result = runner.invoke(cli_app, ["services", "show", "--id", SID])
+
+    assert result.exit_code == 0, result.output
+    assert "Upstream Channels (2)" in result.output
+    # Channel names + their classified types are surfaced.
+    assert "http_relay" in result.output
+    assert "byok" in result.output
+    assert "plus" in result.output
+    assert "enrollable" in result.output
+    # The enrollable channel is flagged as the enrollment channel.
+    assert "enrollment channel" in result.output
+    # Per-channel customer secrets are listed.
+    assert "HTTP_RELAY_BASE_URL" in result.output
+    assert "HTTP_RELAY_API_KEY" in result.output


### PR DESCRIPTION
## What

Surface multi-channel service info in the seller CLI (backend unitysvc#1300 / #1297). Two related gaps:

1. `services run-tests` / `show-test` only showed a single representative upstream probe, hiding the per-channel breakdown the diagnostic now produces.
2. `services show` only listed the user-facing access interfaces, so the upstream **channels** (and their names) were invisible.

## Changes

**Per-channel run-tests output**
- **SDK** (`services.py`): `RunTestsIfaceResult` gains `upstream_channels: dict[str, Any] | None` (keyed by channel name); `_parse_run_tests_payload` reads it. The singleton `upstream` stays for back-compat. The async client reuses the same parser.
- **`services run-tests`**: a failing row prints one `↳ upstream[<channel>]: <status>` line per channel with platform-vs-upstream attribution, falling back to the singleton line.
- **`services show-test`**: adds a **Per-channel upstream results** section, falling back to a single **Upstream result** block.

**Channels in `services show`**
- Adds an **Upstream Channels** section built from `offering.upstream_access_config`: each channel's name, classified type (managed/byok/byoe/enrollable — the #1305 ingest stamp), per-channel `customer_secrets_required`/`optional`, and a marker on the enrollable (enrollment-hosting) channel. No backend change or client regen — the data already rides in the `services_get` response.

Example:
```
Upstream Channels (2)
  • http_relay (byok)
      access_method: http
      customer_secrets_required: HTTP_RELAY_BASE_URL
      customer_secrets_optional: HTTP_RELAY_API_KEY
  • plus (enrollable)  (enrollment channel)
      access_method: http
```

## Tests

- `tests/test_services_run_tests_payload.py` — pins `upstream_channels` parsing.
- `tests/test_services_show_channels.py` — pins the `services show` channel rendering.
- Full suite green (216 passed); ruff + mypy clean on changed files.

## Depends on

- Backend unitysvc#1309 for the per-channel run-tests payload. The `services show` channels section works against the current backend (data already present). All additions degrade gracefully against an older backend (singleton fallback / section omitted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
