### PR TITLE
feat(specs): add `specs expand` to render a param file into an informal `expanded/` tree

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -49,6 +49,7 @@ $ usvc_seller specs [OPTIONS] COMMAND [ARGS]...
 **Commands**:
 
 * `show`: Show expanded data for a service.
+* `expand`: Expand a param file into the informal...
 * `validate`: Validate a repository in the flat...
 * `format`: Format data files (JSON, TOML, MD) to...
 * `populate`: Populate services by executing the repo&#x27;s...
@@ -89,6 +90,35 @@ $ usvc_seller specs show [OPTIONS] SERVICE_NAME
 * `--listing`: Show only listing data.
 * `-d, --data-dir PATH`: Directory containing data files (default: current directory).
 * `-f, --format TEXT`: Output format: json (syntax-highlighted) or text (plain).  [default: json]
+* `--help`: Show this message and exit.
+
+### `usvc_seller specs expand`
+
+Expand a param file into the informal ``expanded/`` tree for inspection.
+
+Renders ``specs/&lt;NAME&gt;.json`` to ``expanded/&lt;NAME&gt;/`` (provider + offering +
+listing + bundled files) at the repo root. The folder is yours to read,
+diff, or delete — it is **never** validated or uploaded, and discovery
+ignores it, so it may go stale after a template change until you re-run
+``expand``. Pass ``--presets`` to also inline preset documents so the folder
+has no references outside itself, or ``--output-dir`` to expand elsewhere.
+
+**Usage**:
+
+```console
+$ usvc_seller specs expand [OPTIONS] NAME
+```
+
+**Arguments**:
+
+* `NAME`: Service name = the param file&#x27;s path under specs/ without .json (e.g. &#x27;parasail/foo&#x27;).  [required]
+
+**Options**:
+
+* `--presets`: Also resolve $doc_preset / $file_preset references and copy their files into the folder.
+* `-o, --output-dir PATH`: Directory to expand into (default: &lt;repo&gt;/expanded — the one tree discovery ignores). The full &lt;service_name&gt; path is created beneath it, so several services never collide.
+* `--flat`: Write the spec files directly into the directory, without the &lt;service_name&gt;/ subfolder (predictable paths). Holds one service at a time; best paired with --output-dir.
+* `-d, --data-dir PATH`: Repo root or specs/ directory (default: current directory).
 * `--help`: Show this message and exit.
 
 ### `usvc_seller specs validate`

--- a/src/unitysvc_sellers/params_render.py
+++ b/src/unitysvc_sellers/params_render.py
@@ -24,6 +24,7 @@ import contextlib
 import io
 import json
 import shutil
+import tempfile
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
@@ -32,6 +33,7 @@ from typing import Any
 import json5
 
 from .template_populate import _sanitize_dirname, populate_from_iterator
+from .utils import EXPANDED_DIRNAME, load_data_file
 
 
 class ParamRenderError(ValueError):
@@ -217,6 +219,134 @@ def materialized_param_specs(root: Path) -> Iterator[list[Path]]:
                 if sid:
                     _write_service_id(sidecar, str(sid))
             shutil.rmtree(folder, ignore_errors=True)
