### PR TITLE
feat(services): submit --no-run-tests to park a service at pending for on-wire testing

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -557,6 +557,12 @@ $ usvc_seller services show [OPTIONS] [NAME]
 
 Submit services for review (draft|rejected → pending).
 
+By default the backend runs the gateway diagnostic after the transition and
+flips the service to ``review`` / ``active`` / ``rejected`` based on the
+result. Pass ``--no-run-tests`` to skip the diagnostic and hold the service
+at ``pending`` — useful when you want it routable for on-wire testing of
+code examples while still iterating.
+
 **Usage**:
 
 ```console
@@ -574,6 +580,7 @@ $ usvc_seller services submit [OPTIONS] [NAME]
 * `-l, --local-ids`: Restrict to services whose IDs are recorded in listing_v1 files under --data-dir.
 * `--data-dir DIRECTORY`: Data directory for --local-ids (default: current directory).  [default: .]
 * `--provider TEXT`: Filter by provider when --all or --local-ids is set.
+* `--run-tests / --no-run-tests`: Run the gateway diagnostic after submitting (default). Use --no-run-tests to park the service at &#x27;pending&#x27; (routable) without triggering the diagnostic — for on-wire testing of code examples. Content is still validated; a service submitted this way stays &#x27;pending&#x27; and won&#x27;t progress to &#x27;active&#x27; until a real diagnostic passes.  [default: run-tests]
 * `-y, --yes`: Skip confirmation prompt.
 * `--api-key TEXT`: Seller API key (svcpass_...). Defaults to $UNITYSVC_SELLER_API_KEY.  [env var: UNITYSVC_SELLER_API_KEY]
 * `--base-url TEXT`: Backend base URL.  [env var: UNITYSVC_SELLER_API_URL; default: https://seller.unitysvc.com/v1]

--- a/docs/seller-lifecycle.md
+++ b/docs/seller-lifecycle.md
@@ -80,6 +80,43 @@ flowchart LR
 -   Your actual provider costs are your trade secret - UnitySVC doesn't need to know
 -   **list_price** is what end users pay
 
+### Submitting for review
+
+`usvc_seller services submit` moves a service `draft|rejected → pending`. By
+default the backend then runs the **gateway diagnostic** and flips the service
+to `review` / `active` / `rejected` based on the result:
+
+```bash
+usvc_seller services submit <service_name>
+```
+
+#### Parking a service at `pending` for on-wire testing
+
+Automated test runners and on-wire testing of code examples only pick up
+services in a **routable** state (`pending` / `review` / `active`) — a `draft`
+is invisible to them. To keep a service routable while you iterate on its code
+examples *without* the submit-time diagnostic auto-rejecting it, submit with
+`--no-run-tests`:
+
+```bash
+usvc_seller services submit <service_name> --no-run-tests
+```
+
+This lands the service at `pending` and **skips the gateway diagnostic**, so it
+stays routable for your own testing instead of being driven straight to
+`active` or `rejected`.
+
+!!! note "What `--no-run-tests` does and doesn't skip"
+    - Content is **still validated** on submit — invalid data is rejected
+      regardless of this flag.
+    - It only skips the post-submit gateway diagnostic job. A service parked
+      this way **will not progress to `active`** on its own; submit again
+      normally (or run the diagnostic) when you're ready for real review.
+    - The flag is meaningful only for the `→ pending` transition;
+      `withdraw` / `deprecate` ignore it.
+
+    SDK equivalent: `client.services.get(id).submit(run_tests=False)`.
+
 ## 2. Active Service
 
 Once approved by admin, your service is **activated** but starts as **unlisted** — it is live and routable, but not yet visible in the public marketplace catalog.

--- a/src/unitysvc_sellers/commands/services.py
+++ b/src/unitysvc_sellers/commands/services.py
@@ -438,20 +438,31 @@ def _bulk_status_change(
     success_verb: str,
     confirm_prompt: str,
     yes: bool,
+    run_tests: bool | None = None,
 ) -> None:
-    """Apply status change across many services with consistent UX."""
+    """Apply status change across many services with consistent UX.
+
+    ``run_tests`` is forwarded to the backend only when not ``None``; it is
+    meaningful only for the ``draft|rejected → pending`` (submit) transition,
+    where ``run_tests=False`` parks the service at ``pending`` without
+    dispatching the gateway diagnostic. Other transitions leave it unset.
+    """
     count = len(service_ids)
     if not yes:
         if not typer.confirm(confirm_prompt):
             console.print("[yellow]Cancelled[/yellow]")
             raise typer.Exit(code=0)
 
+    body: dict[str, Any] = {"status": status}
+    if run_tests is not None:
+        body["run_tests"] = run_tests
+
     async def _impl() -> list[tuple[str, Exception | None]]:
         results: list[tuple[str, Exception | None]] = []
         async with async_client(api_key, base_url) as client:
             for sid in service_ids:
                 try:
-                    await client.services.update(sid, {"status": status})
+                    await client.services.update(sid, dict(body))
                     results.append((sid, None))
                 except Exception as exc:  # noqa: BLE001
                     results.append((sid, exc))
@@ -778,11 +789,30 @@ def submit_service(
     provider: str | None = typer.Option(
         None, "--provider", help="Filter by provider when --all or --local-ids is set."
     ),
+    run_tests: bool = typer.Option(
+        True,
+        "--run-tests/--no-run-tests",
+        help=(
+            "Run the gateway diagnostic after submitting (default). "
+            "Use --no-run-tests to park the service at 'pending' (routable) "
+            "without triggering the diagnostic — for on-wire testing of code "
+            "examples. Content is still validated; a service submitted this way "
+            "stays 'pending' and won't progress to 'active' until a real "
+            "diagnostic passes."
+        ),
+    ),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
     api_key: str | None = api_key_option(),
     base_url: str = base_url_option(),
 ) -> None:
-    """Submit services for review (draft|rejected → pending)."""
+    """Submit services for review (draft|rejected → pending).
+
+    By default the backend runs the gateway diagnostic after the transition and
+    flips the service to ``review`` / ``active`` / ``rejected`` based on the
+    result. Pass ``--no-run-tests`` to skip the diagnostic and hold the service
+    at ``pending`` — useful when you want it routable for on-wire testing of
+    code examples while still iterating.
+    """
     ids = _resolve_or_fetch_ids(
         api_key=api_key,
         base_url=base_url,
@@ -802,6 +832,7 @@ def submit_service(
         success_verb="Submitted",
         confirm_prompt=f"Submit {len(ids)} service(s) for review?",
         yes=yes,
+        run_tests=run_tests,
     )
 
 

--- a/src/unitysvc_sellers/services.py
+++ b/src/unitysvc_sellers/services.py
@@ -253,14 +253,22 @@ class Service:
         """Delete the service. See :meth:`Services.delete`."""
         return self._parent.services.delete(self._raw.id, dryrun=dryrun)
 
-    def submit(self) -> ServiceUpdateResponse:
+    def submit(self, *, run_tests: bool = True) -> ServiceUpdateResponse:
         """Submit for review — shortcut for ``update({"status": "pending"})``.
 
         The seller flow is ``draft`` → ``pending`` (this call) →
         admin sets ``review`` / ``active`` / ``rejected`` /
         ``suspended`` after their checks.
+
+        Args:
+            run_tests: When ``True`` (default) the backend runs the gateway
+                diagnostic after the transition and flips the service to
+                ``review`` / ``active`` / ``rejected`` based on the result.
+                Pass ``False`` to skip the diagnostic and hold the service at
+                ``pending`` (routable) — useful for on-wire testing of code
+                examples while iterating. Content is still validated either way.
         """
-        return self.update({"status": "pending"})
+        return self.update({"status": "pending", "run_tests": run_tests})
 
 
 class ServiceList:

--- a/tests/test_submit_run_tests.py
+++ b/tests/test_submit_run_tests.py
@@ -1,0 +1,163 @@
+"""Tests for the ``run_tests`` control on submit (issue #115).
+
+Submitting a service moves it ``draft|rejected → pending``. By default the
+backend then runs the gateway diagnostic and flips the service to
+``review`` / ``active`` / ``rejected``. ``run_tests=False`` skips the
+diagnostic and parks the service at ``pending`` (routable) — the documented
+path for on-wire testing of code examples.
+
+Covers:
+- SDK ``Service.submit(run_tests=...)`` builds the right PATCH body.
+- CLI ``services submit`` exposes ``--run-tests/--no-run-tests`` (default on).
+- CLI wiring: the flag reaches the PATCH body as ``run_tests``.
+- ``withdraw`` / ``deprecate`` never send ``run_tests`` (it's submit-only).
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import uuid
+
+import httpx
+import pytest
+import respx
+from typer.testing import CliRunner
+
+from unitysvc_sellers.cli import app as cli_app
+from unitysvc_sellers.commands import services as services_cmd
+from unitysvc_sellers.commands.services import submit_service
+from unitysvc_sellers.services import Service
+
+_BASE_URL = "https://seller.test.unitysvc"
+
+
+# ---------------------------------------------------------------------------
+# SDK: Service.submit(run_tests=...)
+# ---------------------------------------------------------------------------
+
+
+class _CapturingServices:
+    """Stub of ``client.services`` that records the last update body."""
+
+    def __init__(self) -> None:
+        self.captured: tuple[str, dict] | None = None
+
+    def update(self, service_id: str, body: dict) -> dict:
+        self.captured = (str(service_id), body)
+        return body
+
+
+class _CapturingParent:
+    def __init__(self) -> None:
+        self.services = _CapturingServices()
+
+
+class _Raw:
+    id = "11111111-1111-1111-1111-111111111111"
+
+
+def _proxy() -> tuple[Service, _CapturingParent]:
+    parent = _CapturingParent()
+    return Service(_Raw(), parent=parent), parent  # type: ignore[arg-type]
+
+
+def test_sdk_submit_default_runs_tests() -> None:
+    svc, parent = _proxy()
+    svc.submit()
+    assert parent.services.captured is not None
+    _, body = parent.services.captured
+    assert body == {"status": "pending", "run_tests": True}
+
+
+def test_sdk_submit_no_run_tests() -> None:
+    svc, parent = _proxy()
+    svc.submit(run_tests=False)
+    assert parent.services.captured is not None
+    _, body = parent.services.captured
+    assert body == {"status": "pending", "run_tests": False}
+
+
+# ---------------------------------------------------------------------------
+# CLI: surface lock
+# ---------------------------------------------------------------------------
+
+
+def test_cli_submit_exposes_run_tests_flag() -> None:
+    """``submit`` carries a ``--run-tests/--no-run-tests`` boolean defaulting
+    to tests-on (preserving the historical behaviour)."""
+    opt = inspect.signature(submit_service).parameters["run_tests"].default
+    decls = " ".join(opt.param_decls)
+    assert "--run-tests" in decls
+    assert "--no-run-tests" in decls
+    assert opt.default is True
+
+
+# ---------------------------------------------------------------------------
+# CLI: the flag reaches the PATCH body
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def _env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("UNITYSVC_SELLER_API_KEY", "svcpass_test")
+    monkeypatch.setenv("UNITYSVC_SELLER_API_URL", _BASE_URL)
+
+
+def _pin_resolution(monkeypatch: pytest.MonkeyPatch, sid: str) -> None:
+    """Bypass id resolution so the test exercises only the status-change body."""
+    monkeypatch.setattr(services_cmd, "_resolve_or_fetch_ids", lambda **_: [sid])
+
+
+def _last_patch_body(sid: str) -> dict:
+    patch_calls = [c for c in respx.calls if c.request.method == "PATCH" and str(sid) in str(c.request.url)]
+    assert patch_calls, "expected a PATCH to the service"
+    return json.loads(patch_calls[-1].request.content.decode())
+
+
+@respx.mock
+def test_cli_submit_default_sends_run_tests_true(
+    monkeypatch: pytest.MonkeyPatch, _runner: CliRunner, _env: None
+) -> None:
+    sid = str(uuid.uuid4())
+    _pin_resolution(monkeypatch, sid)
+    respx.patch(f"{_BASE_URL}/services/{sid}").mock(return_value=httpx.Response(200, json={"id": sid}))
+
+    result = _runner.invoke(cli_app, ["services", "submit", "--id", sid, "--yes"])
+
+    assert result.exit_code == 0, result.stdout
+    assert _last_patch_body(sid) == {"status": "pending", "run_tests": True}
+
+
+@respx.mock
+def test_cli_submit_no_run_tests_sends_false(
+    monkeypatch: pytest.MonkeyPatch, _runner: CliRunner, _env: None
+) -> None:
+    sid = str(uuid.uuid4())
+    _pin_resolution(monkeypatch, sid)
+    respx.patch(f"{_BASE_URL}/services/{sid}").mock(return_value=httpx.Response(200, json={"id": sid}))
+
+    result = _runner.invoke(cli_app, ["services", "submit", "--id", sid, "--no-run-tests", "--yes"])
+
+    assert result.exit_code == 0, result.stdout
+    assert _last_patch_body(sid) == {"status": "pending", "run_tests": False}
+
+
+@respx.mock
+def test_cli_withdraw_omits_run_tests(monkeypatch: pytest.MonkeyPatch, _runner: CliRunner, _env: None) -> None:
+    """``run_tests`` is submit-only; ``withdraw`` (→ draft) must not send it."""
+    sid = str(uuid.uuid4())
+    _pin_resolution(monkeypatch, sid)
+    respx.patch(f"{_BASE_URL}/services/{sid}").mock(return_value=httpx.Response(200, json={"id": sid}))
+
+    result = _runner.invoke(cli_app, ["services", "withdraw", "--id", sid, "--yes"])
+
+    assert result.exit_code == 0, result.stdout
+    body = _last_patch_body(sid)
+    assert body == {"status": "draft"}
+    assert "run_tests" not in body


### PR DESCRIPTION
Closes #115.

## Problem

`usvc_seller services submit` always drives a service through the backend gateway diagnostic, which then flips it to `review` / `active` / `rejected`. There was **no documented, supported way to park a service at `pending` (routable) without tests** — the state needed for on-wire testing of code examples (automated/scheduled runners and gateway probes only pick up `pending` / `review` / `active`, never `draft`).

The only way to reach the persistent-pending state was an **undocumented loophole**: the backend's `PATCH /seller/services/{id}` accepts `run_tests=false`, but the CLI hardcoded `{"status": "pending"}` and never exposed it, so it was reachable only via a raw SDK/HTTP call.

History check (per the issue): the `run_tests` field has **never** been a hand-written CLI flag — it entered the SDK in `ac2e160` purely as auto-generated output mirroring the backend's unified update endpoint. The backend mechanism is intentional; it was just never surfaced or documented.

## Change

Surface the existing backend capability — no backend change needed (it already supports `run_tests`):

- **CLI** — `usvc_seller services submit --run-tests/--no-run-tests` (default `--run-tests`, preserving today's behavior). `--no-run-tests` threads `run_tests=false` through `_bulk_status_change` into the PATCH body. The field is **submit-only**: `withdraw` / `deprecate` never send it.
- **SDK** — `Service.submit(run_tests: bool = True)` for parity.
- **Docs** — new "Parking a service at `pending` for on-wire testing" section in `seller-lifecycle.md`; regenerated `cli-reference.md`.

### Important semantics

`--no-run-tests` skips **only** the post-submit gateway diagnostic. Content is still validated on submit (invalid data is still rejected), and a service parked this way **stays at `pending`** — it won't progress to `active` until a real diagnostic passes.

## Verification

- `tests/test_submit_run_tests.py` (new): SDK `submit(run_tests=...)` body, CLI flag surface lock, CLI→PATCH-body wiring for both default and `--no-run-tests`, and that `withdraw` omits `run_tests`.
- `uv run --extra test pytest tests/` → **272 passed**
- `ruff check src/ tests/` → clean · `mypy src/` → clean
- `mkdocs build` → ok

## Design note

Restoring/adding the CLI flag (the option flagged in the issue) was evaluated as the primary approach and chosen: it's the smallest change, backward-compatible (default unchanged), maps 1:1 onto the backend parameter, and is discoverable + documented — versus leaving the SDK-only loophole or inventing a new transition verb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
