### PR TITLE
Remove enrollment.scope option (codes are now always globally unique)

### DIFF
--- a/docs/file-schemas.md
+++ b/docs/file-schemas.md
@@ -232,7 +232,7 @@ The `service_options` field configures backend behavior for service listings. Al
 | ------------------------ | ------ | ------------------------------------------------------------------------------ |
 | `ops_testing_parameters` | object | Default parameter values for testing (see [User Parameters](#user-parameters)) |
 | `routing_vars`           | object | Seller-managed operational variables, referenced as `{{ routing_vars.X }}`     |
-| `enrollment`             | object | Per-enrollment configuration — code scope and enrollment limits (see below)    |
+| `enrollment`             | object | Per-enrollment configuration — enrollment limits (see below)    |
 
 **Enrollment configuration (`enrollment`):**
 
@@ -240,7 +240,6 @@ All enrollment-related options live under a single `enrollment` object:
 
 | Key                  | Type    | Description                                                                                                                                                                                              |
 | -------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `scope`              | string  | Enrollment-code scope: `"customer"` (default) or `"global"`. With `"global"`, each enrollment gets a longer, globally-unique code — use it when the code lands in a **shared upstream namespace** (e.g. a notification topic), where a per-customer-only code could collide across customers. |
 | `limit`              | integer | Maximum total active enrollments for this service (global)                                                                                                                                              |
 | `limit_per_customer` | integer | Maximum active enrollments per customer                                                                                                                                                                 |
 | `limit_per_user`     | integer | Maximum active enrollments per user (creator)                                                                                                                                                           |
@@ -264,7 +263,6 @@ All enrollment-related options live under a single `enrollment` object:
             "region": "us-east-1"
         },
         "enrollment": {
-            "scope": "global",
             "limit": 100,
             "limit_per_customer": 5,
             "limit_per_user": 2
@@ -281,7 +279,6 @@ api_key = "${ secrets.SERVICE_API_KEY }"
 region = "us-east-1"
 
 [service_options.enrollment]
-scope = "global"
 limit = 100
 limit_per_customer = 5
 limit_per_user = 2

--- a/docs/service-types.md
+++ b/docs/service-types.md
@@ -239,10 +239,6 @@ base_url = "${API_GATEWAY_BASE_URL}/ntfy/{{ enrollment.code }}"
 `{{ enrollment.code }}` renders to the enrollment's unique code (e.g. `CEFF`) at enrollment
 time. The same enrollment is also reachable directly at `/e/CEFF` regardless of `base_url`.
 
-> If the code is used as the discriminator in a **shared upstream namespace** (e.g. an ntfy
-> topic shared across customers), set `service_options.scope = "global"` so the
-> code is globally unique rather than only per-customer. See
-> [file-schemas.md](file-schemas.md#service-options).
 
 See [file-schemas.md](file-schemas.md#jinja2-template-values) for the full templating model, and
 [service-templates.md](service-templates.md) for instantiating these patterns from a template.


### PR DESCRIPTION
Follows unitysvc/unitysvc#1446 — all enrollment codes are now globally unique by default. The `service_options.enrollment.scope` field is no longer read by the backend and sellers should remove it from their service definitions.