+
+
+def _localize_file_paths(obj: Any, folder: Path) -> bool:
+    """Copy any absolute ``file_path`` in *obj* into *folder* and rewrite it to the
+    local basename. Returns True if anything was localized.
+
+    Preset expansion (``$doc_preset`` / ``$file_preset``) yields records whose
+    ``file_path`` is an absolute path into the installed ``unitysvc-data``
+    package; copying the file in beside the JSON makes the rendered folder
+    self-contained for inspection.
+    """
+    changed = False
+    if isinstance(obj, dict):
+        fp = obj.get("file_path")
+        if isinstance(fp, str) and Path(fp).is_absolute() and Path(fp).is_file():
+            shutil.copyfile(fp, folder / Path(fp).name)
+            obj["file_path"] = Path(fp).name
+            changed = True
+        for value in obj.values():
+            changed = _localize_file_paths(value, folder) or changed
+    elif isinstance(obj, list):
+        for value in obj:
+            changed = _localize_file_paths(value, folder) or changed
+    return changed
+
+
+def _materialize_presets(folder: Path) -> None:
+    """Resolve ``$doc_preset`` / ``$file_preset`` references in a rendered folder.
+
+    For each spec file, expand its preset sentinels (via the preset-aware
+    :func:`load_data_file`), copy any referenced document files in beside the
+    JSON, and write the resolved form back — but only when expansion actually
+    changed the file, so preset-free specs stay byte-for-byte as rendered.
+    """
+    for kind in ("provider", "offering", "listing"):
+        path = folder / f"{kind}.json"
+        if not path.is_file():
+            continue
+        expanded, _ = load_data_file(path)
+        if not isinstance(expanded, dict):
+            continue
+        _localize_file_paths(expanded, folder)
+        if expanded != _load_json(path):
+            path.write_text(json.dumps(expanded, indent=2, ensure_ascii=False) + "\n")
+
+
+def _render_one(ctx: dict[str, Any], tdir: Path, into_root: Path, *, expand_presets: bool) -> Path:
+    """Render ``ctx`` into ``into_root/<ctx['name']>/`` and return that leaf folder:
+    populate the templates, bundle the template's extra files, and (optionally)
+    resolve presets. Shared by the nested and ``--flat`` expand paths.
+    """
+    with contextlib.redirect_stdout(io.StringIO()):
+        populate_from_iterator(iter([ctx]), templates_dir=tdir, output_dir=into_root, deprecate_missing=False)
+    leaf = into_root / ctx["name"]
+    # Bundle the template's other files (e.g. connectivity.sh.j2) so the folder
+    # is self-contained (provider.json is already copied by the populator).
+    extras = [f for f in tdir.iterdir() if f.is_file() and f.name not in (_NON_BUNDLED | {"provider.json"})]
+    for f in extras:
+        shutil.copyfile(f, leaf / f.name)
+    if expand_presets:
+        _materialize_presets(leaf)
+    return leaf
+
+
+def expand_param_file(
+    param_file: Path,
+    *,
+    expand_presets: bool = False,
+    output_dir: Path | None = None,
+    flat: bool = False,
+) -> Path:
+    """Render one param file into the informal ``expanded/`` inspection tree.
+
+    ``specs/<name>.json`` → ``expanded/<name>/`` (provider + offering + listing +
+    bundled template files), beside ``specs/`` at the repo root. Unlike the
+    ephemeral render in :func:`materialized_param_specs`, this folder is a
+    **static, user-owned artifact**: it is refreshed in place on each call and
+    then left on disk for inspection. It never carries a ``service.json`` —
+    backend identity stays with the param file's ``<name>.service.json`` sidecar
+    — and every formal command ignores the default ``expanded/`` tree (see
+    :data:`unitysvc_sellers.utils.EXPANDED_DIRNAME`), so a stale render (e.g.
+    after a template change) is harmless until the next ``expand``.
+
+    With ``expand_presets``, ``$doc_preset`` / ``$file_preset`` document
+    references are also resolved and their files copied in, so the folder has no
+    references outside itself.
+
+    ``output_dir`` overrides the default ``expanded/`` location. By default the
+    full ``<service_name>`` path is created beneath it, so expanding several
+    services into one directory never collides. With ``flat``, the spec files are
+    written **directly** into the directory (no ``<service_name>/``) for
+    predictable paths — which only holds one service at a time, so it overwrites
+    its own spec files but leaves any other files in the directory untouched.
+
+    Returns the rendered folder path (the ``<service_name>/`` leaf, or the
+    directory itself when ``flat``).
+    """
+    data = _load_json(param_file)
+    tdir = _resolve_template_dir(param_file, data.get("template"))
+    specs_root = _specs_root_for(param_file)
+    service_name = _service_name_for(param_file)
+    expanded_root = Path(output_dir) if output_dir is not None else specs_root.parent / EXPANDED_DIRNAME
+
+    ctx = {
+        "name": service_name,  # name_field → folder path under output_dir
+        "service_name": service_name,
+        "provider_name": service_name.split("/")[0],
+        **(data.get("parameters") or {}),
+    }
+
+    if flat:
+        # Render into a throwaway tree, then copy just this service's files in —
+        # so a shared output dir keeps its other contents (can't blanket-rmtree).
+        with tempfile.TemporaryDirectory() as tmp:
+            leaf = _render_one(ctx, tdir, Path(tmp), expand_presets=expand_presets)
+            expanded_root.mkdir(parents=True, exist_ok=True)
+            for f in leaf.iterdir():
+                if f.is_file():
+                    shutil.copyfile(f, expanded_root / f.name)
+        return expanded_root
+
+    folder = expanded_root / service_name
+    # Refresh in place: drop any previous render so a removed/renamed file in the
+    # template doesn't linger.
+    if folder.exists():
+        shutil.rmtree(folder)
+    _render_one(ctx, tdir, expanded_root, expand_presets=expand_presets)
+    return folder
 
 
 # Keys that ``materialized_param_specs`` injects from the param file's path, so

