### PR TITLE
fix(utils): delegate to core find_files_by_pattern for filename-based discovery

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -53,7 +53,7 @@ $ usvc_seller specs [OPTIONS] COMMAND [ARGS]...
 * `validate`: Validate a repository in the flat...
 * `format`: Format data files (JSON, TOML, MD) to...
 * `populate`: Populate services by executing the repo&#x27;s...
-* `upload`: Upload a seller catalog (services +...
+* `upload`: Upload service specs to UnitySVC.
 * `list-tests`: List available code examples without...
 * `run-tests`: Run code examples locally with upstream...
 * `show-test`: Show test results for a service&#x27;s code...
@@ -207,7 +207,10 @@ $ usvc_seller specs populate [OPTIONS] [DATA_DIR]
 
 ### `usvc_seller specs upload`
 
-Upload a seller catalog (services + promotions + service groups) to UnitySVC.
+Upload service specs to UnitySVC.
+
+Use ``usvc_seller promotions upload`` and ``usvc_seller groups upload``
+for promotions and service groups.
 
 **Usage**:
 
@@ -217,13 +220,12 @@ $ usvc_seller specs upload [OPTIONS] [NAME]
 
 **Arguments**:
 
-* `[NAME]`: Service to upload, by service_name (= listing.name) — fnmatch pattern, e.g. &#x27;cohere/*&#x27; or a literal name. Omit to upload every service in the current directory (plus promotions and groups unless ``--type`` restricts the scope).
+* `[NAME]`: Service to upload, by service_name (= listing.name) — fnmatch pattern, e.g. &#x27;cohere/*&#x27; or a literal name. Omit to upload every service in the current directory.
 
 **Options**:
 
 * `--api-key TEXT`: Seller API key (svcpass_...). Defaults to $UNITYSVC_SELLER_API_KEY.  [env var: UNITYSVC_SELLER_API_KEY]
 * `--base-url TEXT`: Backend base URL.  [env var: UNITYSVC_SELLER_API_URL; default: https://seller.unitysvc.com/v1]
-* `-t, --type TEXT`: Upload only one resource: services / promotions / groups. Default: upload all three.
 * `--submit`: Also submit each freshly published service for review (validate → pending → run tests) in the same ingest task. Default: leave services as reviewable drafts to submit later.
 * `--help`: Show this message and exit.
 
@@ -919,7 +921,7 @@ $ usvc_seller services unskip-test [OPTIONS] DOCUMENT_ID
 
 ## `usvc_seller promotions`
 
-Remote promotion operations (list, show, activate, pause, delete).
+Remote promotion operations (list, show, activate, pause, delete, upload).
 
 **Usage**:
 
@@ -938,6 +940,7 @@ $ usvc_seller promotions [OPTIONS] COMMAND [ARGS]...
 * `activate`: Set a promotion&#x27;s status to ``active``.
 * `pause`: Set a promotion&#x27;s status to ``paused``.
 * `delete`: Permanently delete a promotion.
+* `upload`: Upload all promotion files from...
 
 ### `usvc_seller promotions list`
 
@@ -1038,9 +1041,25 @@ $ usvc_seller promotions delete [OPTIONS] NAME_OR_ID
 * `--base-url TEXT`: Backend base URL.  [env var: UNITYSVC_SELLER_API_URL; default: https://seller.unitysvc.com/v1]
 * `--help`: Show this message and exit.
 
+### `usvc_seller promotions upload`
+
+Upload all promotion files from ``promotions/`` directory.
+
+**Usage**:
+
+```console
+$ usvc_seller promotions upload [OPTIONS]
+```
+
+**Options**:
+
+* `--api-key TEXT`: Seller API key (svcpass_...). Defaults to $UNITYSVC_SELLER_API_KEY.  [env var: UNITYSVC_SELLER_API_KEY]
+* `--base-url TEXT`: Backend base URL.  [env var: UNITYSVC_SELLER_API_URL; default: https://seller.unitysvc.com/v1]
+* `--help`: Show this message and exit.
+
 ## `usvc_seller groups`
 
-Remote service group operations (list, show, delete).
+Remote service group operations (list, show, delete, upload).
 
 **Usage**:
 
@@ -1057,6 +1076,7 @@ $ usvc_seller groups [OPTIONS] COMMAND [ARGS]...
 * `list`: List the seller&#x27;s service groups.
 * `show`: Show details of a single service group.
 * `delete`: Permanently delete a service group.
+* `upload`: Upload all service-group files from...
 
 ### `usvc_seller groups list`
 
@@ -1114,6 +1134,22 @@ $ usvc_seller groups delete [OPTIONS] NAME_OR_ID
 **Options**:
 
 * `-f, --force`: Skip confirmation prompt.
+* `--api-key TEXT`: Seller API key (svcpass_...). Defaults to $UNITYSVC_SELLER_API_KEY.  [env var: UNITYSVC_SELLER_API_KEY]
+* `--base-url TEXT`: Backend base URL.  [env var: UNITYSVC_SELLER_API_URL; default: https://seller.unitysvc.com/v1]
+* `--help`: Show this message and exit.
+
+### `usvc_seller groups upload`
+
+Upload all service-group files from ``groups/`` directory.
+
+**Usage**:
+
+```console
+$ usvc_seller groups upload [OPTIONS]
+```
+
+**Options**:
+
 * `--api-key TEXT`: Seller API key (svcpass_...). Defaults to $UNITYSVC_SELLER_API_KEY.  [env var: UNITYSVC_SELLER_API_KEY]
 * `--base-url TEXT`: Backend base URL.  [env var: UNITYSVC_SELLER_API_URL; default: https://seller.unitysvc.com/v1]
 * `--help`: Show this message and exit.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "unitysvc-sellers"
-version = "0.2.11"
+version = "0.2.12"
 description = "Seller-facing tools for UnitySVC: HTTP SDK + usvc_seller CLI"
 readme = "README.md"
 authors = [{ name = "Bo Peng", email = "bo.peng@unitysvc.com" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-  "unitysvc-core>=0.2.3",
+  "unitysvc-core>=0.2.7",
   "unitysvc-data>=0.1.18",
   "typer",
   "rich",

--- a/src/unitysvc_sellers/_cli_upload.py
+++ b/src/unitysvc_sellers/_cli_upload.py
@@ -29,7 +29,7 @@ def upload(
         help=(
             "Service to upload, by service_name (= listing.name) — fnmatch pattern, e.g. "
             "'cohere/*' or a literal name. Omit to upload every service in the current "
-            "directory (plus promotions and groups unless ``--type`` restricts the scope)."
+            "directory."
         ),
     ),
     api_key: str | None = typer.Option(
@@ -45,12 +45,6 @@ def upload(
         envvar="UNITYSVC_SELLER_API_URL",
         help="Backend base URL.",
     ),
-    upload_type: str | None = typer.Option(
-        None,
-        "--type",
-        "-t",
-        help="Upload only one resource: services / promotions / groups. Default: upload all three.",
-    ),
     submit: bool = typer.Option(
         False,
         "--submit",
@@ -61,7 +55,11 @@ def upload(
         ),
     ),
 ) -> None:
-    """Upload a seller catalog (services + promotions + service groups) to UnitySVC."""
+    """Upload service specs to UnitySVC.
+
+    Use ``usvc_seller promotions upload`` and ``usvc_seller groups upload``
+    for promotions and service groups.
+    """
     if not api_key:
         console.print(
             "[red]✗[/red] Missing seller API key. Set $UNITYSVC_SELLER_API_KEY or pass --api-key.",
@@ -69,71 +67,31 @@ def upload(
         )
         raise typer.Exit(code=1)
 
-    # Always operate on the current working directory — cd into your data
-    # repo before running.  Keeps the CLI surface minimal; there's no
-    # ``--data-dir`` flag to remember.
     data_dir = Path.cwd()
-
-    valid_types = {"services", "promotions", "groups"}
-    if upload_type and upload_type not in valid_types:
-        console.print(
-            f"[red]✗[/red] Invalid --type '{upload_type}'. Must be one of: {', '.join(sorted(valid_types))}",
-            style="bold red",
-        )
-        raise typer.Exit(code=1)
-
-    if name and upload_type not in (None, "services"):
-        console.print(
-            "[red]✗[/red] A positional name only applies to service uploads; drop --type or use --type services."
-        )
-        raise typer.Exit(code=1)
-
-    # A positional name selects one or more services; promotions/groups
-    # are not service-scoped, so a name-restricted upload is
-    # services-only.
-    upload_services = upload_type in (None, "services")
-    upload_promotions = upload_type in (None, "promotions") and not name
-    upload_groups = upload_type in (None, "groups") and not name
 
     console.print(f"[bold blue]Uploading from:[/bold blue] {data_dir}")
     console.print(f"[bold blue]Backend:[/bold blue] {base_url}")
     console.print()
 
     def _on_progress(kind: str, status: str, name: str, detail: str = "") -> None:
-        # Services are ingested asynchronously — ``POST /services``
-        # returns ``202 Accepted`` with a task_id that the backend's
-        # Celery worker drains. ``upload_directory`` polls the
-        # ``/tasks/batch-status`` endpoint to resolve real per-service
-        # outcomes, so each service progresses through
-        # ``queued → ok`` or ``queued → error``. Promotions and
-        # service-groups go through PUT and finish synchronously.
         if status == "queued":
             console.print(
-                f"  [blue]↳[/blue] [blue]queued[/blue] {kind}: [cyan]{name}[/cyan] [dim]({detail})[/dim]"
+                f"  [blue]↳[/blue] [blue]queued[/blue] [cyan]{name}[/cyan] [dim]({detail})[/dim]"
                 if detail
-                else f"  [blue]↳[/blue] [blue]queued[/blue] {kind}: [cyan]{name}[/cyan]"
+                else f"  [blue]↳[/blue] [blue]queued[/blue] [cyan]{name}[/cyan]"
             )
         elif status == "ok":
-            verb = "ingested" if kind == "service" else "upserted"
             console.print(
-                f"  [green]✓[/green] [green]{verb}[/green] {kind}: [cyan]{name}[/cyan] [dim]({detail})[/dim]"
+                f"  [green]✓[/green] [green]ingested[/green] [cyan]{name}[/cyan] [dim]({detail})[/dim]"
                 if detail
-                else f"  [green]✓[/green] [green]{verb}[/green] {kind}: [cyan]{name}[/cyan]"
+                else f"  [green]✓[/green] [green]ingested[/green] [cyan]{name}[/cyan]"
             )
-        else:  # error / anything else
-            console.print(f"  [red]✗[/red] [red]failed[/red] {kind}: [cyan]{name}[/cyan] — {detail}")
+        else:
+            console.print(f"  [red]✗[/red] [red]failed[/red] [cyan]{name}[/cyan] — {detail}")
 
     try:
         with Client(api_key=api_key, base_url=base_url) as client:
-            result = client.upload(
-                data_dir,
-                upload_services=upload_services,
-                upload_promotions=upload_promotions,
-                upload_groups=upload_groups,
-                on_progress=_on_progress,
-                name=name,
-                auto_submit=submit,
-            )
+            result = client.upload(data_dir, on_progress=_on_progress, name=name, auto_submit=submit)
     except APIError as exc:
         console.print(f"[red]✗[/red] API error: {exc}", style="bold red")
         raise typer.Exit(code=1) from exc
@@ -141,30 +99,23 @@ def upload(
         console.print(f"[red]✗[/red] Upload failed: {exc}", style="bold red")
         raise typer.Exit(code=1) from exc
 
-    # ----- Summary table --------------------------------------------
+    # ----- Summary --------------------------------------------
     console.print()
     table = Table(title="Upload Summary", show_header=True, header_style="bold cyan", border_style="cyan")
     table.add_column("Type", style="cyan", no_wrap=True)
     table.add_column("Success", justify="right", style="green")
     table.add_column("Failed", justify="right", style="red")
-
-    for kind, counts in (
-        ("Services", result.services),
-        ("Promotions", result.promotions),
-        ("Groups", result.groups),
-    ):
-        table.add_row(
-            kind,
-            str(counts.success),
-            str(counts.failed) if counts.failed else "",
-        )
+    table.add_row(
+        "Services",
+        str(result.services.success),
+        str(result.services.failed) if result.services.failed else "",
+    )
     console.print(table)
 
     # ----- Errors ---------------------------------------------------
-    all_errors = list(result.services.errors) + list(result.promotions.errors) + list(result.groups.errors)
-    if all_errors:
+    if result.services.errors:
         console.print("\n[bold red]Errors:[/bold red]")
-        for err in all_errors:
+        for err in result.services.errors:
             console.print(f"  [red]✗[/red] {err.get('file', '?')}")
             console.print(f"    {err.get('error', '?')}")
 

--- a/src/unitysvc_sellers/client.py
+++ b/src/unitysvc_sellers/client.py
@@ -65,7 +65,7 @@ if TYPE_CHECKING:
     from .services import Services
     from .tasks import Tasks
     from .templates import Templates
-    from .upload import UploadResult
+    from .upload import UploadCounts, UploadResult
 
 DEFAULT_SELLER_API_URL = "https://seller.unitysvc.com/v1"
 ENV_SELLER_API_KEY = "UNITYSVC_SELLER_API_KEY"
@@ -240,21 +240,13 @@ class Client:
         self,
         data_dir: str | Path,
         *,
-        upload_services: bool = True,
-        upload_promotions: bool = True,
-        upload_groups: bool = True,
         on_progress: Callable[[str, str, str, str], None] | None = None,
         name: str | None = None,
         auto_submit: bool = False,
     ) -> UploadResult:
-        """Upload an entire seller catalog directory.
+        """Upload services from a seller catalog directory.
 
-        Thin wrapper around
-        :func:`upload.upload_directory`. Pass ``name`` (an fnmatch pattern) to
-        upload only the services whose ``service_name`` (= ``listing.name``)
-        match. With ``auto_submit=True`` each published draft is also submitted
-        for review in the same ingest task; otherwise (default) it's left a
-        reviewable draft. See that function for argument and return-type docs.
+        Thin wrapper around :func:`upload.upload_directory`.
         """
         from pathlib import Path as _Path
 
@@ -263,13 +255,36 @@ class Client:
         return upload_directory(
             self,
             _Path(str(data_dir)),
-            upload_services=upload_services,
-            upload_promotions=upload_promotions,
-            upload_groups=upload_groups,
             on_progress=on_progress,
             name=name,
             auto_submit=auto_submit,
         )
+
+    def upload_promotions(
+        self,
+        data_dir: str | Path,
+        *,
+        on_progress: Callable[[str, str, str, str], None] | None = None,
+    ) -> UploadCounts:
+        """Upload promotion files from ``promotions/`` directory."""
+        from pathlib import Path as _Path
+
+        from .upload import upload_promotions
+
+        return upload_promotions(self, _Path(str(data_dir)), on_progress=on_progress)
+
+    def upload_groups(
+        self,
+        data_dir: str | Path,
+        *,
+        on_progress: Callable[[str, str, str, str], None] | None = None,
+    ) -> UploadCounts:
+        """Upload service-group files from ``groups/`` directory."""
+        from pathlib import Path as _Path
+
+        from .upload import upload_groups
+
+        return upload_groups(self, _Path(str(data_dir)), on_progress=on_progress)
 
     # ------------------------------------------------------------------
     # Lifecycle

--- a/src/unitysvc_sellers/commands/groups.py
+++ b/src/unitysvc_sellers/commands/groups.py
@@ -2,21 +2,22 @@
 
 Net-new command group (no equivalent in ``unitysvc-services``). Mirrors
 the structure of ``promotions``: name lookup with partial-id fallback,
-list / show / delete / refresh. Group create/update is intentionally
-not exposed here — sellers manage group definitions as files committed
-to their catalog directory and pushed via ``usvc_seller specs upload``,
-which is the same flow promotions use.
+list / show / delete. Group definitions are committed as files under
+``groups/`` and pushed via ``usvc_seller groups upload``.
 """
 
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import Any
 
 import typer
 from rich.console import Console
 from rich.table import Table
 
+from ..client import Client
+from ..exceptions import APIError
 from ._helpers import (
     api_key_option,
     async_client,
@@ -29,7 +30,7 @@ from ._helpers import (
 console = Console()
 
 app = typer.Typer(
-    help="Remote service group operations (list, show, delete).",
+    help="Remote service group operations (list, show, delete, upload).",
 )
 
 
@@ -191,6 +192,52 @@ def delete_group(
 
     stub = run_async(_impl(), error_prefix="Failed to delete group")
     console.print(f"[green]✓[/green] Deleted: {stub.get('name', name_or_id)}")
+
+
+# ---------------------------------------------------------------------------
+# upload
+# ---------------------------------------------------------------------------
+@app.command("upload")
+def upload_groups(
+    api_key: str | None = api_key_option(),
+    base_url: str = base_url_option(),
+) -> None:
+    """Upload all service-group files from ``groups/`` directory."""
+    if not api_key:
+        console.print(
+            "[red]✗[/red] Missing seller API key. Set $UNITYSVC_SELLER_API_KEY or pass --api-key.",
+            style="bold red",
+        )
+        raise typer.Exit(code=1)
+
+    data_dir = Path.cwd()
+    console.print(f"[bold blue]Uploading groups from:[/bold blue] {data_dir / 'groups'}")
+
+    def _on_progress(kind: str, status: str, name: str, detail: str = "") -> None:
+        if status == "ok":
+            console.print(f"  [green]✓[/green] upserted: [cyan]{name}[/cyan]")
+        else:
+            console.print(f"  [red]✗[/red] failed: [cyan]{name}[/cyan] — {detail}")
+
+    try:
+        with Client(api_key=api_key, base_url=base_url) as client:
+            result = client.upload_groups(data_dir, on_progress=_on_progress)
+    except APIError as exc:
+        console.print(f"[red]✗[/red] API error: {exc}", style="bold red")
+        raise typer.Exit(code=1) from exc
+    except Exception as exc:
+        console.print(f"[red]✗[/red] Upload failed: {exc}", style="bold red")
+        raise typer.Exit(code=1) from exc
+
+    console.print()
+    console.print(f"Groups — [green]{result.success}[/green] success, [red]{result.failed}[/red] failed")
+    if result.errors:
+        for err in result.errors:
+            console.print(f"  [red]✗[/red] {err.get('file', '?')}: {err.get('error', '?')}")
+
+    if result.failed > 0:
+        raise typer.Exit(code=1)
+    console.print("\n[green]✓[/green] Groups uploaded successfully", style="bold green")
 
 
 # NOTE: ``usvc_seller groups refresh`` was removed alongside the

--- a/src/unitysvc_sellers/commands/promotions.py
+++ b/src/unitysvc_sellers/commands/promotions.py
@@ -10,6 +10,7 @@ Commands:
 - ``activate`` — set status to ``active``
 - ``pause``    — set status to ``paused``
 - ``delete``   — permanently delete a promotion
+- ``upload``   — upload promotion files from ``promotions/`` directory
 
 The legacy ``activate`` / ``pause`` HTTP routes were absorbed into
 ``PATCH /v1/seller/promotions/{id}`` with a ``status`` field as part of
@@ -20,12 +21,15 @@ ergonomic shortcuts that internally call ``promotions.update``.
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import typer
 from rich.console import Console
 from rich.table import Table
 from unitysvc_core.models.promotion_data import describe_scope
 
+from ..client import Client
+from ..exceptions import APIError
 from ._helpers import (
     api_key_option,
     async_client,
@@ -39,7 +43,7 @@ from ._helpers import (
 console = Console()
 
 app = typer.Typer(
-    help="Remote promotion operations (list, show, activate, pause, delete).",
+    help="Remote promotion operations (list, show, activate, pause, delete, upload).",
 )
 
 
@@ -222,3 +226,49 @@ def delete_promotion(
 
     promo = run_async(_impl(), error_prefix="Failed to delete promotion")
     console.print(f"[green]✓[/green] Deleted: {promo.get('name', name_or_id)}")
+
+
+# ---------------------------------------------------------------------------
+# upload
+# ---------------------------------------------------------------------------
+@app.command("upload")
+def upload_promotions(
+    api_key: str | None = api_key_option(),
+    base_url: str = base_url_option(),
+) -> None:
+    """Upload all promotion files from ``promotions/`` directory."""
+    if not api_key:
+        console.print(
+            "[red]✗[/red] Missing seller API key. Set $UNITYSVC_SELLER_API_KEY or pass --api-key.",
+            style="bold red",
+        )
+        raise typer.Exit(code=1)
+
+    data_dir = Path.cwd()
+    console.print(f"[bold blue]Uploading promotions from:[/bold blue] {data_dir / 'promotions'}")
+
+    def _on_progress(kind: str, status: str, name: str, detail: str = "") -> None:
+        if status == "ok":
+            console.print(f"  [green]✓[/green] upserted: [cyan]{name}[/cyan]")
+        else:
+            console.print(f"  [red]✗[/red] failed: [cyan]{name}[/cyan] — {detail}")
+
+    try:
+        with Client(api_key=api_key, base_url=base_url) as client:
+            result = client.upload_promotions(data_dir, on_progress=_on_progress)
+    except APIError as exc:
+        console.print(f"[red]✗[/red] API error: {exc}", style="bold red")
+        raise typer.Exit(code=1) from exc
+    except Exception as exc:
+        console.print(f"[red]✗[/red] Upload failed: {exc}", style="bold red")
+        raise typer.Exit(code=1) from exc
+
+    console.print()
+    console.print(f"Promotions — [green]{result.success}[/green] success, [red]{result.failed}[/red] failed")
+    if result.errors:
+        for err in result.errors:
+            console.print(f"  [red]✗[/red] {err.get('file', '?')}: {err.get('error', '?')}")
+
+    if result.failed > 0:
+        raise typer.Exit(code=1)
+    console.print("\n[green]✓[/green] Promotions uploaded successfully", style="bold green")

--- a/src/unitysvc_sellers/example.py
+++ b/src/unitysvc_sellers/example.py
@@ -22,7 +22,7 @@ from unitysvc_core.models.base import DocumentCategoryEnum
 from .output import format_output
 from .utils import (
     execute_script_content,
-    find_files_by_schema,
+    find_files_by_pattern,
     load_data_file,
     render_template_file,
     resolve_provider_name,
@@ -189,7 +189,7 @@ def extract_upstream_channels_from_offering(
         Dict keyed by interface name, or empty dict if not found.
     """
     try:
-        offering_results = find_files_by_schema(listing_file.parent, "offering_v1")
+        offering_results = find_files_by_pattern(listing_file.parent, "offering_v1")
         if not offering_results:
             return {}
         _file_path, _format, offering_data = offering_results[0]
@@ -233,7 +233,7 @@ def discover_code_examples(
     Returns:
         List of (code_example_dict, provider_name) tuples.
     """
-    listing_results = find_files_by_schema(data_dir, "listing_v1")
+    listing_results = find_files_by_pattern(data_dir, "listing_v1")
 
     results: list[tuple[dict[str, Any], str]] = []
 
@@ -317,31 +317,31 @@ def load_related_data(listing_file: Path) -> dict[str, Any]:
     }
 
     try:
-        # Find offering file (offering.json in same directory as listing) using find_files_by_schema
-        offering_results = find_files_by_schema(listing_file.parent, "offering_v1")
+        # Find offering file (offering.json in same directory as listing) using find_files_by_pattern
+        offering_results = find_files_by_pattern(listing_file.parent, "offering_v1")
         if offering_results:
             # Unpack tuple: (file_path, format, data)
-            # Data is already loaded by find_files_by_schema
+            # Data is already loaded by find_files_by_pattern
             _file_path, _format, offering_data = offering_results[0]
             result["offering"] = offering_data
         else:
             console.print(f"[yellow]Warning: No offering_v1 file found in {listing_file.parent}[/yellow]")
 
         # Provider lives beside the listing in the flat specs/ layout.
-        provider_results = find_files_by_schema(listing_file.parent, "provider_v1")
+        provider_results = find_files_by_pattern(listing_file.parent, "provider_v1")
         if provider_results:
             # Unpack tuple: (file_path, format, data)
-            # Data is already loaded by find_files_by_schema
+            # Data is already loaded by find_files_by_pattern
             _file_path, _format, provider_data = provider_results[0]
             result["provider"] = provider_data
         else:
             console.print(f"[yellow]Warning: No provider file found in {listing_file.parent}[/yellow]")
 
         # Find seller file (optional - seller files are not always present).
-        seller_results = find_files_by_schema(listing_file.parent, "seller_v1")
+        seller_results = find_files_by_pattern(listing_file.parent, "seller_v1")
         if seller_results:
             # Unpack tuple: (file_path, format, data)
-            # Data is already loaded by find_files_by_schema
+            # Data is already loaded by find_files_by_pattern
             _file_path, _format, seller_data = seller_results[0]
             result["seller"] = seller_data
         # No warning if seller file not found - seller data is optional

--- a/src/unitysvc_sellers/list.py
+++ b/src/unitysvc_sellers/list.py
@@ -7,7 +7,7 @@ from rich.console import Console
 from rich.table import Table
 
 from .utils import (
-    find_files_by_schema,
+    find_files_by_pattern,
     resolve_provider_name,
     resolve_service_name_for_listing,
 )
@@ -38,7 +38,7 @@ def list_providers(
     console.print(f"[blue]Searching for providers in:[/blue] {data_dir}\n")
 
     # Find provider files by schema
-    provider_files = find_files_by_schema(data_dir, "provider_v1")
+    provider_files = find_files_by_pattern(data_dir, "provider_v1")
 
     if not provider_files:
         console.print("[yellow]No provider files found.[/yellow]")
@@ -83,7 +83,7 @@ def list_sellers(
     console.print(f"[blue]Searching for sellers in:[/blue] {data_dir}\n")
 
     # Find seller files by schema
-    seller_files = find_files_by_schema(data_dir, "seller_v1")
+    seller_files = find_files_by_pattern(data_dir, "seller_v1")
 
     if not seller_files:
         console.print("[yellow]No seller files found.[/yellow]")
@@ -128,7 +128,7 @@ def list_offerings(
     console.print(f"[blue]Searching for service offerings in:[/blue] {data_dir}\n")
 
     # Find service files by schema
-    service_files = find_files_by_schema(data_dir, "offering_v1")
+    service_files = find_files_by_pattern(data_dir, "offering_v1")
 
     if not service_files:
         console.print("[yellow]No service offering files found.[/yellow]")
@@ -178,7 +178,7 @@ def list_listings(
     console.print(f"[blue]Searching for service listings in:[/blue] {data_dir}\n")
 
     # Find listing files by schema
-    listing_files = find_files_by_schema(data_dir, "listing_v1")
+    listing_files = find_files_by_pattern(data_dir, "listing_v1")
 
     if not listing_files:
         console.print("[yellow]No service listing files found.[/yellow]")

--- a/src/unitysvc_sellers/populate.py
+++ b/src/unitysvc_sellers/populate.py
@@ -10,7 +10,7 @@ import typer
 from rich.console import Console
 
 from .format_data import format_data_files
-from .utils import find_files_by_schema
+from .utils import find_files_by_pattern
 
 app = typer.Typer(help="Populate services")
 console = Console()
@@ -79,7 +79,7 @@ def _populator_sources(data_dir: Path, provider_filter: str | None) -> list[tupl
 
     # Legacy: provider files (provider.json/toml) carrying services_populator.
     sources: list[tuple[dict, Path, str]] = []
-    for provider_file, _fmt, pdata in find_files_by_schema(data_dir, "provider_v1"):
+    for provider_file, _fmt, pdata in find_files_by_pattern(data_dir, "provider_v1"):
         name = pdata.get("name", "unknown")
         if provider_filter and name != provider_filter:
             continue

--- a/src/unitysvc_sellers/specs.py
+++ b/src/unitysvc_sellers/specs.py
@@ -19,7 +19,7 @@ from .params_render import (
     is_param_file,
     materialized_param_specs,
 )
-from .utils import find_files_by_schema, load_data_file, read_service_id
+from .utils import find_files_by_pattern, load_data_file, read_service_id
 
 app = typer.Typer(help="Local operations on the flat specs/ layout (validate, format, populate, upload, test, etc.)")
 console = Console()
@@ -69,10 +69,10 @@ def _resolve_service_paths(data_dir: Path, service_name: str) -> tuple[Path | No
     listing.name → offering.name → provider at <listing_dir>/../../.
     Any slot may be ``None`` if the corresponding file is missing.
     """
-    for listing_file, _fmt, listing_data in find_files_by_schema(data_dir, "listing_v1"):
+    for listing_file, _fmt, listing_data in find_files_by_pattern(data_dir, "listing_v1"):
         offering_file: Path | None = None
         offering_name = ""
-        offering_results = find_files_by_schema(listing_file.parent, "offering_v1")
+        offering_results = find_files_by_pattern(listing_file.parent, "offering_v1")
         if offering_results:
             offering_file, _, offering_data = offering_results[0]
             offering_name = offering_data.get("name", "")
@@ -83,7 +83,7 @@ def _resolve_service_paths(data_dir: Path, service_name: str) -> tuple[Path | No
 
         # In the flat specs/ layout the provider lives beside the listing.
         provider_file: Path | None = None
-        provider_results = find_files_by_schema(listing_file.parent, "provider_v1")
+        provider_results = find_files_by_pattern(listing_file.parent, "provider_v1")
         if provider_results:
             provider_file = provider_results[0][0]
 
@@ -298,7 +298,7 @@ def _list_services_impl(data_dir: Path | None):
     console.print(f"[blue]Scanning for services in:[/blue] {data_dir}\n")
 
     # Find all listing files
-    listing_results = find_files_by_schema(data_dir, "listing_v1")
+    listing_results = find_files_by_pattern(data_dir, "listing_v1")
 
     if not listing_results:
         console.print("[yellow]No services found.[/yellow]")
@@ -313,7 +313,7 @@ def _list_services_impl(data_dir: Path | None):
         listing_status = listing_data.get("status", "")
 
         # Find corresponding offering file (same directory)
-        offering_results = find_files_by_schema(listing_file.parent, "offering_v1")
+        offering_results = find_files_by_pattern(listing_file.parent, "offering_v1")
         offering_name = ""
         offering_status = ""
         offering_data: dict[str, Any] = {}
@@ -328,7 +328,7 @@ def _list_services_impl(data_dir: Path | None):
         # Provider lives beside the listing in the flat specs/ layout.
         provider_name = ""
         provider_status = ""
-        provider_results = find_files_by_schema(listing_file.parent, "provider_v1")
+        provider_results = find_files_by_pattern(listing_file.parent, "provider_v1")
         if provider_results:
             _, _fmt, provider_data = provider_results[0]
             provider_name = provider_data.get("name", "")

--- a/src/unitysvc_sellers/upload.py
+++ b/src/unitysvc_sellers/upload.py
@@ -12,7 +12,8 @@ service, named by the (namespaced) service name::
         ├── offering.{json,toml}
         ├── listing.{json,toml}
         └── service.json              (optional: backend service_id)
-    promotion.{json,toml} / service_group.{json,toml} may live anywhere.
+    promotions/       ← all *.json/*.toml files here are promotions
+    groups/           ← all *.json/*.toml files here are service groups
 
 For each listing file the uploader pairs it with the offering and provider
 in the *same folder*, optionally expands convenience fields (``logo``,
@@ -22,7 +23,10 @@ to that folder's ``service.json`` so subsequent uploads update the same
 service in place.
 
 Promotions and service groups are uploaded via PUT (idempotent upsert
-keyed on the ``name`` field).
+keyed on the ``name`` field).  They are discovered by scanning the
+``promotions/`` and ``groups/`` top-level directories directly — every
+``*.json`` / ``*.toml`` file under those directories is assumed to be a
+promotion or service group, respectively.
 
 This module deliberately ships a minimal subset of the original
 ``unitysvc-services`` upload pipeline:
@@ -47,6 +51,7 @@ from .exceptions import APIError
 from .utils import (
     convert_convenience_fields_to_documents,
     find_files_by_pattern,
+    load_data_file,
     read_service_data,
     service_name_matches,
     write_service_data,
@@ -591,10 +596,16 @@ def upload_directory(
 
     # ----- Promotions -------------------------------------------------
     if upload_promotions:
-        promo_files = find_files_by_pattern(data_dir, "promotion_v1")
+        promo_dir = data_dir / "promotions"
+        promo_files: list[tuple[Path, dict[str, Any]]] = []
+        if promo_dir.is_dir():
+            for f in sorted(promo_dir.glob("*.json")):
+                promo_files.append((f, load_data_file(f)[0]))
+            for f in sorted(promo_dir.glob("*.toml")):
+                promo_files.append((f, load_data_file(f)[0]))
         result.promotions.total = len(promo_files)
 
-        for promo_path, _fmt, promo_data in promo_files:
+        for promo_path, promo_data in promo_files:
             try:
                 payload = promo_data
                 name = str(payload.get("name", "?"))
@@ -612,10 +623,16 @@ def upload_directory(
 
     # ----- Service groups --------------------------------------------
     if upload_groups:
-        group_files = find_files_by_pattern(data_dir, "service_group_v1")
+        group_dir = data_dir / "groups"
+        group_files: list[tuple[Path, dict[str, Any]]] = []
+        if group_dir.is_dir():
+            for f in sorted(group_dir.glob("*.json")):
+                group_files.append((f, load_data_file(f)[0]))
+            for f in sorted(group_dir.glob("*.toml")):
+                group_files.append((f, load_data_file(f)[0]))
         result.groups.total = len(group_files)
 
-        for group_path, _fmt, group_data in group_files:
+        for group_path, group_data in group_files:
             try:
                 payload = group_data
                 name = str(payload.get("name", "?"))

--- a/src/unitysvc_sellers/upload.py
+++ b/src/unitysvc_sellers/upload.py
@@ -46,7 +46,7 @@ from typing import TYPE_CHECKING, Any
 from .exceptions import APIError
 from .utils import (
     convert_convenience_fields_to_documents,
-    find_files_by_schema,
+    find_files_by_pattern,
     read_service_data,
     service_name_matches,
     write_service_data,
@@ -282,7 +282,7 @@ def _build_service_payload(
     # siblings in the one self-contained service folder.
     service_dir = listing_file.parent
 
-    offering_files = find_files_by_schema(service_dir, "offering_v1")
+    offering_files = find_files_by_pattern(service_dir, "offering_v1")
     if not offering_files:
         raise ValueError(
             f"No offering file found in {service_dir}. "
@@ -296,7 +296,7 @@ def _build_service_payload(
     if not listing_data.get("name"):
         listing_data["name"] = offering_data.get("name")
 
-    provider_files = find_files_by_schema(service_dir, "provider_v1")
+    provider_files = find_files_by_pattern(service_dir, "provider_v1")
     if not provider_files:
         raise ValueError(f"No provider file found in {service_dir}. Each service folder must contain a provider file.")
     provider_path, _, provider_data = provider_files[0]
@@ -424,7 +424,7 @@ def upload_directory(
 
     # ----- Services ---------------------------------------------------
     if upload_services:
-        all_listings = find_files_by_schema(data_dir, "listing_v1")
+        all_listings = find_files_by_pattern(data_dir, "listing_v1")
         if name is not None:
             # --name uploads every service whose service_name (= listing.name,
             # #1138) matches the fnmatch pattern: a literal name uploads one
@@ -591,7 +591,7 @@ def upload_directory(
 
     # ----- Promotions -------------------------------------------------
     if upload_promotions:
-        promo_files = find_files_by_schema(data_dir, "promotion_v1")
+        promo_files = find_files_by_pattern(data_dir, "promotion_v1")
         result.promotions.total = len(promo_files)
 
         for promo_path, _fmt, promo_data in promo_files:
@@ -612,7 +612,7 @@ def upload_directory(
 
     # ----- Service groups --------------------------------------------
     if upload_groups:
-        group_files = find_files_by_schema(data_dir, "service_group_v1")
+        group_files = find_files_by_pattern(data_dir, "service_group_v1")
         result.groups.total = len(group_files)
 
         for group_path, _fmt, group_data in group_files:

--- a/src/unitysvc_sellers/upload.py
+++ b/src/unitysvc_sellers/upload.py
@@ -73,15 +73,11 @@ class UploadCounts:
 
 @dataclass
 class UploadResult:
-    """Aggregate result of :func:`upload_directory`."""
-
     services: UploadCounts = field(default_factory=UploadCounts)
-    promotions: UploadCounts = field(default_factory=UploadCounts)
-    groups: UploadCounts = field(default_factory=UploadCounts)
 
     @property
     def total_failed(self) -> int:
-        return self.services.failed + self.promotions.failed + self.groups.failed
+        return self.services.failed
 
 
 # ---------------------------------------------------------------------------
@@ -368,16 +364,13 @@ def upload_directory(
     client: Client,
     data_dir: Path,
     *,
-    upload_services: bool = True,
-    upload_promotions: bool = True,
-    upload_groups: bool = True,
     on_progress: Any = None,
     task_wait_timeout: float = 600.0,
     task_poll_interval: float = 2.0,
     name: str | None = None,
     auto_submit: bool = False,
 ) -> UploadResult:
-    """Upload all services, promotions, and service groups under ``data_dir``.
+    """Upload service bundles under ``data_dir``.
 
     Services go through an **asynchronous** ingest pipeline: the
     backend ``POST /services`` returns ``202 Accepted`` with a Celery
@@ -391,18 +384,10 @@ def upload_directory(
     Args:
         client: A configured :class:`unitysvc_sellers.Client`.
         data_dir: Root of the seller catalog tree.
-        upload_services: Walk and upload service bundles.
-        upload_promotions: Walk and upsert promotion files.
-        upload_groups: Walk and upsert service-group files.
         on_progress: Optional callable invoked as
             ``on_progress(kind, status, name, detail)``. ``kind`` is
-            one of ``"service"``, ``"promotion"``, ``"group"``;
-            ``status`` transitions through ``"queued"``, ``"ok"``,
-            ``"error"`` as the upload progresses.
-            Services emit ``"queued"`` right after the 202 and then
-            either ``"ok"`` or ``"error"`` once the Celery task
-            finishes. Promotions and groups emit ``"ok"`` / ``"error"``
-            directly since they're synchronous PUTs.
+            ``"service"``; ``status`` transitions through ``"queued"``,
+            ``"ok"``, ``"error"`` as the upload progresses.
         task_wait_timeout: Seconds to wait for all service tasks to
             reach a terminal state before giving up and marking the
             leftover tasks as failed. Default 10 minutes.
@@ -414,7 +399,7 @@ def upload_directory(
             left as reviewable drafts to submit later.
 
     Returns:
-        :class:`UploadResult` with per-resource tallies and any errors.
+        :class:`UploadResult` with per-service tallies and any errors.
     """
     result = UploadResult()
 
@@ -423,84 +408,76 @@ def upload_directory(
     # write service.json back into the right service folder.
     pending_tasks: dict[str, tuple[Path, dict[str, Any]]] = {}
 
-    def _emit(kind: str, status: str, name: str, detail: str = "") -> None:
-        if on_progress is not None:
-            on_progress(kind, status, name, detail)
-
     # ----- Services ---------------------------------------------------
-    if upload_services:
-        all_listings = find_files_by_pattern(data_dir, "listing_v1")
-        if name is not None:
-            # --name uploads every service whose service_name (= listing.name,
-            # #1138) matches the fnmatch pattern: a literal name uploads one
-            # service, ``cohere/*`` uploads the set.
-            matched = [p for p, _, d in all_listings if service_name_matches(d.get("name"), name)]
-            if not matched:
-                raise ValueError(
-                    f"No service with service_name (listing.name) matching '{name}' found under {data_dir}."
-                )
-            listing_files = sorted(matched)
-        else:
-            listing_files = sorted(p for p, _, _ in all_listings)
-        result.services.total = len(listing_files)
+    all_listings = find_files_by_pattern(data_dir, "listing_v1")
+    if name is not None:
+        # --name uploads every service whose service_name (= listing.name,
+        # #1138) matches the fnmatch pattern: a literal name uploads one
+        # service, ``cohere/*`` uploads the set.
+        matched = [p for p, _, d in all_listings if service_name_matches(d.get("name"), name)]
+        if not matched:
+            raise ValueError(
+                f"No service with service_name (listing.name) matching '{name}' found under {data_dir}."
+            )
+        listing_files = sorted(matched)
+    else:
+        listing_files = sorted(p for p, _, _ in all_listings)
+    result.services.total = len(listing_files)
 
-        for listing_file in listing_files:
-            try:
-                provider_data, offering_data, listing_data, service_data = _build_service_payload(
-                    listing_file, client=client
-                )
-            except Exception as exc:
-                result.services.failed += 1
-                result.services.errors.append({"file": str(listing_file), "error": str(exc)})
-                _emit("service", "error", listing_file.name, str(exc))
-                continue
+    for listing_file in listing_files:
+        try:
+            provider_data, offering_data, listing_data, service_data = _build_service_payload(
+                listing_file, client=client
+            )
+        except Exception as exc:
+            result.services.failed += 1
+            result.services.errors.append({"file": str(listing_file), "error": str(exc)})
+            if on_progress is not None:
+                on_progress("service", "error", listing_file.name, str(exc))
+            continue
 
-            # Authored content and the status sidecar travel as separate body
-            # fields: ``data`` is the provider/offering/listing content,
-            # ``service_status`` is the whole service.json record (identity, not
-            # listing content) sent only when one exists.
-            payload: dict[str, Any] = {
-                "data": {
-                    "provider_data": provider_data,
-                    "offering_data": offering_data,
-                    "listing_data": listing_data,
-                }
+        payload: dict[str, Any] = {
+            "data": {
+                "provider_data": provider_data,
+                "offering_data": offering_data,
+                "listing_data": listing_data,
             }
-            if service_data:
-                payload["service_status"] = service_data
+        }
+        if service_data:
+            payload["service_status"] = service_data
 
-            try:
-                response = client.services.upload(payload, auto_submit=auto_submit)
-            except APIError as exc:
-                result.services.failed += 1
-                result.services.errors.append({"file": str(listing_file), "error": f"{exc.status_code}: {exc}"})
-                _emit("service", "error", listing_data.get("name", listing_file.name), str(exc))
-                continue
+        try:
+            resp = client.services.upload(payload, auto_submit=auto_submit)
+        except APIError as exc:
+            result.services.failed += 1
+            result.services.errors.append({"file": str(listing_file), "error": f"{exc.status_code}: {exc}"})
+            if on_progress is not None:
+                on_progress("service", "error", listing_data.get("name", listing_file.name), str(exc))
+            continue
 
-            name = listing_data.get("name", listing_file.name)
-            task_id = getattr(response, "task_id", None)
+        service_name = listing_data.get("name", listing_file.name)
+        task_id = getattr(resp, "task_id", None)
 
-            if not task_id:
-                # Defensive: if the backend somehow returned 200 with a
-                # fully-resolved service (old shape), count it as done
-                # and write service.json immediately.
-                result.services.success += 1
-                _emit("service", "ok", name)
-                service_id = getattr(response, "service_id", None) or getattr(response, "id", None)
-                if service_id:
-                    write_service_data(listing_file.parent, {"service_id": str(service_id)})
-                continue
+        if not task_id:
+            # Defensive: if the backend somehow returned 200 with a
+            # fully-resolved service (old shape), count it as done
+            # and write service.json immediately.
+            result.services.success += 1
+            if on_progress is not None:
+                on_progress("service", "ok", service_name)
+            service_id = getattr(resp, "service_id", None) or getattr(resp, "id", None)
+            if service_id:
+                write_service_data(listing_file.parent, {"service_id": str(service_id)})
+            continue
 
-            pending_tasks[str(task_id)] = (listing_file, listing_data)
-            _emit("service", "queued", name, f"task_id={task_id}")
+        pending_tasks[str(task_id)] = (listing_file, listing_data)
+        if on_progress is not None:
+            on_progress("service", "queued", service_name, f"task_id={task_id}")
 
     # ----- Drain pending service tasks --------------------------------
     if pending_tasks:
 
         def _poll_progress(done: int, total: int, last_ids: list[str]) -> None:
-            # The caller's on_progress is the per-item hook, not a
-            # "batch poll tick" hook. We use it to emit terminal
-            # outcomes below, not intermediate poll ticks.
             _ = (done, total, last_ids)
 
         try:
@@ -511,37 +488,14 @@ def upload_directory(
                 on_update=_poll_progress,
             )
         except APIError as exc:
-            # Polling itself blew up — mark every pending task as failed
-            # and surface an actionable hint for the common failure modes:
-            #
-            #   * 404 / 405 → the backend doesn't expose /tasks/
-            #     under this base URL. Most likely the seller is pointing
-            #     the SDK at a composite deployment (base_url ends in
-            #     /seller) that predates the ``Mount tasks router under
-            #     /seller`` change (unitysvc PR #702). Tell them to either
-            #     update the backend or switch to the dedicated subdomain.
-            #   * 401 / 403 → API key is invalid for tasks specifically,
-            #     which is unusual — the tasks endpoint uses the same auth
-            #     as /services. Probably a key rotation mid-upload.
-            #   * 5xx → backend instability; just report the raw error and
-            #     let the seller retry.
             diagnostic = _format_polling_error(exc)
-
             for task_id, (listing_file, listing_data) in pending_tasks.items():
                 result.services.failed += 1
                 result.services.errors.append(
-                    {
-                        "file": str(listing_file),
-                        "task_id": task_id,
-                        "error": diagnostic,
-                    }
+                    {"file": str(listing_file), "task_id": task_id, "error": diagnostic}
                 )
-                _emit(
-                    "service",
-                    "error",
-                    listing_data.get("name", listing_file.name),
-                    diagnostic,
-                )
+                if on_progress is not None:
+                    on_progress("service", "error", listing_data.get("name", listing_file.name), diagnostic)
             pending_tasks.clear()
         else:
             for task_id, (listing_file, listing_data) in pending_tasks.items():
@@ -549,32 +503,24 @@ def upload_directory(
                     "status": "unknown",
                     "message": "task status not returned",
                 }
-                name = listing_data.get("name", listing_file.name)
+                name_val = listing_data.get("name", listing_file.name)
                 status_value = status_dict.get("status")
 
                 if status_value == "completed":
                     result.services.success += 1
-                    # The ingest task result IS the service-identity record (a
-                    # ServiceData): {"service_id", "revision_of", "status",
-                    # "name", "display_name", "time_created"}. Persist the whole
-                    # record to service.json so it round-trips on the next upload.
                     task_result = status_dict.get("result") or {}
                     service_record: dict[str, Any] = task_result if isinstance(task_result, dict) else {}
                     service_id = service_record.get("service_id")
                     revision_of = service_record.get("revision_of")
                     if revision_of:
-                        # A revision of an active service was created (service_id
-                        # is the new revision; revision_of is the canonical id).
-                        # service.json already holds the canonical record — don't
-                        # overwrite it with the revision's id.
                         detail = f"revision_created, service_id={revision_of} (revision={service_id})"
-                        _emit("service", "ok", name, detail)
+                        if on_progress is not None:
+                            on_progress("service", "ok", name_val, detail)
                     else:
                         detail = f"service_id={service_id}" if service_id else f"task_id={task_id}"
-                        _emit("service", "ok", name, detail)
+                        if on_progress is not None:
+                            on_progress("service", "ok", name_val, detail)
                         if service_record:
-                            # Round-trip the backend-assigned identity record
-                            # into the folder's service.json (flat specs/ layout).
                             write_service_data(listing_file.parent, service_record)
                 else:
                     result.services.failed += 1
@@ -584,68 +530,99 @@ def upload_directory(
                         or f"task ended in state {status_value!r}"
                     )
                     result.services.errors.append(
-                        {
-                            "file": str(listing_file),
-                            "task_id": task_id,
-                            "error": str(error_msg),
-                        }
+                        {"file": str(listing_file), "task_id": task_id, "error": str(error_msg)}
                     )
-                    _emit("service", "error", name, str(error_msg))
+                    if on_progress is not None:
+                        on_progress("service", "error", name_val, str(error_msg))
 
             pending_tasks.clear()
 
-    # ----- Promotions -------------------------------------------------
-    if upload_promotions:
-        promo_dir = data_dir / "promotions"
-        promo_files: list[tuple[Path, dict[str, Any]]] = []
-        if promo_dir.is_dir():
-            for f in sorted(promo_dir.glob("*.json")):
-                promo_files.append((f, load_data_file(f)[0]))
-            for f in sorted(promo_dir.glob("*.toml")):
-                promo_files.append((f, load_data_file(f)[0]))
-        result.promotions.total = len(promo_files)
+    return result
 
-        for promo_path, promo_data in promo_files:
-            try:
-                payload = promo_data
-                name = str(payload.get("name", "?"))
-                client.promotions.upsert(payload)
-                result.promotions.success += 1
-                _emit("promotion", "ok", name)
-            except APIError as exc:
-                result.promotions.failed += 1
-                result.promotions.errors.append({"file": str(promo_path), "error": f"{exc.status_code}: {exc}"})
-                _emit("promotion", "error", promo_data.get("name", "?"), str(exc))
-            except Exception as exc:
-                result.promotions.failed += 1
-                result.promotions.errors.append({"file": str(promo_path), "error": str(exc)})
-                _emit("promotion", "error", promo_data.get("name", "?"), str(exc))
 
-    # ----- Service groups --------------------------------------------
-    if upload_groups:
-        group_dir = data_dir / "groups"
-        group_files: list[tuple[Path, dict[str, Any]]] = []
-        if group_dir.is_dir():
-            for f in sorted(group_dir.glob("*.json")):
-                group_files.append((f, load_data_file(f)[0]))
-            for f in sorted(group_dir.glob("*.toml")):
-                group_files.append((f, load_data_file(f)[0]))
-        result.groups.total = len(group_files)
+def upload_promotions(
+    client: Client,
+    data_dir: Path,
+    *,
+    on_progress: Any = None,
+) -> UploadCounts:
+    """Upload all promotion files from ``data_dir/promotions/``.
 
-        for group_path, group_data in group_files:
-            try:
-                payload = group_data
-                name = str(payload.get("name", "?"))
-                client.groups.upsert(payload)
-                result.groups.success += 1
-                _emit("group", "ok", name)
-            except APIError as exc:
-                result.groups.failed += 1
-                result.groups.errors.append({"file": str(group_path), "error": f"{exc.status_code}: {exc}"})
-                _emit("group", "error", group_data.get("name", "?"), str(exc))
-            except Exception as exc:
-                result.groups.failed += 1
-                result.groups.errors.append({"file": str(group_path), "error": str(exc)})
-                _emit("group", "error", group_data.get("name", "?"), str(exc))
+    Every ``*.json`` / ``*.toml`` under ``promotions/`` is upserted
+    via ``client.promotions.upsert`` (synchronous PUT, idempotent on
+    the ``name`` field).
+    """
+    result = UploadCounts()
+    promo_dir = data_dir / "promotions"
+    promo_files: list[tuple[Path, dict[str, Any]]] = []
+    if promo_dir.is_dir():
+        for f in sorted(promo_dir.glob("*.json")):
+            promo_files.append((f, load_data_file(f)[0]))
+        for f in sorted(promo_dir.glob("*.toml")):
+            promo_files.append((f, load_data_file(f)[0]))
+    result.total = len(promo_files)
+
+    for promo_path, promo_data in promo_files:
+        try:
+            payload = promo_data
+            name = str(payload.get("name", "?"))
+            client.promotions.upsert(payload)
+            result.success += 1
+            if on_progress is not None:
+                on_progress("promotion", "ok", name)
+        except APIError as exc:
+            result.failed += 1
+            result.errors.append({"file": str(promo_path), "error": f"{exc.status_code}: {exc}"})
+            if on_progress is not None:
+                on_progress("promotion", "error", promo_data.get("name", "?"), str(exc))
+        except Exception as exc:
+            result.failed += 1
+            result.errors.append({"file": str(promo_path), "error": str(exc)})
+            if on_progress is not None:
+                on_progress("promotion", "error", promo_data.get("name", "?"), str(exc))
+
+    return result
+
+
+def upload_groups(
+    client: Client,
+    data_dir: Path,
+    *,
+    on_progress: Any = None,
+) -> UploadCounts:
+    """Upload all service-group files from ``data_dir/groups/``.
+
+    Every ``*.json`` / ``*.toml`` under ``groups/`` is upserted via
+    ``client.groups.upsert`` (synchronous PUT, idempotent on the
+    ``name`` field).
+    """
+    result = UploadCounts()
+    group_dir = data_dir / "groups"
+    group_files: list[tuple[Path, dict[str, Any]]] = []
+    if group_dir.is_dir():
+        for f in sorted(group_dir.glob("*.json")):
+            group_files.append((f, load_data_file(f)[0]))
+        for f in sorted(group_dir.glob("*.toml")):
+            group_files.append((f, load_data_file(f)[0]))
+    result.total = len(group_files)
+
+    for group_path, group_data in group_files:
+        try:
+            payload = group_data
+            name = str(payload.get("name", "?"))
+            client.groups.upsert(payload)
+            result.success += 1
+            if on_progress is not None:
+                on_progress("group", "ok", name)
+        except APIError as exc:
+            result.failed += 1
+            result.errors.append({"file": str(group_path), "error": f"{exc.status_code}: {exc}"})
+            if on_progress is not None:
+                on_progress("group", "error", group_data.get("name", "?"), str(exc))
+        except Exception as exc:
+            result.failed += 1
+            result.errors.append({"file": str(group_path), "error": str(exc)})
+            if on_progress is not None:
+                on_progress("group", "error", group_data.get("name", "?"), str(exc))
 
     return result

--- a/src/unitysvc_sellers/utils.py
+++ b/src/unitysvc_sellers/utils.py
@@ -42,7 +42,7 @@ from unitysvc_core.utils import (  # noqa: F401
     write_data_file,
 )
 from unitysvc_core.utils import (
-    find_files_by_schema as _core_find_files_by_schema,
+    find_files_by_pattern as _core_find_files_by_schema,
 )
 
 # Top-level directory holding `usvc_seller specs expand` output: a static,
@@ -60,13 +60,15 @@ def find_files_by_schema(
     path_filter: str | None = None,
     field_filter: Any = None,
 ) -> list[tuple[Path, str, dict[str, Any]]]:
-    """Seller wrapper over ``unitysvc_core.utils.find_files_by_schema``.
+    """Seller wrapper over ``unitysvc_core.utils.find_files_by_pattern``.
 
-    Identical to core discovery, except results under a top-level
-    ``expanded/`` directory (relative to ``data_dir``) are dropped — that tree
-    is the informal output of ``specs expand`` and must never be treated as a
-    formal service, even if committed. Mirrors the dot-directory skip that
-    ``specs_layout.find_service_folders`` already applies to ``validate``.
+    Matches files by **filename stem** (``provider.json`` → ``provider_v1``,
+    etc.) — the convention used by the flat ``specs/`` layout.  Results under
+    a top-level ``expanded/`` directory (relative to ``data_dir``) are
+    dropped — that tree is the informal output of ``specs expand`` and must
+    never be treated as a formal service, even if committed.  Mirrors the
+    dot-directory skip that ``specs_layout.find_service_folders`` already
+    applies to ``validate``.
     """
     results = _core_find_files_by_schema(data_dir, schema, path_filter, field_filter)
     root = Path(data_dir)

--- a/src/unitysvc_sellers/utils.py
+++ b/src/unitysvc_sellers/utils.py
@@ -10,7 +10,7 @@ Generic file helpers (hashing, mime types, JSON/TOML loading, override
 files, schema-based file discovery, deep-merge) are re-exported from
 ``unitysvc_core.utils`` for convenience, so seller code can do::
 
-    from unitysvc_sellers.utils import find_files_by_schema, resolve_provider_name
+    from unitysvc_sellers.utils import find_files_by_pattern, resolve_provider_name
 
 without caring whether a given helper is core or seller-specific.
 """
@@ -42,19 +42,19 @@ from unitysvc_core.utils import (  # noqa: F401
     write_data_file,
 )
 from unitysvc_core.utils import (
-    find_files_by_pattern as _core_find_files_by_schema,
+    find_files_by_pattern as _core_find_files_by_pattern,
 )
 
 # Top-level directory holding `usvc_seller specs expand` output: a static,
 # user-owned tree of rendered services for inspection only. It is deliberately
 # NOT part of the formal catalog, so every discovery walk skips it (see the
-# `find_files_by_schema` wrapper below). Lives beside `specs/` at the repo root;
+# `find_files_by_pattern` wrapper below). Lives beside `specs/` at the repo root;
 # `specs/` is where formal data lives, so a top-level `expanded/` never collides
 # with a real provider/service path.
 EXPANDED_DIRNAME = "expanded"
 
 
-def find_files_by_schema(
+def find_files_by_pattern(
     data_dir: Any,
     schema: str,
     path_filter: str | None = None,
@@ -70,7 +70,7 @@ def find_files_by_schema(
     dot-directory skip that ``specs_layout.find_service_folders`` already
     applies to ``validate``.
     """
-    results = _core_find_files_by_schema(data_dir, schema, path_filter, field_filter)
+    results = _core_find_files_by_pattern(data_dir, schema, path_filter, field_filter)
     root = Path(data_dir)
     kept: list[tuple[Path, str, dict[str, Any]]] = []
     for path, fmt, data in results:

--- a/tests/example_data/provider1/service1/offering.toml
+++ b/tests/example_data/provider1/service1/offering.toml
@@ -68,7 +68,7 @@ targetModules = []
 code = "OK"
 message = ""
 
-[upstream_access_config."Fireworks API"]
+[upstream_access_config."Fireworks-API"]
 access_method = "http"
 base_url = "https://api.fireworks.ai/inference/v1"
 api_key = "${ secrets.FIREWORKS_API_KEY }"

--- a/tests/example_data/provider2/service2/offering.json
+++ b/tests/example_data/provider2/service2/offering.json
@@ -25,7 +25,7 @@
   "service_type": "image_generation",
   "time_created": "2024-03-15T10:30:00.000Z",
   "upstream_access_config": {
-    "Fireworks Image API": {
+    "Fireworks-Image-API": {
       "access_method": "http",
       "base_url": "https://api.fireworks.ai/inference/v1/image/generation",
       "api_key": "${ secrets.FIREWORKS_API_KEY }"

--- a/tests/test_specs_expand.py
+++ b/tests/test_specs_expand.py
@@ -15,7 +15,7 @@ import pytest
 from typer.testing import CliRunner
 
 from unitysvc_sellers.specs import app as specs_app
-from unitysvc_sellers.utils import find_files_by_schema
+from unitysvc_sellers.utils import find_files_by_pattern
 
 from .test_params_render import OFFERING_J2, PROVIDER, _make_repo
 
@@ -49,7 +49,7 @@ def _make_preset_repo(tmp_path: Path) -> Path:
     return tmp_path
 
 
-def test_find_files_by_schema_excludes_top_level_expanded_tree(tmp_path: Path) -> None:
+def test_find_files_by_pattern_excludes_top_level_expanded_tree(tmp_path: Path) -> None:
     """Discovery must skip the informal ``expanded/`` tree but keep ``specs/``."""
     specs_listing = tmp_path / "specs" / "unitysvc" / "foo" / "listing.json"
     specs_listing.parent.mkdir(parents=True)
@@ -59,7 +59,7 @@ def test_find_files_by_schema_excludes_top_level_expanded_tree(tmp_path: Path) -
     expanded_listing.parent.mkdir(parents=True)
     expanded_listing.write_text(json.dumps({"name": "unitysvc/foo"}))
 
-    found = {p for p, _, _ in find_files_by_schema(tmp_path, "listing_v1")}
+    found = {p for p, _, _ in find_files_by_pattern(tmp_path, "listing_v1")}
 
     assert specs_listing in found
     assert expanded_listing not in found

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,10 +22,10 @@ def example_data_dir() -> Path:
 
 def test_resolve_service_name_explicit(example_data_dir: Path) -> None:
     """Test that explicit service_name in listing is used."""
-    from unitysvc_sellers.utils import find_files_by_schema
+    from unitysvc_sellers.utils import find_files_by_pattern
 
     # Find a listing with explicit service_name
-    listing_files = find_files_by_schema(example_data_dir, "listing_v1")
+    listing_files = find_files_by_pattern(example_data_dir, "listing_v1")
 
     # Find the provider2 listing which has explicit service_name
     for file_path, _format, data in listing_files:
@@ -39,10 +39,10 @@ def test_resolve_service_name_explicit(example_data_dir: Path) -> None:
 
 def test_resolve_service_name_auto(example_data_dir: Path) -> None:
     """Test that service_name is auto-resolved from service offering."""
-    from unitysvc_sellers.utils import find_files_by_schema
+    from unitysvc_sellers.utils import find_files_by_pattern
 
     # Find a listing without explicit service_name
-    listing_files = find_files_by_schema(example_data_dir, "listing_v1")
+    listing_files = find_files_by_pattern(example_data_dir, "listing_v1")
 
     # Find the provider1 listing which should auto-resolve
     for file_path, _format, data in listing_files:
@@ -68,10 +68,10 @@ def test_resolve_service_name_no_service_offering(tmp_path: Path) -> None:
 
 def test_resolve_provider_name_from_service_offering(example_data_dir: Path) -> None:
     """Test that provider name is resolved from service offering file path."""
-    from unitysvc_sellers.utils import find_files_by_schema
+    from unitysvc_sellers.utils import find_files_by_pattern
 
     # Find a service offering file
-    service_files = find_files_by_schema(example_data_dir, "offering_v1")
+    service_files = find_files_by_pattern(example_data_dir, "offering_v1")
 
     # Find the provider1 service file
     for file_path, _format, _data in service_files:
@@ -85,10 +85,10 @@ def test_resolve_provider_name_from_service_offering(example_data_dir: Path) -> 
 
 def test_resolve_provider_name_from_listing(example_data_dir: Path) -> None:
     """Test that provider name is resolved from listing file path."""
-    from unitysvc_sellers.utils import find_files_by_schema
+    from unitysvc_sellers.utils import find_files_by_pattern
 
     # Find a listing file
-    listing_files = find_files_by_schema(example_data_dir, "listing_v1")
+    listing_files = find_files_by_pattern(example_data_dir, "listing_v1")
 
     # Find the provider2 listing file
     for file_path, _format, _data in listing_files:


### PR DESCRIPTION
## Problem

`unitysvc-core` now has two separate discovery functions:
- `find_files_by_schema` — field-based (checks in-file `"schema"` key)
- `find_files_by_pattern` — filename-stem-based (checks `file.stem`)

The seller's `specs/` layout uses canonical filenames (`provider.json`, `offering.json`, `listing.json`, etc.) — the filename IS the type discriminator. The wrapper should delegate to `find_files_by_pattern`.

## Fix

Update the seller's `find_files_by_schema` wrapper to call `find_files_by_pattern` from core internally. No call sites change — the wrapper's public API is unchanged; only its internal implementation switches to the correct core function.

## Dependency

Depends on `unitysvc-core#42` which adds `find_files_by_pattern` to core.