### PR TITLE
chore(release): bump version to 0.2.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "unitysvc-sellers"
-version = "0.2.12"
+version = "0.2.13"
 description = "Seller-facing tools for UnitySVC: HTTP SDK + usvc_seller CLI"
 readme = "README.md"
 authors = [{ name = "Bo Peng", email = "bo.peng@unitysvc.com" }]


### PR DESCRIPTION
Bumps `unitysvc-sellers` to **0.2.13** to cut a release that includes the merged
`find_files_by_pattern` discovery fix (#121).

Why it matters: the published 0.2.12 silently discovered **0 services** for repos
that author services as local-template param files (`specs/<provider>/<name>.json`
= `{ template, parameters }`) — so `specs upload` uploaded nothing. `main` already
has the fix; this versions it for PyPI.

- `pyproject.toml`: 0.2.12 → 0.2.13.
- Dependency on **`unitysvc-core>=0.2.7`** (latest — provides the
  field-/filename-based `find_files` split the fix delegates to) is already in
  place, left unchanged.

After merge: publish a GitHub Release tagged `v0.2.13` to trigger `publish.yml`
(Trusted Publishing → PyPI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)