### PR TITLE
feat(run-tests): scope per-channel tests by document meta.channels

### DIFF
--- a/docs/code-examples.md
+++ b/docs/code-examples.md
@@ -284,6 +284,11 @@ Code examples are referenced in your `listing.json` or `listing.toml` file under
     -   Examples: `"✓ Test passed"`, `"\"choices\""`, `"Status: 200"`
     -   If specified, test passes only if stdout contains this string
     -   Without this field, tests only check exit code (0 = pass, non-zero = fail)
+-   **`meta.channels`**: _(User-maintained, multi-channel services only)_ Restrict this document to specific upstream access channels
+    -   A list of upstream channel names from the offering's `upstream_access_config` (e.g., `["apprise"]`)
+    -   When set, `run-tests` only runs this document against the listed channels; channels not in the list are skipped
+    -   **Omit it (the default)** for single-channel services, or whenever every channel behaves the same — the document then applies to all channels with no annotation
+    -   Use it only when channels deliver differently (e.g., one channel posts an Apprise body, another a channel-native body) and each needs its own code example / connectivity test
 
 **System-Maintained Fields (in `meta` object):**
 

--- a/src/unitysvc_sellers/example.py
+++ b/src/unitysvc_sellers/example.py
@@ -146,6 +146,7 @@ def extract_code_examples_from_listing(listing_data: dict[str, Any], listing_fil
                     "output_contains": meta.get("output_contains"),  # Substring to check in output (from meta)
                     "requirements": meta.get("requirements"),  # Required packages (from meta)
                     "category": category,  # Track which category this is
+                    "channels": meta.get("channels"),  # Upstream channels this doc applies to (None/[] = all)
                 }
                 code_examples.append(code_example)
 
@@ -195,6 +196,18 @@ def extract_upstream_channels_from_offering(
         return offering_data.get("upstream_access_config", {}) or {}
     except Exception:
         return {}
+
+
+def document_applies_to_channel(allowed_channels: list[str] | None, channel_name: str | None) -> bool:
+    """Whether a document applies to a given upstream channel.
+
+    A document's ``meta.channels`` (when non-empty) restricts it to the listed
+    upstream channels; absent or empty means it applies to every channel. This
+    lets a multi-channel service give a channel that delivers differently its
+    own code example / connectivity test, while equivalent channels share one
+    document with no annotation (unitysvc#1321).
+    """
+    return not allowed_channels or channel_name in allowed_channels
 
 
 def discover_code_examples(
@@ -267,7 +280,13 @@ def discover_code_examples(
         # Extract code examples × upstream interfaces
         for example in extract_code_examples_from_listing(listing_data, listing_file):
             if upstream_channels:
+                allowed_channels = example.get("channels")
                 for iface_name, iface_data in upstream_channels.items():
+                    # Per-channel docs: skip a channel the document does not
+                    # apply to, so a multi-channel service only runs each test
+                    # against its relevant channels (unitysvc#1321).
+                    if not document_applies_to_channel(allowed_channels, iface_name):
+                        continue
                     ex = {
                         **example,
                         "upstream_channel_name": iface_name,

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -5,11 +5,15 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from unitysvc_core.models.base import DocumentCategoryEnum
+
 from unitysvc_sellers.example import (
     build_upstream_template_context,
     discover_code_examples,
+    document_applies_to_channel,
     execute_code_example,
     expand_template_strings,
+    extract_code_examples_from_listing,
 )
 
 EXAMPLE_DATA = Path(__file__).parent / "example_data"
@@ -202,3 +206,38 @@ def test_discover_code_examples_exposes_channel_name() -> None:
         assert "upstream_channel_name" in example
         assert "upstream_channel" in example
         assert "upstream_interface_name" not in example
+
+
+def test_document_applies_to_channel() -> None:
+    """Absent/empty ``meta.channels`` applies to every channel; a non-empty
+    list restricts the document to exactly those channels (unitysvc#1321)."""
+    assert document_applies_to_channel(None, "apprise") is True
+    assert document_applies_to_channel([], "apprise") is True
+    assert document_applies_to_channel(["apprise"], "apprise") is True
+    assert document_applies_to_channel(["apprise", "native"], "native") is True
+    assert document_applies_to_channel(["apprise"], "native") is False
+
+
+def test_extract_code_examples_captures_meta_channels() -> None:
+    """``meta.channels`` is carried onto the discovered example so the
+    document × channel cross-product can filter per channel (unitysvc#1321)."""
+    listing_data = {
+        "name": "demo/svc",
+        "documents": {
+            "Scoped": {
+                "category": DocumentCategoryEnum.connectivity_test,
+                "file_path": "scoped.sh.j2",
+                "mime_type": "shell",
+                "meta": {"channels": ["apprise"]},
+            },
+            "Shared": {
+                "category": DocumentCategoryEnum.connectivity_test,
+                "file_path": "shared.sh.j2",
+                "mime_type": "shell",
+                "meta": {},
+            },
+        },
+    }
+    by_title = {e["title"]: e for e in extract_code_examples_from_listing(listing_data, Path("/tmp/listing.json"))}
+    assert by_title["Scoped"]["channels"] == ["apprise"]
+    assert by_title["Shared"]["channels"] is None


### PR DESCRIPTION
## What

`run-tests` now scopes a code-example / connectivity-test document to specific upstream access channels via **`meta.channels`**. When the field is a non-empty list, the document is only run against the channels it names; **absent or empty means all channels** (the default — no annotation needed).

## Why

Per [unitysvc#1321](https://github.com/unitysvc/unitysvc/issues/1321), a multi-channel service can have channels that deliver to upstream differently (e.g. one channel posts an Apprise body to the apprise-api, another posts a channel-native body to the channel's own server). Such channels need their own connectivity test / code example, but until now the `discover_code_examples` cross-product ran **every** document against **every** channel. `meta.channels` lets a divergent channel get its own document while the common all-equivalent case stays annotation-free.

## How

- `extract_code_examples_from_listing` carries `meta.channels` onto each discovered example.
- `discover_code_examples` skips a `(document, channel)` pair the document doesn't apply to, via a small pure `document_applies_to_channel(allowed, channel_name)` helper (`not allowed or channel_name in allowed`).
- `docs/code-examples.md` documents the field under the optional `meta` fields.

## Tests

- `test_document_applies_to_channel` — absent/empty = all; a list restricts.
- `test_extract_code_examples_captures_meta_channels` — the field flows onto the example.

`ruff check`, `ruff format --check`, `mypy`, and `pytest tests/test_example.py` all pass (13 tests).

## Companion

The backend's server-side run (the `service_health_tasks` upstream probe) gets the same filter in a parallel unitysvc PR, so local and server-side per-channel runs agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