--- a/src/unitysvc_sellers/specs.py
+++ b/src/unitysvc_sellers/specs.py
@@ -12,7 +12,7 @@ from rich.table import Table
 from . import _cli_upload as upload_cmd
 from . import example, format_data, populate, specs_layout
 from . import list as list_cmd
-from .params_render import ParamRenderError, materialized_param_specs
+from .params_render import ParamRenderError, expand_param_file, is_param_file, materialized_param_specs
 from .utils import find_files_by_schema, load_data_file, read_service_id
 
 app = typer.Typer(help="Local operations on the flat specs/ layout (validate, format, populate, upload, test, etc.)")
@@ -33,7 +33,10 @@ def _expand_params(ctx: typer.Context) -> None:
     committed files themselves, not the expanded view.
     """
     sub = ctx.invoked_subcommand
-    if not sub or sub in {"format", "populate"}:
+    # ``format``/``populate`` operate on the committed files themselves; ``expand``
+    # writes the informal expanded/ tree from the param file directly — none of
+    # them want the ephemeral whole-repo render.
+    if not sub or sub in {"format", "populate", "expand"}:
         return
     try:
         ctx.with_resource(materialized_param_specs(Path.cwd()))
@@ -175,6 +178,78 @@ def show_service(
         _render_output(sections[selected[0]], output_format)
     else:
         _render_output({k: sections[k] for k in selected}, output_format)
+
+
+@app.command("expand")
+def expand_service(
+    name: str = typer.Argument(
+        ...,
+        help="Service name = the param file's path under specs/ without .json (e.g. 'parasail/foo').",
+    ),
+    presets: bool = typer.Option(
+        False,
+        "--presets",
+        help="Also resolve $doc_preset / $file_preset references and copy their files into the folder.",
+    ),
+    output_dir: Path | None = typer.Option(
+        None,
+        "--output-dir",
+        "-o",
+        help=(
+            "Directory to expand into (default: <repo>/expanded — the one tree discovery ignores). "
+            "The full <service_name> path is created beneath it, so several services never collide."
+        ),
+    ),
+    flat: bool = typer.Option(
+        False,
+        "--flat",
+        help=(
+            "Write the spec files directly into the directory, without the <service_name>/ subfolder "
+            "(predictable paths). Holds one service at a time; best paired with --output-dir."
+        ),
+    ),
+    data_dir: Path | None = typer.Option(
+        None,
+        "--data-dir",
+        "-d",
+        help="Repo root or specs/ directory (default: current directory).",
+    ),
+) -> None:
+    """Expand a param file into the informal ``expanded/`` tree for inspection.
+
+    Renders ``specs/<NAME>.json`` to ``expanded/<NAME>/`` (provider + offering +
+    listing + bundled files) at the repo root. The folder is yours to read,
+    diff, or delete — it is **never** validated or uploaded, and discovery
+    ignores it, so it may go stale after a template change until you re-run
+    ``expand``. Pass ``--presets`` to also inline preset documents so the folder
+    has no references outside itself, or ``--output-dir`` to expand elsewhere.
+    """
+    start = (data_dir or Path.cwd()).resolve()
+    specs_root = specs_layout.resolve_specs_root(start)
+    param_file = specs_root / f"{name}.json"
+    if not param_file.is_file():
+        console.print(f"[red]✗[/red] No param file for {name!r} at {param_file}")
+        raise typer.Exit(1)
+    if not is_param_file(param_file):
+        console.print(
+            f"[red]✗[/red] {param_file.name} is not a param file (a {{template?, parameters}} spec). "
+            f"'expand' only renders param files."
+        )
+        raise typer.Exit(1)
+    try:
+        folder = expand_param_file(param_file, expand_presets=presets, output_dir=output_dir, flat=flat)
+    except ParamRenderError as exc:
+        console.print(f"[red]✗[/red] Param render error: {exc}")
+        raise typer.Exit(1) from exc
+    console.print(f"[green]✓[/green] Expanded to {folder}")
+    if output_dir is None:
+        console.print("[dim]Inspection only — not part of the catalog; re-run 'expand' to refresh.[/dim]")
+    else:
+        # Only the default expanded/ tree is auto-excluded from discovery.
+        console.print(
+            "[dim]Inspection only. Note: a custom --output-dir is not auto-ignored by discovery — "
+            "keep it outside the catalog (or gitignored) so it isn't picked up as a service.[/dim]"
+        )
 
 
 # Register subcommands

--- a/src/unitysvc_sellers/upload.py
+++ b/src/unitysvc_sellers/upload.py
@@ -43,11 +43,10 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from unitysvc_core.utils import find_files_by_schema
-
 from .exceptions import APIError
 from .utils import (
     convert_convenience_fields_to_documents,
+    find_files_by_schema,
     read_service_data,
     service_name_matches,
     write_service_data,

--- a/src/unitysvc_sellers/utils.py
+++ b/src/unitysvc_sellers/utils.py
@@ -34,7 +34,6 @@ from unitysvc_core.utils import (  # noqa: F401
     compute_file_hash,
     deep_merge_dicts,
     find_data_files,
-    find_files_by_schema,
     generate_content_based_key,
     get_basename,
     get_file_extension,
@@ -42,6 +41,46 @@ from unitysvc_core.utils import (  # noqa: F401
     mime_type_to_extension,
     write_data_file,
 )
+from unitysvc_core.utils import (
+    find_files_by_schema as _core_find_files_by_schema,
+)
+
+# Top-level directory holding `usvc_seller specs expand` output: a static,
+# user-owned tree of rendered services for inspection only. It is deliberately
+# NOT part of the formal catalog, so every discovery walk skips it (see the
+# `find_files_by_schema` wrapper below). Lives beside `specs/` at the repo root;
+# `specs/` is where formal data lives, so a top-level `expanded/` never collides
+# with a real provider/service path.
+EXPANDED_DIRNAME = "expanded"
+
+
+def find_files_by_schema(
+    data_dir: Any,
+    schema: str,
+    path_filter: str | None = None,
+    field_filter: Any = None,
+) -> list[tuple[Path, str, dict[str, Any]]]:
+    """Seller wrapper over ``unitysvc_core.utils.find_files_by_schema``.
+
+    Identical to core discovery, except results under a top-level
+    ``expanded/`` directory (relative to ``data_dir``) are dropped — that tree
+    is the informal output of ``specs expand`` and must never be treated as a
+    formal service, even if committed. Mirrors the dot-directory skip that
+    ``specs_layout.find_service_folders`` already applies to ``validate``.
+    """
+    results = _core_find_files_by_schema(data_dir, schema, path_filter, field_filter)
+    root = Path(data_dir)
+    kept: list[tuple[Path, str, dict[str, Any]]] = []
+    for path, fmt, data in results:
+        try:
+            rel = path.relative_to(root)
+        except ValueError:
+            kept.append((path, fmt, data))
+            continue
+        if rel.parts and rel.parts[0] == EXPANDED_DIRNAME:
+            continue
+        kept.append((path, fmt, data))
+    return kept
 
 
 def service_name_matches(service_name: str | None, pattern: str) -> bool:

--- a/tests/test_specs_expand.py
+++ b/tests/test_specs_expand.py
@@ -1,0 +1,286 @@
+"""Tests for ``usvc_seller specs expand`` and the informal ``expanded/`` tree.
+
+``expand`` renders a param file (``specs/<name>.json``) into a *static*,
+user-owned inspection tree at the repo root (``expanded/<name>/``) that the
+formal pipeline must ignore — it is never validated, uploaded, or refreshed by
+anything except a re-run of ``expand`` itself.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from unitysvc_sellers.specs import app as specs_app
+from unitysvc_sellers.utils import find_files_by_schema
+
+from .test_params_render import OFFERING_J2, PROVIDER, _make_repo
+
+runner = CliRunner()
+
+# A listing whose only document is a bundled preset reference. ``expand
+# --presets`` should turn the ``$doc_preset`` sentinel into a record that points
+# at a LOCAL copy of the bundled file.
+_LISTING_PRESET_J2 = """{
+  "name": "{{ service_name }}",
+  "display_name": "P {{ status }}",
+  "currency": "USD",
+  "status": "ready",
+  "list_price": {"type": "constant", "price": "0", "description": "Free"},
+  "user_access_interfaces": {"direct_response": {"access_method": "http", "base_url": "x"}},
+  "documents": {"Connectivity": {"$doc_preset": "s3_connectivity_v1"}}
+}
+"""
+
+
+def _make_preset_repo(tmp_path: Path) -> Path:
+    """Repo whose template emits a ``$doc_preset`` document reference."""
+    tdir = tmp_path / "templates" / "p"
+    tdir.mkdir(parents=True)
+    (tdir / "provider.json").write_text(PROVIDER + "\n")
+    (tdir / "offering.json.j2").write_text(OFFERING_J2)
+    (tdir / "listing.json.j2").write_text(_LISTING_PRESET_J2)
+    specs = tmp_path / "specs" / "unitysvc"
+    specs.mkdir(parents=True)
+    (specs / "p1.json").write_text(json.dumps({"template": "p", "parameters": {"status": 200, "label": "OK"}}) + "\n")
+    return tmp_path
+
+
+def test_find_files_by_schema_excludes_top_level_expanded_tree(tmp_path: Path) -> None:
+    """Discovery must skip the informal ``expanded/`` tree but keep ``specs/``."""
+    specs_listing = tmp_path / "specs" / "unitysvc" / "foo" / "listing.json"
+    specs_listing.parent.mkdir(parents=True)
+    specs_listing.write_text(json.dumps({"name": "unitysvc/foo"}))
+
+    expanded_listing = tmp_path / "expanded" / "unitysvc" / "foo" / "listing.json"
+    expanded_listing.parent.mkdir(parents=True)
+    expanded_listing.write_text(json.dumps({"name": "unitysvc/foo"}))
+
+    found = {p for p, _, _ in find_files_by_schema(tmp_path, "listing_v1")}
+
+    assert specs_listing in found
+    assert expanded_listing not in found
+
+
+def test_expand_param_file_writes_static_inspection_tree(tmp_path: Path) -> None:
+    """``expand_param_file`` renders into ``expanded/<name>/`` and leaves both the
+    param file and the formal ``specs/`` tree untouched."""
+    from unitysvc_sellers.params_render import expand_param_file
+
+    root = _make_repo(tmp_path)  # specs/unitysvc/resp200.json (param file)
+    param_file = root / "specs" / "unitysvc" / "resp200.json"
+
+    folder = expand_param_file(param_file)
+
+    assert folder == root / "expanded" / "unitysvc" / "resp200"
+    for f in ("provider.json", "offering.json", "listing.json", "connectivity.sh.j2"):
+        assert (folder / f).is_file(), f
+    listing = json.loads((folder / "listing.json").read_text())
+    assert listing["name"] == "unitysvc/resp200"
+    # Inspection-only: no backend identity record is ever written here.
+    assert not (folder / "service.json").exists()
+    # The formal layout is untouched: param file stays, no specs/<name>/ folder.
+    assert param_file.exists()
+    assert not (root / "specs" / "unitysvc" / "resp200").exists()
+
+
+def test_expand_param_file_custom_output_dir(tmp_path: Path) -> None:
+    """``output_dir`` overrides the default ``expanded/`` location; the full
+    ``<service_name>`` path is still nested under it."""
+    from unitysvc_sellers.params_render import expand_param_file
+
+    root = _make_repo(tmp_path)
+    out = tmp_path / "scratch"
+
+    folder = expand_param_file(root / "specs" / "unitysvc" / "resp200.json", output_dir=out)
+
+    assert folder == out / "unitysvc" / "resp200"
+    assert (folder / "listing.json").is_file()
+
+
+def test_expand_multiple_services_share_dir_without_collision(tmp_path: Path) -> None:
+    """Two services expanded into one dir land in distinct ``<service_name>/``
+    subfolders — the collision-avoidance invariant."""
+    from unitysvc_sellers.params_render import expand_param_file
+
+    root = _make_repo(
+        tmp_path,
+        params={"resp200": {"status": 200, "label": "OK"}, "resp404": {"status": 404, "label": "NF"}},
+    )
+    out = tmp_path / "expanded"
+
+    f200 = expand_param_file(root / "specs" / "unitysvc" / "resp200.json", output_dir=out)
+    f404 = expand_param_file(root / "specs" / "unitysvc" / "resp404.json", output_dir=out)
+
+    assert f200 != f404
+    assert json.loads((f200 / "listing.json").read_text())["name"] == "unitysvc/resp200"
+    assert json.loads((f404 / "listing.json").read_text())["name"] == "unitysvc/resp404"
+
+
+def test_expand_flat_writes_files_directly_into_dir(tmp_path: Path) -> None:
+    """``flat`` drops the ``<service_name>/`` nesting — files land directly in the
+    output dir, with predictable paths regardless of service name."""
+    from unitysvc_sellers.params_render import expand_param_file
+
+    root = _make_repo(tmp_path)
+    out = tmp_path / "look"
+
+    folder = expand_param_file(root / "specs" / "unitysvc" / "resp200.json", output_dir=out, flat=True)
+
+    assert folder == out
+    for f in ("provider.json", "offering.json", "listing.json", "connectivity.sh.j2"):
+        assert (out / f).is_file(), f
+    assert not (out / "unitysvc").exists()
+    # Content still carries the real service name (only the *path* is flattened).
+    assert json.loads((out / "listing.json").read_text())["name"] == "unitysvc/resp200"
+
+
+def test_expand_flat_preserves_unrelated_files(tmp_path: Path) -> None:
+    """Flat must not nuke the output dir — it only writes its own spec files."""
+    from unitysvc_sellers.params_render import expand_param_file
+
+    root = _make_repo(tmp_path)
+    out = tmp_path / "look"
+    out.mkdir()
+    (out / "notes.txt").write_text("keep me")
+
+    expand_param_file(root / "specs" / "unitysvc" / "resp200.json", output_dir=out, flat=True)
+
+    assert (out / "notes.txt").read_text() == "keep me"
+    assert (out / "listing.json").is_file()
+
+
+def test_expand_command_flat_option(tmp_path: Path) -> None:
+    root = _make_repo(tmp_path)
+    out = tmp_path / "look"
+
+    result = runner.invoke(specs_app, ["expand", "unitysvc/resp200", "--flat", "-o", str(out), "-d", str(root)])
+
+    assert result.exit_code == 0, result.output
+    assert (out / "listing.json").is_file()
+    assert not (out / "unitysvc").exists()
+
+
+def test_expand_param_file_is_idempotent(tmp_path: Path) -> None:
+    """Re-running refreshes the folder in place (overwrites a stale render)."""
+    from unitysvc_sellers.params_render import expand_param_file
+
+    root = _make_repo(tmp_path)
+    param_file = root / "specs" / "unitysvc" / "resp200.json"
+
+    folder = expand_param_file(param_file)
+    (folder / "stale.txt").write_text("left over from a previous expand\n")
+
+    again = expand_param_file(param_file)
+
+    assert again == folder
+    assert (folder / "listing.json").is_file()
+    assert not (folder / "stale.txt").exists()
+
+
+def test_expand_without_presets_leaves_sentinel_untouched(tmp_path: Path) -> None:
+    """Default expand keeps ``$doc_preset`` as authored — no file is materialized."""
+    from unitysvc_sellers.params_render import expand_param_file
+
+    root = _make_preset_repo(tmp_path)
+    folder = expand_param_file(root / "specs" / "unitysvc" / "p1.json")
+
+    listing = json.loads((folder / "listing.json").read_text())
+    assert listing["documents"]["Connectivity"] == {"$doc_preset": "s3_connectivity_v1"}
+
+
+def test_expand_presets_materializes_doc_into_folder(tmp_path: Path) -> None:
+    """``--presets`` resolves the sentinel and copies the bundled doc in, with a
+    folder-local ``file_path`` so the render is self-contained."""
+    from unitysvc_sellers.params_render import expand_param_file
+
+    root = _make_preset_repo(tmp_path)
+    folder = expand_param_file(root / "specs" / "unitysvc" / "p1.json", expand_presets=True)
+
+    listing = json.loads((folder / "listing.json").read_text())
+    record = listing["documents"]["Connectivity"]
+
+    # Sentinel resolved away, file_path now points at a local sibling that exists.
+    assert "$doc_preset" not in json.dumps(record)
+    assert not Path(record["file_path"]).is_absolute()
+    assert (folder / record["file_path"]).is_file()
+
+
+def test_expand_command_renders_and_reports(tmp_path: Path) -> None:
+    root = _make_repo(tmp_path)
+
+    result = runner.invoke(specs_app, ["expand", "unitysvc/resp200", "-d", str(root)])
+
+    assert result.exit_code == 0, result.output
+    folder = root / "expanded" / "unitysvc" / "resp200"
+    assert (folder / "listing.json").is_file()
+    # The folder path is reported (rich may soft-wrap it, so compare whitespace-free).
+    assert str(folder) in "".join(result.output.split())
+
+
+def test_expand_command_presets_flag(tmp_path: Path) -> None:
+    root = _make_preset_repo(tmp_path)
+
+    result = runner.invoke(specs_app, ["expand", "unitysvc/p1", "--presets", "-d", str(root)])
+
+    assert result.exit_code == 0, result.output
+    listing = json.loads((root / "expanded" / "unitysvc" / "p1" / "listing.json").read_text())
+    assert "$doc_preset" not in json.dumps(listing["documents"]["Connectivity"])
+
+
+def test_expand_command_output_dir_option(tmp_path: Path) -> None:
+    root = _make_repo(tmp_path)
+    out = tmp_path / "look_here"
+
+    result = runner.invoke(specs_app, ["expand", "unitysvc/resp200", "-o", str(out), "-d", str(root)])
+
+    assert result.exit_code == 0, result.output
+    assert (out / "unitysvc" / "resp200" / "listing.json").is_file()
+    # Default expanded/ tree is NOT created when an output dir is given.
+    assert not (root / "expanded").exists()
+
+
+def test_expand_command_unknown_name_errors(tmp_path: Path) -> None:
+    root = _make_repo(tmp_path)
+
+    result = runner.invoke(specs_app, ["expand", "unitysvc/nope", "-d", str(root)])
+
+    assert result.exit_code != 0
+
+
+def test_expand_command_rejects_non_param_file(tmp_path: Path) -> None:
+    """Pointing expand at a real spec file (not a param file) is a clear error."""
+    root = _make_repo(tmp_path)
+    (root / "specs" / "unitysvc" / "provider.json").write_text(PROVIDER + "\n")
+
+    result = runner.invoke(specs_app, ["expand", "unitysvc/provider", "-d", str(root)])
+
+    assert result.exit_code != 0
+
+
+def test_pipeline_ignores_expanded_tree_end_to_end(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """After ``expand`` materializes ``expanded/<name>/``, a real ``list`` (which
+    walks the repo via the wrapped discovery) still reports only the formal
+    services — the inspection tree is neither counted nor cleaned up."""
+    from unitysvc_sellers.cli import app as cli_app
+
+    root = _make_repo(
+        tmp_path,
+        params={"resp200": {"status": 200, "label": "OK"}, "resp404": {"status": 404, "label": "NF"}},
+    )
+    monkeypatch.chdir(root)
+
+    expanded = CliRunner().invoke(cli_app, ["specs", "expand", "unitysvc/resp200"])
+    assert expanded.exit_code == 0, expanded.output
+    inspect_listing = root / "expanded" / "unitysvc" / "resp200" / "listing.json"
+    assert inspect_listing.is_file()
+
+    listed = CliRunner().invoke(cli_app, ["specs", "list", "services"])
+    assert listed.exit_code == 0, listed.output
+    # Exactly the two formal services — resp200 is NOT double-counted via expanded/.
+    assert "2 service(s)" in listed.output
+    # The pipeline left the inspection tree alone.
+    assert inspect_listing.is_file()


### PR DESCRIPTION
## What

Adds `usvc_seller specs expand NAME [--presets] [--flat] [-o/--output-dir DIR] [-d/--data-dir DIR]`, which renders a param file `specs/<NAME>.json` (`{template?, parameters}`) into a **static, user-owned inspection tree** at `expanded/<NAME>/` — a visible directory parallel to `specs/` at the repo root.

```
specs/parasail/foo.json  --expand-->  expanded/parasail/foo/{provider,offering,listing}.json (+ bundled files)
```

The tree is purely for eyeballing/diffing what a param file expands to. It is **never validated, uploaded, or refreshed** by anything except `expand` itself, so it may go stale after a template change until you re-run `expand` — and discovery skips it, so committing it is harmless (not disallowed).

## Why this shape

Earlier design iterations expanded into `specs/<NAME>/`, which collides with where the pipeline renders param files ephemerally, and weighed move-aside / temp-dir / in-memory tricks to avoid clobbering. Relocating the output to a separate **informal** tree dissolves the conflict entirely: the pipeline keeps rendering `specs/<NAME>/` ephemerally exactly as before — **no move-aside, no temp dir, no in-memory refactor, no pipeline surgery.**

## Options

- **`--presets`** — also resolve `$doc_preset` / `$file_preset` references and copy the referenced files in, rewriting `file_path` to a local basename, so the folder has no references outside itself.
- **`--output-dir` / `-o`** — expand somewhere other than `expanded/`. The full `<service_name>` path is created beneath it, so several services never collide. (Only the default `expanded/` is auto-ignored by discovery; the CLI warns when a custom dir is used.)
- **`--flat`** (opt-in) — write spec files *directly* into the dir, dropping the `<service_name>/` subfolder, for predictable paths regardless of service name. Holds one service at a time and preserves other files in the dir; best paired with `-o`. Default stays nested/collision-safe.

## Implementation

- `expand_param_file()` + `_render_one` / `_materialize_presets` / `_localize_file_paths` in `params_render.py`. Never writes `service.json` (backend identity stays with the param file's `<NAME>.service.json` sidecar).
- `EXPANDED_DIRNAME = "expanded"` + a seller `find_files_by_schema` wrapper in `utils.py` that drops the top-level `expanded/` tree from discovery. All seller discovery routes through it — `upload.py` switched off its direct `unitysvc_core` import. `validate` already ignores it (roots at `specs/`).
- CLI command in `specs.py`, added to the param-render callback's skip set so it doesn't trigger the ephemeral whole-repo render.
- The "both `specs/<NAME>.json` and `specs/<NAME>/` exist" sanity raise in `materialized_param_specs` is **kept** (orthogonal now; `expand` never writes `specs/<NAME>/`).

## Test plan

- New `tests/test_specs_expand.py` (16 tests): discovery exclusion; render + idempotency; no `service.json`; `specs/` untouched; `--presets` materialize/localize (and sentinel-untouched without the flag); `-o` + multi-service no-collision; `--flat` render / preserves-unrelated-files; CLI flags + unknown-name / non-param-file errors; end-to-end (`expand` then `list services` reports only formal services and leaves the tree intact).
- Full suite **229 passed**, `ruff` + `mypy` clean, CLI reference regenerated, smoke-tested with the real CLI.

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)
