### PR TITLE
fix(services): resolve --local-ids from flat-specs `<name>.service.json` sidecars

### DIFF
--- a/src/unitysvc_sellers/utils.py
+++ b/src/unitysvc_sellers/utils.py
@@ -189,32 +189,76 @@ def write_service_id(service_dir: Path, service_id: str) -> None:
     write_service_data(service_dir, {"service_id": str(service_id)})
 
 
+def _provider_from_specs_path(path: Path) -> str | None:
+    """Provider slug for a flat ``specs/<provider>/…`` path — the directory
+    segment right after ``specs/``.
+
+    Fallback for the file-based param layout, where a ``<name>.service.json``
+    sidecar has no sibling ``provider.{json,toml}``. By convention the provider
+    directory name equals ``provider.name``.
+    """
+    parts = path.parts
+    if "specs" in parts:
+        i = parts.index("specs")
+        if i + 2 < len(parts):  # specs / <provider> / … / <file>
+            return parts[i + 1]
+    return None
+
+
+def _find_service_sidecars(data_dir: Path) -> list[Path]:
+    """Every service-id sidecar under ``data_dir`` — a recursive walk matching
+    both on-disk shapes at any depth (service names can be hierarchical, e.g.
+    ``parasail/Qwen/Qwen2.5-…`` → a deeply-nested sidecar):
+
+    - the folder layout's bare ``service.json``, and
+    - the flat param layout's ``<name>.service.json`` (beside ``<name>.json``).
+
+    Sorted for deterministic output.
+    """
+    found: list[Path] = []
+    for root, _dirs, files in os.walk(data_dir):
+        for fname in files:
+            if fname == "service.json" or fname.endswith(".service.json"):
+                found.append(Path(root) / fname)
+    return sorted(found)
+
+
 def read_local_service_ids(data_dir: Path, provider: str | None = None) -> list[str]:
     """Collect backend ``service_id``s for the local services under ``data_dir``.
 
     The shared ``-l`` / ``--local-ids`` resolution used across the ``services``
-    command family: walk every ``listing_v1`` file beneath ``data_dir`` and read
-    the backend-assigned id from the sibling ``service.json`` (the flat
-    ``specs/`` layout keeps the id as provenance beside the spec files). Folders
-    without a recorded id are skipped.
+    command family. ``specs``/``data upload`` records the backend id in a sidecar
+    beside the spec files; this reads it from every sidecar :func:`found
+    <_find_service_sidecars>` under ``data_dir`` — both the folder layout's
+    ``service.json`` and the flat param layout's ``<name>.service.json``, at any
+    depth. (The earlier ``listing_v1``-anchored walk missed flat repos: their
+    param files have stem ``<name>``, not ``listing``, and aren't ``listing_v1``
+    until materialised.)
 
-    With ``provider`` set, keep only services whose sibling ``provider_v1``
-    ``name`` contains the given substring (case-insensitive) — matching the
-    filter the bulk ``services`` commands apply in ``--local-ids`` mode.
+    Sidecars without a ``service_id`` are skipped; ids are de-duplicated. With
+    ``provider`` set, keep only services whose provider ``name`` contains the
+    substring (case-insensitive) — resolved from a sibling ``provider_v1`` or,
+    failing that, the ``specs/<provider>/`` path segment.
     """
     provider_lower = provider.lower() if provider else None
     ids: list[str] = []
-    for listing_path, _fmt, _data in find_files_by_schema(data_dir, "listing_v1"):
-        sid = read_service_id(listing_path.parent)
-        if not sid:
+    seen: set[str] = set()
+
+    for sidecar in _find_service_sidecars(data_dir):
+        try:
+            data = json.loads(sidecar.read_text())
+        except Exception:
+            continue
+        sid = str(data["service_id"]) if isinstance(data, dict) and data.get("service_id") else None
+        if not sid or sid in seen:
             continue
         if provider_lower is not None:
