### PR TITLE
chore(release): bump version to 0.2.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "unitysvc-sellers"
-version = "0.2.11"
+version = "0.2.12"
 description = "Seller-facing tools for UnitySVC: HTTP SDK + usvc_seller CLI"
 readme = "README.md"
 authors = [{ name = "Bo Peng", email = "bo.peng@unitysvc.com" }]


### PR DESCRIPTION
Hotfix release 0.2.12 — fixes `'AsyncServices' object has no attribute 'submit_for_review'` so `usvc_seller services submit` / `enable-testing` work (broken in 0.2.11). See #119.