### PR TITLE
fix(run-tests): resolve embedded ${ secrets.* } refs in service_base_url

### DIFF
--- a/src/unitysvc_sellers/example.py
+++ b/src/unitysvc_sellers/example.py
@@ -353,12 +353,18 @@ def load_related_data(listing_file: Path) -> dict[str, Any]:
 
 
 _SECRETS_RE = re.compile(
-    # Two valid forms (matching backend/app/core/var_substitution.py):
+    # Mirrors backend/app/core/var_substitution.py: references are substituted
+    # *in place* wherever they appear in a string (NOT only when the reference
+    # is the entire value), so a base_url like
+    #   "${ customer_secrets.HOST ?? http://h:8800 }/path"
+    # resolves to "<HOST or default>/path". Two valid forms:
     #   ${ namespace.VAR }                   — required
     #   ${ namespace.VAR ?? default }        — optional with fallback
-    # Default is free-form (hyphens, slashes, spaces, URLs, empty).
-    r"^\$\{\s*(?:secrets|customer_secrets)\.([A-Za-z_][A-Za-z0-9_]*)"
-    r"(?:\s*\?\?\s*(.*?))?\s*\}$",
+    # Default is free-form (hyphens, slashes, spaces, URLs, empty). The lazy
+    # ``.*?`` before ``\}`` keeps multi-ref strings from swallowing across
+    # ``}`` boundaries — same as the backend parser.
+    r"\$\{\s*(?:secrets|customer_secrets)\.([A-Za-z_][A-Za-z0-9_]*)"
+    r"(?:\s*\?\?\s*(.*?))?\s*\}",
     re.DOTALL,
 )
 
@@ -384,40 +390,44 @@ class MissingSecretEnvVar(typer.Exit):
 
 
 def resolve_secret_ref(value: str, field_name: str) -> str:
-    """Resolve a ``${ secrets.VAR }`` or ``${ customer_secrets.VAR }`` reference.
+    """Resolve ``${ secrets.VAR }`` / ``${ customer_secrets.VAR }`` references.
 
-    If *value* is a literal string (not a secrets reference) it is returned
-    as-is. If it matches the pattern the corresponding environment variable
-    is looked up and returned.
+    References are substituted **in place**, anywhere they appear in *value* —
+    matching the backend ``var_substitution`` parser. A bare ``base_url`` like
+    ``"${ customer_secrets.HOST ?? http://h:8800 }/path"`` resolves to
+    ``"<HOST or default>/path"``; a literal string with no reference is
+    returned unchanged.
 
     Supports the ``??`` default-value operator:
 
-    * ``${ ns.VAR }`` — required. Missing env var raises
+    * ``${ ns.VAR }`` — required. A missing env var raises
       :class:`MissingSecretEnvVar`.
     * ``${ ns.VAR ?? default }`` — optional. If the env var is unset the
-      literal ``default`` is returned. An explicitly-empty env var value
+      literal ``default`` is used. An explicitly-empty env var value
       is preserved (``??`` coalesces on null, not on empty) — matches the
       backend ``var_substitution`` parser exactly.
 
     Raises:
