### PR TITLE
chore(release): 0.2.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "unitysvc-sellers"
-version = "0.2.9"
+version = "0.2.10"
 description = "Seller-facing tools for UnitySVC: HTTP SDK + usvc_seller CLI"
 readme = "README.md"
 authors = [{ name = "Bo Peng", email = "bo.peng@unitysvc.com" }]


### PR DESCRIPTION
Bumps the package version `0.2.9` → `0.2.10` (`pyproject.toml`).

Releases the work merged since `v0.2.9`:
- feat(specs): `specs expand` — render a param file into an informal `expanded/` tree ([#112](https://github.com/unitysvc/unitysvc-sellers/pull/112))
- feat(run-tests): scope per-channel tests by document `meta.channels` (#110)
- fix(services): resolve `--local-ids` by walking for all service sidecars (#109)

On merge, creating the GitHub Release `v0.2.10` triggers `publish.yml` → build + publish to PyPI (trusted publishing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