-            # The provider lives beside the listing in the flat layout.
-            prov = find_files_by_schema(listing_path.parent, "provider_v1")
-            prov_name = (prov[0][2].get("name") or "") if prov else ""
+            prov_name = resolve_provider_name(sidecar) or _provider_from_specs_path(sidecar) or ""
             if provider_lower not in prov_name.lower():
                 continue
+        seen.add(sid)
         ids.append(sid)
+
     return ids
 
 

--- a/tests/test_services_local_ids.py
+++ b/tests/test_services_local_ids.py
@@ -503,3 +503,74 @@ def test_read_ids_from_data_dir_delegates_to_utility(tmp_path: Path) -> None:
     """The private services-module reader stays as a thin wrapper."""
     _write_listing(tmp_path / "a" / "listing.json", {"service_id": _UUID_A})
     assert _read_ids_from_data_dir(tmp_path) == [_UUID_A]
+
+
+# ---------------------------------------------------------------------------
+# read_local_service_ids — flat param layout (`<name>.service.json` sidecars)
+# ---------------------------------------------------------------------------
+
+
+def _write_flat_param(repo: Path, provider: str, name: str, service_id: str | None) -> None:
+    """Flat param layout: a ``specs/<provider>/<name>.json`` param file plus the
+    ``<name>.service.json`` sidecar that ``specs upload`` writes — no
+    ``listing.json`` in the directory."""
+    pdir = repo / "specs" / provider
+    pdir.mkdir(parents=True, exist_ok=True)
+    (pdir / f"{name}.json").write_text(json.dumps({"template": "t", "parameters": {}}))
+    if service_id is not None:
+        (pdir / f"{name}.service.json").write_text(json.dumps({"service_id": service_id}))
+
+
+def test_read_local_service_ids_collects_flat_sidecars(tmp_path: Path) -> None:
+    _write_flat_param(tmp_path, "labs", "discord-relay", _UUID_A)
+    _write_flat_param(tmp_path, "labs", "msg-to-discord", _UUID_B)
+    _write_flat_param(tmp_path, "labs", "not-uploaded", None)  # no sidecar → skipped
+    assert sorted(read_local_service_ids(tmp_path)) == sorted([_UUID_A, _UUID_B])
+
+
+def test_read_local_service_ids_flat_provider_from_path(tmp_path: Path) -> None:
+    # No sibling provider.json in the param layout — provider comes from the
+    # ``specs/<provider>/`` path segment.
+    _write_flat_param(tmp_path, "labs", "discord-relay", _UUID_A)
+    _write_flat_param(tmp_path, "acme", "thing", _UUID_B)
+    assert read_local_service_ids(tmp_path, provider="labs") == [_UUID_A]
+    assert read_local_service_ids(tmp_path, provider="acme") == [_UUID_B]
+
+
+def test_read_local_service_ids_mixed_layouts(tmp_path: Path) -> None:
+    # A folder-layout service and a flat-param service coexist; both surface once.
+    _write_listing(tmp_path / "old" / "services" / "svc" / "listing.json", {"service_id": _UUID_A})
+    _write_flat_param(tmp_path, "labs", "discord-relay", _UUID_B)
+    assert sorted(read_local_service_ids(tmp_path)) == sorted([_UUID_A, _UUID_B])
+
+
+def test_read_local_service_ids_deeply_nested_hierarchical_name(tmp_path: Path) -> None:
+    # Hierarchical service name (parasail/Qwen/Qwen2.5-…) → a deeply-nested
+    # `<name>.service.json` sidecar. The recursive walk finds it at any depth.
+    sidecar = tmp_path / "specs" / "parasail" / "Qwen" / "Qwen2.5-Coder-7B-Instruct.service.json"
+    sidecar.parent.mkdir(parents=True, exist_ok=True)
+    sidecar.write_text(json.dumps({"service_id": _UUID_A}))
+    assert read_local_service_ids(tmp_path) == [_UUID_A]
+    # Provider is the segment right after `specs/`, not a nested name segment.
+    assert read_local_service_ids(tmp_path, provider="parasail") == [_UUID_A]
+    assert read_local_service_ids(tmp_path, provider="qwen") == []
+
+
+def test_read_local_service_ids_bare_service_json_at_depth(tmp_path: Path) -> None:
+    # A bare `service.json` with no sibling listing.json is still found by the
+    # walk — the earlier listing_v1-anchored discovery missed exactly this.
+    sidecar = tmp_path / "specs" / "acme" / "deep" / "svc" / "service.json"
+    sidecar.parent.mkdir(parents=True, exist_ok=True)
+    sidecar.write_text(json.dumps({"service_id": _UUID_B}))
+    assert read_local_service_ids(tmp_path) == [_UUID_B]
+
+
+def test_read_local_service_ids_mixed_sidecar_shapes_one_repo(tmp_path: Path) -> None:
+    # Real repos (e.g. anthropic) carry both shapes side by side under one
+    # provider dir: a bare `service.json` plus per-model `<name>.service.json`.
+    pdir = tmp_path / "specs" / "anthropic"
+    pdir.mkdir(parents=True)
+    (pdir / "service.json").write_text(json.dumps({"service_id": _UUID_A}))
+    (pdir / "claude-opus.service.json").write_text(json.dumps({"service_id": _UUID_B}))
+    assert sorted(read_local_service_ids(tmp_path)) == sorted([_UUID_A, _UUID_B])
+    assert sorted(read_local_service_ids(tmp_path, provider="anthropic")) == sorted([_UUID_A, _UUID_B])