-        MissingSecretEnvVar: When the environment variable is not set
-            *and* no ``?? default`` is provided. Subclass of
+        MissingSecretEnvVar: When a referenced environment variable is not
+            set *and* no ``?? default`` is provided. Subclass of
             ``typer.Exit`` — callers that want to collect missing secrets
             should catch this specifically; callers that just want to
             skip-on-failure can continue catching ``typer.Exit``.
     """
-    m = _SECRETS_RE.match(value)
-    if not m:
+    if "${" not in value:
         return value
 
-    var_name = m.group(1)
-    default = m.group(2)  # None when no `??` in the reference.
-    env_value = os.environ.get(var_name)
-    if env_value is None:
-        if default is not None:
-            return default
-        raise MissingSecretEnvVar(var_name, field_name)
-    return env_value
+    def _replace(m: re.Match[str]) -> str:
+        var_name = m.group(1)
+        default = m.group(2)  # None when no `??` in the reference.
+        env_value = os.environ.get(var_name)
+        if env_value is None:
+            if default is not None:
+                return default
+            raise MissingSecretEnvVar(var_name, field_name)
+        return env_value
+
+    return _SECRETS_RE.sub(_replace, value)
 
 
 def load_upstream_access_interface(listing_file: Path) -> dict[str, str] | None:

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -5,15 +5,18 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
 from unitysvc_core.models.base import DocumentCategoryEnum
 
 from unitysvc_sellers.example import (
+    MissingSecretEnvVar,
     build_upstream_template_context,
     discover_code_examples,
     document_applies_to_channel,
     execute_code_example,
     expand_template_strings,
     extract_code_examples_from_listing,
+    resolve_secret_ref,
 )
 
 EXAMPLE_DATA = Path(__file__).parent / "example_data"
@@ -241,3 +244,66 @@ def test_extract_code_examples_captures_meta_channels() -> None:
     by_title = {e["title"]: e for e in extract_code_examples_from_listing(listing_data, Path("/tmp/listing.json"))}
     assert by_title["Scoped"]["channels"] == ["apprise"]
     assert by_title["Shared"]["channels"] is None
+
+
+# --- resolve_secret_ref: in-place (embedded) substitution -------------------
+
+
+def test_resolve_secret_ref_literal_passthrough() -> None:
+    """A string with no reference is returned unchanged."""
+    assert resolve_secret_ref("https://api.example.com/v1", "base_url") == "https://api.example.com/v1"
+
+
+def test_resolve_secret_ref_non_secret_namespace_untouched() -> None:
+    """``${VAR}`` env-style refs (no secrets namespace) are left alone."""
+    assert resolve_secret_ref("${API_GATEWAY_BASE_URL}/svc", "base_url") == "${API_GATEWAY_BASE_URL}/svc"
+
+
+def test_resolve_secret_ref_whole_value_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A whole-value reference resolves from the environment (back-compat)."""
+    monkeypatch.setenv("MY_TOKEN", "abc123")
+    assert resolve_secret_ref("${ secrets.MY_TOKEN }", "api_key") == "abc123"
+
+
+def test_resolve_secret_ref_default_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``?? default`` is used when the env var is unset."""
+    monkeypatch.delenv("MY_TOKEN", raising=False)
+    assert resolve_secret_ref("${ secrets.MY_TOKEN ?? fallback }", "api_key") == "fallback"
+
+
+def test_resolve_secret_ref_required_missing_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A required reference with no default and no env var raises."""
+    monkeypatch.delenv("MY_TOKEN", raising=False)
+    with pytest.raises(MissingSecretEnvVar):
+        resolve_secret_ref("${ secrets.MY_TOKEN }", "api_key")
+
+
+def test_resolve_secret_ref_embedded_prefix_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The regression: a ref embedded as a URL *prefix* resolves, keeping the path.
+
+    This is the stress-service base_url shape — previously the whole-value
+    regex failed to match, leaving the raw ``${ ... }`` to reach bash as a
+    ``bad substitution``.
+    """
+    monkeypatch.setenv("UNITYSVC_STRESS_BASE_URL", "https://stress.unitysvc.dev")
+    out = resolve_secret_ref(
+        "${ customer_secrets.UNITYSVC_STRESS_BASE_URL ?? http://stress-server:8800 }/stress/anthropic",
+        "base_url",
+    )
+    assert out == "https://stress.unitysvc.dev/stress/anthropic"
+
+
+def test_resolve_secret_ref_embedded_prefix_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Embedded ref falls back to its default and keeps the trailing path."""
+    monkeypatch.delenv("UNITYSVC_STRESS_BASE_URL", raising=False)
+    out = resolve_secret_ref(
+        "${ customer_secrets.UNITYSVC_STRESS_BASE_URL ?? http://stress-server:8800 }/stress/anthropic",
+        "base_url",
+    )
+    assert out == "http://stress-server:8800/stress/anthropic"
+
+
+def test_resolve_secret_ref_empty_env_preserved(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``??`` coalesces on null, not empty — an empty env value is kept."""
+    monkeypatch.setenv("MY_TOKEN", "")
+    assert resolve_secret_ref("${ secrets.MY_TOKEN ?? fallback }", "api_key") == ""


### PR DESCRIPTION
## Problem

`usvc_seller specs run-tests` fails with a bash **`bad substitution`** error for any service whose upstream `base_url` embeds a secret-ref as a *prefix* — e.g. the `unitysvc-stress` services:

```
${ customer_secrets.UNITYSVC_STRESS_BASE_URL ?? http://stress-server:8800 }/stress/anthropic
   → /tmp/xxx.sh: line 10: ${ customer_secrets.UNITYSVC_STRESS_BASE_URL ?? ... }/...: bad substitution
```

The raw `${ … }` reaches the rendered connectivity script and bash can't parse it. Setting `UNITYSVC_STRESS_BASE_URL` had **no effect**.

## Root cause

`resolve_secret_ref` (example.py) used a **whole-value-anchored** regex and `.match`:

```python
_SECRETS_RE = re.compile(r"^\$\{ … \}$", re.DOTALL)   # ^…$ — entire value only
m = _SECRETS_RE.match(value)
if not m:
    return value          # embedded ref → returned RAW
```

So it only resolved a reference that *was* the whole field value. The stress `base_url` is a ref **prefix + trailing path**, so it never matched and was returned unchanged. The code comment claims it matches `backend/app/core/var_substitution.py`, but the backend uses `VAR_RE.finditer(text)` — **embedded, in-place** substitution. The seller tool had diverged.

## Fix

Mirror the backend parser: drop the `^…$` anchors and substitute **every** `${ secrets|customer_secrets.VAR [?? default] }` reference in place with `re.sub`, preserving surrounding text. Unchanged: whole-value refs, `??` default fallback, the empty-env-value rule (`??` coalesces on null not empty), and the `MissingSecretEnvVar` skip path.

## Verification

- `pytest` — **280 passed** (incl. 8 new `resolve_secret_ref` tests: literal passthrough, non-secret `${VAR}` left alone, whole-value, default fallback, required-missing raises, embedded-prefix from env + default, empty-env preserved). `ruff` + `mypy` clean.
- End-to-end against `unitysvc-stress` with `UNITYSVC_STRESS_BASE_URL=https://stress.unitysvc.dev`:
  - **Before:** 0/6 pass — all `bad substitution`.
  - **After:** URL resolves to `https://stress.unitysvc.dev/stress/anthropic/...`; **2/6 pass**, the other 4 now return *real* HTTP results (e.g. `404`) instead of the tooling error.

The remaining stress 404s are genuine endpoint/routing results — a separate issue from this tooling bug, now surfaced correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)