### PR TITLE
chore(release): bump version to 0.2.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "unitysvc-sellers"
-version = "0.2.10"
+version = "0.2.11"
 description = "Seller-facing tools for UnitySVC: HTTP SDK + usvc_seller CLI"
 readme = "README.md"
 authors = [{ name = "Bo Peng", email = "bo.peng@unitysvc.com" }]


### PR DESCRIPTION
Release 0.2.11.

Highlights (from #117):
- Split `services submit` (validate + run activation tests via the new `POST /services/{id}/submit`) from the new `services enable-testing` (pure status change → `pending`, no tests) for on-wire testing of code examples.
- SDK: `Services.submit_for_review()`, `Service.submit()`/`Service.mark_pending()`.
- Removed the undocumented `run_tests` opt-out; full client regen synced with upstream seller spec.

Pairs with backend unitysvc#1359 (the `/submit` endpoint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)