### PR TITLE
chore(release): bump version to 0.2.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "unitysvc-sellers"
-version = "0.2.13"
+version = "0.2.14"
 description = "Seller-facing tools for UnitySVC: HTTP SDK + usvc_seller CLI"
 readme = "README.md"
 authors = [{ name = "Bo Peng", email = "bo.peng@unitysvc.com" }]


### PR DESCRIPTION
Bump `0.2.13` → `0.2.14` (pyproject + uv.lock self-version) to release the run-tests fix merged in #123: embedded `${ customer_secrets.X ?? default }/path` references in `service_base_url` now resolve in place (mirroring the backend `var_substitution` parser) instead of reaching bash as `bad substitution`.

A GitHub Release `v0.2.14` will be created after merge to trigger the PyPI publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)