### PR TITLE
fix(services): add submit_for_review/mark_pending to the async client

### DIFF
--- a/src/unitysvc_sellers/aservices.py
+++ b/src/unitysvc_sellers/aservices.py
@@ -75,9 +75,15 @@ class AsyncService:
     async def delete(self, *, dryrun: bool = False) -> ServiceDeleteResponse:
         return await self._parent.services.delete(self._raw.id, dryrun=dryrun)
 
-    async def submit(self) -> ServiceUpdateResponse:
-        """Submit for review — shortcut for ``update({"status": "pending"})``."""
+    async def mark_pending(self) -> ServiceUpdateResponse:
+        """Mark the service ``pending`` (routable) without running tests —
+        a pure status change. See :meth:`Service.mark_pending` (sync)."""
         return await self.update({"status": "pending"})
+
+    async def submit(self) -> ServiceUpdateResponse:
+        """Submit for review — sets ``pending`` and runs the activation test
+        pipeline. See :meth:`AsyncServices.submit_for_review`."""
+        return await self._parent.services.submit_for_review(self._raw.id)
 
 
 class AsyncServiceList:
@@ -308,6 +314,23 @@ class AsyncServices:
                 service_id=str(service_id),
                 client=self._client,
                 body=ServiceUpdate.from_dict(body),
+            )
+        )
+
+    async def submit_for_review(self, service_id: str | UUID) -> ServiceUpdateResponse:
+        """Submit a service for review (``draft`` / ``rejected`` / ``suspended``
+        → ``pending``) and run the activation test pipeline.
+
+        Calls ``POST /v1/seller/services/{id}/submit``.  See
+        :meth:`unitysvc_sellers.services.Services.submit_for_review` for the
+        full semantics (dup content → 200 no-op; invalid → raises).
+        """
+        from ._generated.api.seller_services import services_submit
+
+        return unwrap(
+            await services_submit.asyncio_detailed(
+                service_id=str(service_id),
+                client=self._client,
             )
         )
 

--- a/tests/test_aclient.py
+++ b/tests/test_aclient.py
@@ -146,6 +146,25 @@ class TestAsyncClient:
 
     @pytest.mark.asyncio
     @respx.mock
+    async def test_services_submit_for_review_posts_to_submit(self) -> None:
+        """Regression: the async manager must expose ``submit_for_review`` and
+        POST to ``/submit`` — the CLI's ``services submit`` runs through the
+        async client, so a sync-only method silently breaks it (#117 follow-up)."""
+        sid = uuid.uuid4()
+        route = respx.post(f"{BASE_URL}/services/{sid}/submit").mock(
+            return_value=httpx.Response(
+                200, json=_service_update_response(id=str(sid), status="pending")
+            )
+        )
+
+        async with AsyncClient(api_key="svcpass_test", base_url=BASE_URL) as client:
+            resp = await client.services.submit_for_review(sid)
+
+        assert route.called
+        assert resp.status == "pending"
+
+    @pytest.mark.asyncio
+    @respx.mock
     async def test_promotions_list_async(self) -> None:
         respx.get(f"{BASE_URL}/promotions").mock(return_value=httpx.Response(200, json={"data": [], "has_more": False}))
 

--- a/tests/test_submit_and_mark_pending.py
+++ b/tests/test_submit_and_mark_pending.py
@@ -37,6 +37,24 @@ def _env(monkeypatch: pytest.MonkeyPatch) -> None:
 # ---------------------------------------------------------------------------
 
 
+def test_sync_async_service_method_parity() -> None:
+    """The sync and async clients must expose the same service operations.
+
+    Guards against the #117 regression where ``submit_for_review`` was added to
+    the sync ``Services`` but not ``AsyncServices`` — silently breaking the CLI
+    (which runs through the async client) at runtime.
+    """
+    from unitysvc_sellers.aservices import AsyncService, AsyncServices
+    from unitysvc_sellers.services import Service, Services
+
+    for op in ("submit_for_review", "update", "delete", "run_tests", "get", "list"):
+        assert hasattr(Services, op), f"sync Services missing {op}"
+        assert hasattr(AsyncServices, op), f"AsyncServices missing {op}"
+    for op in ("submit", "mark_pending", "update", "delete", "run_tests"):
+        assert hasattr(Service, op), f"sync Service missing {op}"
+        assert hasattr(AsyncService, op), f"AsyncService missing {op}"
+
+
 @respx.mock
 def test_sdk_submit_for_review_posts_to_submit_endpoint() -> None:
     route = respx.post(f"{_BASE_URL}/services/{_SID}/submit").mock(


### PR DESCRIPTION
Hotfix for 0.2.11.

`usvc_seller services submit` (and `enable-testing`) run through the **AsyncClient**, but #117 only added `submit_for_review` to the **sync** `Services` — so the CLI fails at runtime:

```
✗ <id>: 'AsyncServices' object has no attribute 'submit_for_review'
```

Fix:
- `AsyncServices.submit_for_review()` → `POST /services/{id}/submit`.
- `AsyncService.submit()` now delegates to it (was still a bare status PATCH); `AsyncService.mark_pending()` added for parity.
- Tests: an async test that exercises the **real** `AsyncServices.submit_for_review` against a mocked `/submit` (the old CLI tests mocked the method, so they missed this), plus a sync/async method-parity guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)