### PR DESCRIPTION
## Summary

`services run-tests/list/submit --local-ids` returned **"No service IDs found"** for flat param-layout repos — right after a successful `specs upload` that wrote the ids. This reworks the `--local-ids` resolver to find every service-id sidecar, in both on-disk shapes, at any depth.

## Reproduce

In a flat param-layout repo (e.g. `unitysvc-services-notify`, `specs/labs/discord-relay.json`):

```
$ usvc_seller specs upload
  ✓ ingested service: labs/discord-relay (service_id=7369ec80-…)   # writes specs/labs/discord-relay.service.json
$ usvc_seller services run-tests -l
No service IDs found in service.json files under the given directory.
```

## Root cause

`read_local_service_ids` walked `listing_v1` files and read the id from a sibling **`service.json`**. That misses two real cases:

- **Flat param layout** — the param file's stem is `<name>` (not `listing`), so it isn't `listing_v1` until materialised, and `specs upload` writes the id to **`<name>.service.json`**, not `service.json`. Nothing matched → no ids.
- **Sidecars at depth** — service names can be hierarchical (`parasail/Qwen/Qwen2.5-…`), so the sidecar can be deeply nested.

Real repos carry **both** sidecar shapes side by side — e.g. `unitysvc-services-anthropic` has a bare `service.json` *and* a per-model `claude-*.service.json`.

## Fix

Replace the `listing_v1`-anchored discovery with a single recursive `os.walk` (`_find_service_sidecars`) that collects every sidecar in **both shapes** — the folder layout's bare `service.json` and the flat layout's `<name>.service.json` — at any depth, then reads `service_id` from each (skipping ones without; de-duping). For the provider filter, the flat layout has no sibling `provider.json`, so it falls back to the `specs/<provider>/` path segment (by convention the provider directory name equals `provider.name`).

## Tests

`tests/test_services_local_ids.py` — flat sidecars, deeply-nested hierarchical name (provider from the `specs/<provider>/` segment, not a nested name segment), bare `service.json` at depth with no sibling listing, and a real-repo mixed-shapes layout (`service.json` + `<name>.service.json` under one provider). Full suite **235 pass**; `ruff`/`mypy` clean; `docs/cli-reference.md` unchanged.

Verified live: `read_local_service_ids` returns **2** ids for `unitysvc-services-notify` (flat) and **9** for `unitysvc-services-anthropic` (mixed shapes + hierarchical names).
