### PR TITLE
feat(secrets): add `secrets upload` to bulk-set from a file or stdin

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1048,7 +1048,7 @@ $ usvc_seller groups delete [OPTIONS] NAME_OR_ID
 
 ## `usvc_seller secrets`
 
-Remote secret operations (list, show, set, delete).
+Remote secret operations (list, show, set, upload, delete).
 
 **Usage**:
 
@@ -1065,6 +1065,7 @@ $ usvc_seller secrets [OPTIONS] COMMAND [ARGS]...
 * `list`: List the seller&#x27;s secrets (metadata only —...
 * `show`: Show metadata for a single secret by name.
 * `set`: Set a secret to ``value`` (idempotent —...
+* `upload`: Bulk-set secrets from a sourceable file or...
 * `delete`: Permanently delete a secret.
 
 ### `usvc_seller secrets list`
@@ -1132,6 +1133,42 @@ $ usvc_seller secrets set [OPTIONS] NAME
 **Options**:
 
 * `-v, --value TEXT`: Secret value. If omitted: reads from stdin when piped, prompts with hidden input when run interactively.
+* `-f, --format TEXT`: Output format: table | json.  [default: table]
+* `--api-key TEXT`: Seller API key (svcpass_...). Defaults to $UNITYSVC_SELLER_API_KEY.  [env var: UNITYSVC_SELLER_API_KEY]
+* `--base-url TEXT`: Backend base URL.  [env var: UNITYSVC_SELLER_API_URL; default: https://seller.unitysvc.com/v1]
+* `--help`: Show this message and exit.
+
+### `usvc_seller secrets upload`
+
+Bulk-set secrets from a sourceable file or stdin (idempotent).
+
+Reads the same shell-sourceable file you keep for local testing — ``export
+NAME=&quot;value&quot;`` / ``NAME=value`` lines, surrounding quotes stripped, ``#``
+comments and blank lines ignored — and sets each via
+``PUT /v1/seller/secrets/{name}``. Entries with an empty value are skipped
+(fine for OPTIONAL secrets); when a name repeats, the last assignment wins.
+
+Input is a file or a pipe — no implicit default:
+
+  - ``FILE`` argument — a path to a sourceable secrets file
+  - ``-`` or piped stdin — decrypt on the fly, e.g.::
+
+         sops -d .secrets | usvc_seller secrets upload
+         gpg -d .secrets.gpg | usvc_seller secrets upload -
+
+**Usage**:
+
+```console
+$ usvc_seller secrets upload [OPTIONS] [FILE]
+```
+
+**Arguments**:
+
+* `[FILE]`: Secrets file to read (&#x27;export NAME=value&#x27; lines), or &#x27;-&#x27; for stdin. Omit when piping input in.
+
+**Options**:
+
+* `--dry-run`: Parse and list names; upload nothing.
 * `-f, --format TEXT`: Output format: table | json.  [default: table]
 * `--api-key TEXT`: Seller API key (svcpass_...). Defaults to $UNITYSVC_SELLER_API_KEY.  [env var: UNITYSVC_SELLER_API_KEY]
 * `--base-url TEXT`: Backend base URL.  [env var: UNITYSVC_SELLER_API_URL; default: https://seller.unitysvc.com/v1]

--- a/src/unitysvc_sellers/commands/secrets.py
+++ b/src/unitysvc_sellers/commands/secrets.py
@@ -5,14 +5,17 @@ Commands:
 - ``list``   — list the seller's secrets (metadata only)
 - ``show``   — show one secret's metadata by name
 - ``set``    — set a secret (idempotent — creates or rotates)
+- ``upload`` — bulk-set secrets from a sourceable file or stdin
 - ``delete`` — permanently delete a secret
 """
 
 from __future__ import annotations
 
 import json
+import re
 import sys
 from getpass import getpass
+from pathlib import Path
 
 import typer
 from rich.console import Console
@@ -30,8 +33,11 @@ from ._helpers import (
 console = Console()
 
 app = typer.Typer(
-    help="Remote secret operations (list, show, set, delete).",
+    help="Remote secret operations (list, show, set, upload, delete).",
 )
+
+# Valid env-var / secret name: leading letter or underscore, then word chars.
+_VALID_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
 # ---------------------------------------------------------------------------
@@ -57,6 +63,85 @@ def _resolve_value(value: str | None, *, name: str) -> str:
         return sys.stdin.read().rstrip("\n")
     # Terminal: prompt with hidden input.
     return getpass(f"Value for secret '{name}': ")
+
+
+def _parse_secrets_text(text: str) -> list[tuple[str, str]]:
+    """Parse sourceable / dotenv-style text into ``(name, value)`` pairs.
+
+    Accepts the same lines you would ``source`` in a shell — ``NAME=value`` or
+    ``export NAME=value``. ``#`` comment lines and blank lines are ignored, one
+    layer of surrounding single/double quotes is stripped, and when a name is
+    assigned more than once the last assignment wins (``source`` semantics).
+
+    Values are taken verbatim after the first ``=`` (minus surrounding quotes);
+    no shell expansion or escape processing is performed, which is correct for
+    opaque secret material (tokens, URLs, ids). Lines that are not a valid
+    assignment are skipped.
+    """
+    pairs: dict[str, str] = {}
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith(("export ", "export\t")):
+            line = line[len("export") :].lstrip()
+        name, sep, value = line.partition("=")
+        if not sep:
+            continue
+        name = name.strip()
+        if not _VALID_NAME_RE.match(name):
+            continue
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+            value = value[1:-1]
+        pairs[name] = value
+    return list(pairs.items())
+
+
+def _read_secrets_source(file: str | None) -> str:
+    """Read secrets text from a file path or stdin — no implicit default.
+
+    Resolution:
+      - ``file == "-"`` or piped stdin → read stdin
+      - ``file`` is a path             → read that file
+      - nothing given (interactive)    → usage error
+    """
+    if file == "-":
+        return sys.stdin.read()
+    if file is None:
+        if sys.stdin.isatty():
+            console.print(
+                "[red]No input.[/red] Pass a file or pipe one in:\n"
+                "  usvc_seller secrets upload FILE\n"
+                "  <decrypt> | usvc_seller secrets upload"
+            )
+            raise typer.Exit(code=2)
+        return sys.stdin.read()
+    path = Path(file)
+    if not path.is_file():
+        console.print(f"[red]Secrets file not found:[/red] {file}")
+        raise typer.Exit(code=1)
+    return path.read_text()
+
+
+def _print_upload_summary(rows: list[tuple[str, str]], output_format: str, *, dry_run: bool) -> None:
+    """Render the per-secret outcome table (or JSON) plus a one-line tally."""
+    if output_format == "json":
+        console.print(json.dumps([{"name": n, "status": s} for n, s in rows], indent=2))
+        return
+    table = Table(title="Secrets (dry run)" if dry_run else "Secrets uploaded")
+    table.add_column("Name", style="bold")
+    table.add_column("Status", style="dim")
+    for name, status in rows:
+        table.add_row(name, status)
+    console.print(table)
+    n_set = sum(1 for _, s in rows if s in ("set", "would set"))
+    n_skip = sum(1 for _, s in rows if s.startswith("skip"))
+    verb = "would upload" if dry_run else "uploaded"
+    summary = f"[green]✓[/green] {verb} {n_set} secret(s)"
+    if n_skip:
+        summary += f", skipped {n_skip} empty"
+    console.print(summary)
 
 
 # ---------------------------------------------------------------------------
@@ -177,6 +262,62 @@ def set_secret(
         console.print(json.dumps(result, indent=2, default=str))
     else:
         console.print(f"[green]✓[/green] Set secret: [bold]{result.get('name', name)}[/bold]")
+
+
+# ---------------------------------------------------------------------------
+# upload (bulk set from a sourceable file or stdin)
+# ---------------------------------------------------------------------------
+@app.command("upload")
+def upload_secrets(
+    file: str | None = typer.Argument(
+        None,
+        help=("Secrets file to read ('export NAME=value' lines), or '-' for stdin. Omit when piping input in."),
+    ),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Parse and list names; upload nothing."),
+    output_format: str = typer.Option("table", "--format", "-f", help="Output format: table | json."),
+    api_key: str | None = api_key_option(),
+    base_url: str = base_url_option(),
+) -> None:
+    """Bulk-set secrets from a sourceable file or stdin (idempotent).
+
+    Reads the same shell-sourceable file you keep for local testing — ``export
+    NAME="value"`` / ``NAME=value`` lines, surrounding quotes stripped, ``#``
+    comments and blank lines ignored — and sets each via
+    ``PUT /v1/seller/secrets/{name}``. Entries with an empty value are skipped
+    (fine for OPTIONAL secrets); when a name repeats, the last assignment wins.
+
+    Input is a file or a pipe — no implicit default:
+
+      - ``FILE`` argument — a path to a sourceable secrets file
+      - ``-`` or piped stdin — decrypt on the fly, e.g.::
+
+             sops -d .secrets | usvc_seller secrets upload
+             gpg -d .secrets.gpg | usvc_seller secrets upload -
+    """
+    entries = _parse_secrets_text(_read_secrets_source(file))
+    if not entries:
+        console.print("[yellow]No secrets found in input.[/yellow]")
+        raise typer.Exit(code=0)
+
+    settable = [(n, v) for n, v in entries if v != ""]
+    skipped = [n for n, v in entries if v == ""]
+
+    if dry_run:
+        rows = [(n, "would set") for n, _ in settable] + [(n, "skip (empty)") for n in skipped]
+        _print_upload_summary(rows, output_format, dry_run=True)
+        return
+
+    async def _impl() -> list[str]:
+        done: list[str] = []
+        async with async_client(api_key, base_url) as client:
+            for name, value in settable:
+                await client.secrets.set(name, value)
+                done.append(name)
+        return done
+
+    done = run_async(_impl(), error_prefix="Failed to upload secrets")
+    rows = [(n, "set") for n in done] + [(n, "skip (empty)") for n in skipped]
+    _print_upload_summary(rows, output_format, dry_run=False)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_secrets_cli.py
+++ b/tests/test_secrets_cli.py
@@ -1,0 +1,159 @@
+"""Tests for ``usvc_seller secrets upload`` and its dotenv-style parser.
+
+The parser and dry-run path are fully offline. The actual upload loop is
+covered by monkeypatching ``async_client`` so no backend is required.
+"""
+
+from __future__ import annotations
+
+import json
+from contextlib import asynccontextmanager
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from unitysvc_sellers.commands.secrets import (
+    _parse_secrets_text,
+    _read_secrets_source,
+    app,
+)
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# parser
+# ---------------------------------------------------------------------------
+def test_parse_handles_export_quotes_comments_and_blanks() -> None:
+    text = """
+    # a comment
+    export DISCORD_WEBHOOK_BASE="https://mock.unitysvc.dev/discord/api/webhooks"
+
+    DISCORD_WEBHOOK_ID='demo'
+    export DISCORD_WEBHOOK_TOKEN=demotoken
+    """
+    assert _parse_secrets_text(text) == [
+        ("DISCORD_WEBHOOK_BASE", "https://mock.unitysvc.dev/discord/api/webhooks"),
+        ("DISCORD_WEBHOOK_ID", "demo"),
+        ("DISCORD_WEBHOOK_TOKEN", "demotoken"),
+    ]
+
+
+def test_parse_last_assignment_wins_and_keeps_position() -> None:
+    assert _parse_secrets_text("A=1\nB=2\nA=3\n") == [("A", "3"), ("B", "2")]
+
+
+def test_parse_skips_invalid_names_and_non_assignments() -> None:
+    text = "1BAD=x\nnot an assignment\nGOOD=ok\n"
+    assert _parse_secrets_text(text) == [("GOOD", "ok")]
+
+
+def test_parse_preserves_empty_values() -> None:
+    # Empty values are kept (the command decides to skip them).
+    assert _parse_secrets_text("OPT=\nREQ=v\n") == [("OPT", ""), ("REQ", "v")]
+
+
+def test_parse_does_not_strip_inner_hash() -> None:
+    # '#' only starts a comment at the beginning of a (stripped) line.
+    assert _parse_secrets_text('TOK="a#b"\n') == [("TOK", "a#b")]
+
+
+# ---------------------------------------------------------------------------
+# dry-run (offline)
+# ---------------------------------------------------------------------------
+def test_dry_run_from_file_lists_names_without_network(tmp_path: Path) -> None:
+    f = tmp_path / "secrets.txt"
+    f.write_text("export A=1\nB=2\nEMPTY=\n")
+    result = runner.invoke(app, ["upload", str(f), "--dry-run"])
+    assert result.exit_code == 0, result.output
+    assert "A" in result.output and "B" in result.output
+    assert "would set" in result.output
+    assert "would upload 2" in result.output
+    assert "skipped 1" in result.output
+
+
+def test_dry_run_json(tmp_path: Path) -> None:
+    f = tmp_path / "secrets.txt"
+    f.write_text("A=1\nEMPTY=\n")
+    result = runner.invoke(app, ["upload", str(f), "--dry-run", "-f", "json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload == [
+        {"name": "A", "status": "would set"},
+        {"name": "EMPTY", "status": "skip (empty)"},
+    ]
+
+
+def test_dry_run_reads_dash_stdin() -> None:
+    result = runner.invoke(app, ["upload", "-", "--dry-run"], input="export FOO=bar\n")
+    assert result.exit_code == 0, result.output
+    assert "FOO" in result.output and "would upload 1" in result.output
+
+
+def test_dry_run_reads_piped_stdin_by_default() -> None:
+    # No FILE arg + piped stdin (CliRunner stdin is not a tty) → read stdin.
+    result = runner.invoke(app, ["upload", "--dry-run"], input="BAZ=qux\n")
+    assert result.exit_code == 0, result.output
+    assert "BAZ" in result.output
+
+
+def test_missing_file_errors() -> None:
+    result = runner.invoke(app, ["upload", "/no/such/secrets.txt", "--dry-run"])
+    assert result.exit_code == 1
+    assert "not found" in result.output
+
+
+def test_empty_input_is_a_clean_noop() -> None:
+    result = runner.invoke(app, ["upload", "-", "--dry-run"], input="# nothing here\n")
+    assert result.exit_code == 0
+    assert "No secrets found" in result.output
+
+
+def test_no_file_and_interactive_terminal_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No FILE and an interactive terminal is a usage error — no implicit default."""
+
+    class _Tty:
+        def isatty(self) -> bool:
+            return True
+
+        def read(self) -> str:  # pragma: no cover — must never be reached
+            raise AssertionError("stdin should not be read at an interactive terminal")
+
+    monkeypatch.setattr("sys.stdin", _Tty())
+    with pytest.raises(typer.Exit) as exc:
+        _read_secrets_source(None)
+    assert exc.value.exit_code == 2
+
+
+# ---------------------------------------------------------------------------
+# real upload path (async_client monkeypatched — no backend)
+# ---------------------------------------------------------------------------
+class _Sink:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+
+    async def set(self, name: str, value: str) -> SimpleNamespace:
+        self.calls.append((name, value))
+        return SimpleNamespace(name=name)
+
+
+def test_upload_sets_each_nonempty_secret_and_skips_empty(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    sink = _Sink()
+
+    @asynccontextmanager
+    async def fake_async_client(api_key=None, base_url=None):  # type: ignore[no-untyped-def]
+        yield SimpleNamespace(secrets=sink)
+
+    monkeypatch.setattr("unitysvc_sellers.commands.secrets.async_client", fake_async_client)
+
+    f = tmp_path / "secrets.txt"
+    f.write_text("export A=1\nB=2\nEMPTY=\n")
+    result = runner.invoke(app, ["upload", str(f)])
+
+    assert result.exit_code == 0, result.output
+    assert sink.calls == [("A", "1"), ("B", "2")]  # EMPTY skipped, not sent
+    assert "uploaded 2" in result.output
+    assert "skipped 1" in result.output


### PR DESCRIPTION
## Summary

Adds `usvc_seller secrets upload [FILE]` — bulk-set seller secrets from a shell-sourceable file or stdin, instead of copying an `upload-secrets.sh` loop into every data repo.

## Why

Bulk-loading a repo's secrets recurs across notification-channel repos and byok provider repos. Shared logic belongs in the versioned, discoverable, tested CLI — not a per-repo script or a personal `~/.zshrc` helper. The `secrets` family (`list`/`show`/`set`/`delete`) and client auth already exist; `upload` just parses a file and loops the existing `set` (`PUT /v1/seller/secrets/{name}`, idempotent).

## Interface

```
usvc_seller secrets upload [FILE]
  --dry-run        # parse + list names, upload nothing
  --format json    # machine-readable per-secret outcome
  --api-key / --base-url   # inherited from the secrets family
```

Input is a file or a pipe — no implicit default: a `FILE` argument, or `-`/piped stdin (running it with no file at an interactive terminal is a usage error, not a silent fallback). Reading stdin lets you decrypt on the fly without a plaintext file on disk:

```
sops -d .secrets | usvc_seller secrets upload
gpg -d .secrets.gpg | usvc_seller secrets upload -
```

## Parsing

Accepts the same lines you would `source` in a shell — `export NAME="value"` or `NAME=value`. Surrounding single/double quotes are stripped, `#` comment lines and blanks are ignored, and when a name repeats the last assignment wins. Values are taken verbatim after the first `=` (no shell expansion), which is correct for opaque secret material. Entries with an empty value are skipped — fine for OPTIONAL secrets.

## Tests

`tests/test_secrets_cli.py` (13 cases): the parser (export prefix, quotes, comments, last-wins, invalid names, empty values, inner `#`), the offline `--dry-run` path (file + `-` stdin + piped stdin + JSON), missing-file / empty-input / interactive-no-input handling, and the real upload loop with `async_client` monkeypatched (asserts `set` is called per non-empty secret and empties are skipped — no backend needed).

`ruff check`, `mypy`, and `pytest` (225) all pass; `docs/cli-reference.md` regenerated via `scripts/generate_cli_reference.sh`.

## Follow-up

The per-repo `upload-secrets.sh` in `unitysvc-services-notify` is now superseded and will be removed in that repo, keeping only the committed `secrets.example.txt`.
